### PR TITLE
Raise perimeter walls into solid full-height walls

### DIFF
--- a/src/features/retro-office/scene/environment.tsx
+++ b/src/features/retro-office/scene/environment.tsx
@@ -177,8 +177,11 @@ function OfficeFlagPole({
 }
 
 // One perimeter wall: plaster lower wall, glass strip, mullion posts and a
-// metal cap rail. The overall x/z footprint matches the old 1-unit tall box
-// exactly so navigation and tests are unaffected.
+// metal cap rail. Roughly 1.7 units tall overall so the walls read taller
+// than agents (~1.0) and tall furniture such as the fridge (~1.4), with the
+// upper part kept as glass so the interior stays visible from the overview
+// camera. The x/z footprint still matches the old 1-unit tall box exactly so
+// navigation and tests are unaffected.
 function PerimeterWall({
   center,
   length,
@@ -193,8 +196,8 @@ function PerimeterWall({
     [length],
   );
   const thickness = 0.12;
-  const lowerHeight = 0.55;
-  const glassHeight = 0.4;
+  const lowerHeight = 0.9;
+  const glassHeight = 0.75;
   const capHeight = 0.05;
   const glassThickness = 0.03;
   const glassCenterY = lowerHeight + glassHeight / 2;

--- a/src/features/retro-office/scene/environment.tsx
+++ b/src/features/retro-office/scene/environment.tsx
@@ -1,7 +1,6 @@
 "use client";
 
 import { memo, useMemo, type ReactNode } from "react";
-import * as THREE from "three";
 import {
   CANVAS_H,
   CANVAS_W,
@@ -176,12 +175,11 @@ function OfficeFlagPole({
   );
 }
 
-// One perimeter wall: plaster lower wall, glass strip, mullion posts and a
-// metal cap rail. Roughly 1.7 units tall overall so the walls read taller
-// than agents (~1.0) and tall furniture such as the fridge (~1.4), with the
-// upper part kept as glass so the interior stays visible from the overview
-// camera. The x/z footprint still matches the old 1-unit tall box exactly so
-// navigation and tests are unaffected.
+// One perimeter wall: a solid plaster wall with a thin dark cap trim on top.
+// Roughly 1.7 units tall overall so the walls read taller than agents (~1.0)
+// and tall furniture such as the fridge (~1.4). The x/z footprint still
+// matches the old 1-unit tall box exactly so navigation and tests are
+// unaffected.
 function PerimeterWall({
   center,
   length,
@@ -196,17 +194,8 @@ function PerimeterWall({
     [length],
   );
   const thickness = 0.12;
-  const lowerHeight = 0.9;
-  const glassHeight = 0.75;
+  const wallHeight = 1.65;
   const capHeight = 0.05;
-  const glassThickness = 0.03;
-  const glassCenterY = lowerHeight + glassHeight / 2;
-  // Mullion posts roughly every 2.7 world units, including both wall ends.
-  const mullionCount = Math.max(2, Math.round(length / 2.7) + 1);
-  const mullionOffsets = Array.from(
-    { length: mullionCount },
-    (_, index) => -length / 2 + (index * length) / (mullionCount - 1),
-  );
   // Maps (along-wall, height, across-wall) sizes onto world axes.
   const dims = (
     along: number,
@@ -217,8 +206,8 @@ function PerimeterWall({
 
   return (
     <group position={[center[0], 0, center[1]]}>
-      <mesh position={[0, lowerHeight / 2, 0]} castShadow receiveShadow>
-        <boxGeometry args={dims(length, lowerHeight, thickness)} />
+      <mesh position={[0, wallHeight / 2, 0]} castShadow receiveShadow>
+        <boxGeometry args={dims(length, wallHeight, thickness)} />
         <meshStandardMaterial
           color="#e9dfd0"
           map={plaster.map}
@@ -229,35 +218,7 @@ function PerimeterWall({
           metalness={0.02}
         />
       </mesh>
-      <mesh position={[0, glassCenterY, 0]}>
-        <boxGeometry args={dims(length, glassHeight, glassThickness)} />
-        <meshPhysicalMaterial
-          color="#cfe4ee"
-          transparent
-          opacity={0.22}
-          roughness={0.08}
-          metalness={0}
-          side={THREE.DoubleSide}
-          envMapIntensity={1.2}
-          depthWrite={false}
-        />
-      </mesh>
-      {mullionOffsets.map((offset, index) => (
-        <mesh
-          key={`mullion-${index}`}
-          position={
-            axis === "x" ? [offset, glassCenterY, 0] : [0, glassCenterY, offset]
-          }
-          castShadow
-        >
-          <boxGeometry args={dims(0.05, glassHeight + 0.04, thickness * 0.8)} />
-          <meshStandardMaterial color="#2b2f33" roughness={0.42} metalness={0.68} />
-        </mesh>
-      ))}
-      <mesh
-        position={[0, lowerHeight + glassHeight + capHeight / 2, 0]}
-        castShadow
-      >
+      <mesh position={[0, wallHeight + capHeight / 2, 0]} castShadow>
         <boxGeometry args={dims(length, capHeight, thickness)} />
         <meshStandardMaterial color="#2b2f33" roughness={0.42} metalness={0.68} />
       </mesh>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The office perimeter walls looked too short — the wall topped out at ~1.0 world units, the same height as the agent characters and well below tall furniture like the fridge (~1.4), so they read as waist-high fences.

This rebuilds `PerimeterWall` in `src/features/retro-office/scene/environment.tsx` as a single solid plaster wall 1.65 units tall with the original thin dark cap trim on top (total ~1.7). The previous glass strip and mullion posts are removed — at the new height they read as a railing rather than part of the wall.

| Piece | Before | After |
| --- | --- | --- |
| Plaster band | 0.55 | 1.65 (full height) |
| Glass strip + posts | 0.4 | removed |
| Cap trim | 0.05 | 0.05 |
| **Total** | **~1.0** | **~1.7** |

The x/z footprint is unchanged, so navigation and layout are unaffected. The framed wall pictures now sit entirely on the plaster instead of overlapping the old glass band, and the walls read clearly taller than agents (~1.0) and the fridge (~1.4).

## Verification

- `npx eslint` on the changed file and `npm run typecheck` pass.
- Verified in the browser against the demo gateway: walls are solid floor-to-top with only the thin top trim, clearly taller than agents and appliances, interior still visible from the default overview camera, no rendering artifacts.

[Office overview with solid full-height perimeter walls](https://cursor.com/agents/bc-8752a1c1-10ea-4278-a9db-af401ac1384f/artifacts?path=%2Ftmp%2Fartifacts%2Fsolid_walls_overview.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-8752a1c1-10ea-4278-a9db-af401ac1384f?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-8752a1c1-10ea-4278-a9db-af401ac1384f&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

