### PR TITLE
Explain Hermes endpoints that cannot serve the gateway protocol

### DIFF
--- a/TUTORIAL.md
+++ b/TUTORIAL.md
@@ -220,6 +220,28 @@ Run this checklist in order:
 
 ## 9) Troubleshooting
 
+### Connecting to the hermes-agent dashboard port (`9119`) instead of the adapter
+
+This is the most common wrong turn, because `9119` is the port the
+hermes-agent dashboard prints on startup.
+
+Hermes3D cannot connect to it. That port serves the dashboard's JSON-RPC 2.0
+gateway on `/api/ws`, guarded by single-use tickets, and it does not terminate
+TLS. Hermes3D speaks a different protocol: it sends a `connect` frame and waits
+for `hello-ok`. Even with correct credentials the handshake never completes, so
+no username, password, or token will make `wss://<host>:9119` work.
+
+Point Hermes3D at `npm run hermes-adapter` instead, as in sections 2 and 4. The
+adapter is the component that speaks the Hermes3D gateway protocol, and it
+reaches Hermes over the OpenAI-compatible HTTP API on port `8642`.
+
+The dashboard username and password are unrelated to Hermes3D. They belong to
+`HERMES_DASHBOARD_BASIC_AUTH_USERNAME` / `_PASSWORD` and only gate the
+hermes-agent web dashboard. If your Hermes API requires a credential, that is
+`HERMES_API_KEY` on the adapter.
+
+`npm run doctor` flags this URL shape, and so does the connect screen.
+
 ### `EPROTO` or `wrong version number`
 
 - Usually means protocol mismatch.

--- a/docs/hermes-gateway.md
+++ b/docs/hermes-gateway.md
@@ -61,7 +61,32 @@ In the connect screen, select `Hermes backend`. Hermes3D will persist that
 selection in Studio settings and show `Hermes` as the active backend once
 the adapter hello response is received.
 
-### 4. Optional all-in-one local startup
+### 4. Remote Hermes on another machine
+
+The adapter and Hermes3D do not have to run where Hermes runs. Pick whichever
+side of the link you would rather keep private.
+
+**Adapter next to Hermes3D.** Only the Hermes HTTP API crosses the network, and
+nothing extra runs on the Hermes host:
+
+```text
+Browser <-> Studio <-> adapter (localhost:18789) <-> Hermes HTTP API (remote:8642)
+```
+
+Bind the Hermes API to the tailnet on the Hermes host, then on the Hermes3D
+machine set `HERMES_API_URL` to the remote address and connect to
+`ws://localhost:18789`.
+
+**Adapter next to Hermes.** The gateway protocol crosses the network, so the
+adapter needs to be published. Keep it on loopback and expose it with Tailscale
+Serve, then connect to `wss://<tailnet-host>` with no port. Full walkthrough in
+[`TUTORIAL.md`](../TUTORIAL.md).
+
+Do not point the gateway URL at port `9119`. That is the hermes-agent
+dashboard's JSON-RPC endpoint, not a Hermes3D gateway, and the two protocols are
+not compatible. See the troubleshooting section of the tutorial.
+
+### 5. Optional all-in-one local startup
 
 The repo also includes:
 

--- a/scripts/lib/hermes3doctor-core.mjs
+++ b/scripts/lib/hermes3doctor-core.mjs
@@ -54,6 +54,99 @@ export const normalizeAdapterType = (value, fallback = "hermes") => {
   return VALID_ADAPTER_TYPES.has(normalized) ? normalized : fallback;
 };
 
+/** Default port of the hermes-agent dashboard / JSON-RPC gateway. */
+export const HERMES_AGENT_DASHBOARD_PORT = "9119";
+
+/** Default port of the Hermes OpenAI-compatible HTTP API. */
+export const HERMES_OPENAI_API_PORT = "8642";
+
+/** Websocket path served by the hermes-agent dashboard backend. */
+export const HERMES_AGENT_WS_PATH = "/api/ws";
+
+const TAILSCALE_TLS_PORTS = new Set(["443", "8443", "10000"]);
+
+const HERMES_AGENT_ENDPOINT_FIX =
+  "Hermes3D connects through its own adapter, not the hermes-agent dashboard. " +
+  "Run `npm run hermes-adapter` with HERMES_API_URL pointing at the Hermes " +
+  "OpenAI-compatible API (port 8642), then connect to the adapter on port 18789.";
+
+/**
+ * Mirror of `inspectUpstreamGatewayUrl` in
+ * `src/lib/gateway/upstreamUrlDiagnostics.ts`. The doctor runs under plain node
+ * and cannot import TypeScript, so the rules are duplicated here and pinned
+ * together by `tests/unit/upstreamUrlDiagnostics.test.ts`.
+ */
+export const inspectUpstreamGatewayUrl = (rawUrl) => {
+  const url = trimString(rawUrl);
+  if (!url) return [];
+
+  let parsed = null;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return [];
+  }
+
+  const findings = [];
+  const protocol = parsed.protocol.toLowerCase();
+  const hostname = parsed.hostname.toLowerCase();
+  const port = parsed.port;
+  const path = parsed.pathname.replace(/\/+$/, "");
+
+  if (port === HERMES_AGENT_DASHBOARD_PORT) {
+    findings.push({
+      code: "hermes_agent_dashboard_port",
+      severity: "error",
+      message:
+        `Port ${HERMES_AGENT_DASHBOARD_PORT} is the hermes-agent dashboard, which speaks ` +
+        "JSON-RPC 2.0 over /api/ws with single-use ticket auth. Hermes3D cannot talk to it.",
+      fix: HERMES_AGENT_ENDPOINT_FIX,
+    });
+  }
+
+  if (path === HERMES_AGENT_WS_PATH) {
+    findings.push({
+      code: "hermes_agent_jsonrpc_path",
+      severity: "error",
+      message: `${HERMES_AGENT_WS_PATH} is the hermes-agent JSON-RPC endpoint, not a Hermes3D gateway.`,
+      fix: HERMES_AGENT_ENDPOINT_FIX,
+    });
+  }
+
+  if (port === HERMES_OPENAI_API_PORT) {
+    findings.push({
+      code: "hermes_openai_api_port",
+      severity: "error",
+      message:
+        `Port ${HERMES_OPENAI_API_PORT} is the Hermes OpenAI-compatible HTTP API. It serves ` +
+        "/v1/chat/completions over HTTP and has no gateway websocket.",
+      fix:
+        "Set HERMES_API_URL to this address and run `npm run hermes-adapter`, then point the " +
+        "gateway URL at the adapter instead.",
+    });
+  }
+
+  if (
+    protocol === "wss:" &&
+    port &&
+    !TAILSCALE_TLS_PORTS.has(port) &&
+    hasHostnameSuffix(hostname, "ts.net")
+  ) {
+    findings.push({
+      code: "tls_on_plain_tailnet_port",
+      severity: "warning",
+      message:
+        `wss:// expects TLS, but Tailscale only terminates TLS on ports ${[...TAILSCALE_TLS_PORTS].join(", ")}. ` +
+        `Port ${port} on a tailnet host is almost certainly plain HTTP.`,
+      fix:
+        "Either use ws:// against this port, or expose the service with " +
+        "`tailscale serve --https=443 http://127.0.0.1:<port>` and connect to wss://<host> with no port.",
+    });
+  }
+
+  return findings;
+};
+
 export const isCustomRuntimeAdapter = (adapterType) => {
   const normalized = normalizeAdapterType(adapterType, "");
   return (
@@ -131,6 +224,10 @@ export const buildGatewayWarnings = ({
   } catch {
     warnings.push("Gateway URL is not a valid URL.");
     return warnings;
+  }
+
+  for (const finding of inspectUpstreamGatewayUrl(url)) {
+    warnings.push(`${finding.message} ${finding.fix}`);
   }
 
   const protocol = parsed.protocol.toLowerCase();

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -1161,6 +1161,12 @@ textarea:focus::-webkit-scrollbar {
   color: var(--danger-soft-fg);
 }
 
+.ui-alert-caution {
+  border: 1px solid var(--status-approval-border);
+  background: var(--status-approval-bg);
+  color: var(--status-approval-fg);
+}
+
 .ui-text-danger {
   color: var(--danger-soft-fg);
 }

--- a/src/features/agents/components/GatewayConnectScreen.tsx
+++ b/src/features/agents/components/GatewayConnectScreen.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState } from "react";
 import { Check, Copy, Eye, EyeOff } from "lucide-react";
 import type { GatewayStatus } from "@/lib/gateway/GatewayClient";
 import { isLocalGatewayUrl } from "@/lib/gateway/local-gateway";
+import { inspectUpstreamGatewayUrl } from "@/lib/gateway/upstreamUrlDiagnostics";
 import type { StudioGatewayAdapterType, StudioGatewaySettings } from "@/lib/studio/settings";
 import { RunningAvatarLoader } from "@/features/agents/components/RunningAvatarLoader";
 
@@ -52,6 +53,7 @@ export const GatewayConnectScreen = ({
     selectedAdapterType === "hermes3d" ||
     selectedAdapterType === "custom";
   const isLocal = useMemo(() => isLocalGatewayUrl(gatewayUrl), [gatewayUrl]);
+  const urlFindings = useMemo(() => inspectUpstreamGatewayUrl(gatewayUrl), [gatewayUrl]);
   const localPort = useMemo(() => resolveLocalGatewayPort(gatewayUrl), [gatewayUrl]);
   const localGatewayCommand = useMemo(
     () => `HERMES_ADAPTER_PORT=${localPort} npm run hermes-adapter`,
@@ -168,6 +170,23 @@ export const GatewayConnectScreen = ({
           spellCheck={false}
         />
       </label>
+
+      {urlFindings.length > 0 ? (
+        <ul className="flex flex-col gap-2" aria-label="Gateway URL warnings">
+          {urlFindings.map((finding) => (
+            <li
+              key={finding.code}
+              data-testid={`gateway-url-finding-${finding.code}`}
+              className={`rounded-md px-3 py-2 text-xs leading-snug ${
+                finding.severity === "error" ? "ui-alert-danger" : "ui-alert-caution"
+              }`}
+            >
+              <p className="font-medium">{finding.message}</p>
+              <p className="mt-1 opacity-80">{finding.fix}</p>
+            </li>
+          ))}
+        </ul>
+      ) : null}
 
       <div className="space-y-0.5 text-xs text-muted-foreground">
         <p className="font-medium text-foreground">Using Tailscale?</p>

--- a/src/lib/gateway/upstreamUrlDiagnostics.ts
+++ b/src/lib/gateway/upstreamUrlDiagnostics.ts
@@ -1,0 +1,112 @@
+/**
+ * Static checks for the upstream gateway URL a user types into the connect UI.
+ *
+ * Hermes3D speaks its own gateway protocol: the client opens a socket, sends a
+ * `connect` frame, and waits for `hello-ok`. Several nearby Hermes endpoints
+ * listen on well-known ports but speak something else entirely, so pointing at
+ * them can never succeed no matter which credentials are supplied. Catching
+ * those here turns a 13s connect timeout into an explanation.
+ *
+ * `scripts/lib/hermes3doctor-core.mjs` mirrors these rules for the CLI doctor,
+ * which runs under plain node and cannot import TypeScript. `tests/unit/
+ * upstreamUrlDiagnostics.test.ts` asserts the two stay in agreement.
+ */
+
+export type UpstreamUrlFindingSeverity = "error" | "warning";
+
+export type UpstreamUrlFinding = {
+  code: string;
+  severity: UpstreamUrlFindingSeverity;
+  message: string;
+  fix: string;
+};
+
+/** Default port of the hermes-agent dashboard / JSON-RPC gateway. */
+export const HERMES_AGENT_DASHBOARD_PORT = "9119";
+
+/** Default port of the Hermes OpenAI-compatible HTTP API. */
+export const HERMES_OPENAI_API_PORT = "8642";
+
+/** Websocket path served by the hermes-agent dashboard backend. */
+export const HERMES_AGENT_WS_PATH = "/api/ws";
+
+/** Ports Tailscale Serve can terminate TLS on. */
+const TAILSCALE_TLS_PORTS = new Set(["443", "8443", "10000"]);
+
+const HERMES_AGENT_ENDPOINT_FIX =
+  "Hermes3D connects through its own adapter, not the hermes-agent dashboard. " +
+  "Run `npm run hermes-adapter` with HERMES_API_URL pointing at the Hermes " +
+  "OpenAI-compatible API (port 8642), then connect to the adapter on port 18789.";
+
+const isTailnetHostname = (hostname: string) =>
+  hostname === "ts.net" || hostname.endsWith(".ts.net");
+
+export const inspectUpstreamGatewayUrl = (rawUrl: unknown): UpstreamUrlFinding[] => {
+  const url = typeof rawUrl === "string" ? rawUrl.trim() : "";
+  if (!url) return [];
+
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return [];
+  }
+
+  const findings: UpstreamUrlFinding[] = [];
+  const protocol = parsed.protocol.toLowerCase();
+  const hostname = parsed.hostname.toLowerCase();
+  const port = parsed.port;
+  const path = parsed.pathname.replace(/\/+$/, "");
+
+  if (port === HERMES_AGENT_DASHBOARD_PORT) {
+    findings.push({
+      code: "hermes_agent_dashboard_port",
+      severity: "error",
+      message:
+        `Port ${HERMES_AGENT_DASHBOARD_PORT} is the hermes-agent dashboard, which speaks ` +
+        "JSON-RPC 2.0 over /api/ws with single-use ticket auth. Hermes3D cannot talk to it.",
+      fix: HERMES_AGENT_ENDPOINT_FIX,
+    });
+  }
+
+  if (path === HERMES_AGENT_WS_PATH) {
+    findings.push({
+      code: "hermes_agent_jsonrpc_path",
+      severity: "error",
+      message:
+        `${HERMES_AGENT_WS_PATH} is the hermes-agent JSON-RPC endpoint, not a Hermes3D gateway.`,
+      fix: HERMES_AGENT_ENDPOINT_FIX,
+    });
+  }
+
+  if (port === HERMES_OPENAI_API_PORT) {
+    findings.push({
+      code: "hermes_openai_api_port",
+      severity: "error",
+      message:
+        `Port ${HERMES_OPENAI_API_PORT} is the Hermes OpenAI-compatible HTTP API. It serves ` +
+        "/v1/chat/completions over HTTP and has no gateway websocket.",
+      fix:
+        "Set HERMES_API_URL to this address and run `npm run hermes-adapter`, then point the " +
+        "gateway URL at the adapter instead.",
+    });
+  }
+
+  if (protocol === "wss:" && port && !TAILSCALE_TLS_PORTS.has(port) && isTailnetHostname(hostname)) {
+    findings.push({
+      code: "tls_on_plain_tailnet_port",
+      severity: "warning",
+      message:
+        `wss:// expects TLS, but Tailscale only terminates TLS on ports ${[...TAILSCALE_TLS_PORTS].join(", ")}. ` +
+        `Port ${port} on a tailnet host is almost certainly plain HTTP.`,
+      fix:
+        "Either use ws:// against this port, or expose the service with " +
+        "`tailscale serve --https=443 http://127.0.0.1:<port>` and connect to wss://<host> with no port.",
+    });
+  }
+
+  return findings;
+};
+
+export const hasBlockingUpstreamUrlFinding = (findings: readonly UpstreamUrlFinding[]): boolean =>
+  findings.some((finding) => finding.severity === "error");

--- a/tests/unit/gatewayConnectScreen-urlFindings.test.ts
+++ b/tests/unit/gatewayConnectScreen-urlFindings.test.ts
@@ -1,0 +1,43 @@
+import { createElement } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render, screen } from "@testing-library/react";
+import { GatewayConnectScreen } from "@/features/agents/components/GatewayConnectScreen";
+
+const renderScreen = (gatewayUrl: string) =>
+  render(
+    createElement(GatewayConnectScreen, {
+      gatewayUrl,
+      token: "",
+      selectedAdapterType: "hermes" as const,
+      activeAdapterType: "hermes" as const,
+      localGatewayDefaults: null,
+      status: "disconnected" as const,
+      error: null,
+      onGatewayUrlChange: vi.fn(),
+      onTokenChange: vi.fn(),
+      onAdapterTypeChange: vi.fn(),
+      onUseLocalDefaults: vi.fn(),
+      onConnect: vi.fn(),
+    }),
+  );
+
+describe("GatewayConnectScreen upstream URL findings", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("warns before connecting when pointed at the hermes-agent dashboard port", () => {
+    renderScreen("wss://luke-hermes.taildb786a.ts.net:9119");
+
+    const dashboardFinding = screen.getByTestId("gateway-url-finding-hermes_agent_dashboard_port");
+    expect(dashboardFinding.textContent).toMatch(/JSON-RPC 2\.0/);
+    expect(dashboardFinding.textContent).toMatch(/npm run hermes-adapter/);
+    expect(screen.getByTestId("gateway-url-finding-tls_on_plain_tailnet_port")).toBeTruthy();
+  });
+
+  it("stays quiet for a valid adapter URL", () => {
+    renderScreen("wss://luke-hermes.taildb786a.ts.net");
+
+    expect(screen.queryByLabelText("Gateway URL warnings")).toBeNull();
+  });
+});

--- a/tests/unit/upstreamUrlDiagnostics.test.ts
+++ b/tests/unit/upstreamUrlDiagnostics.test.ts
@@ -1,0 +1,100 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  hasBlockingUpstreamUrlFinding,
+  inspectUpstreamGatewayUrl,
+} from "@/lib/gateway/upstreamUrlDiagnostics";
+import {
+  buildGatewayWarnings,
+  inspectUpstreamGatewayUrl as inspectUpstreamGatewayUrlFromDoctor,
+} from "../../scripts/lib/hermes3doctor-core.mjs";
+
+const codesFor = (url: string) => inspectUpstreamGatewayUrl(url).map((finding) => finding.code);
+
+describe("upstream gateway URL diagnostics", () => {
+  it("accepts the adapter endpoints Hermes3D actually speaks to", () => {
+    expect(codesFor("ws://localhost:18789")).toEqual([]);
+    expect(codesFor("wss://luke-hermes.taildb786a.ts.net")).toEqual([]);
+    expect(codesFor("wss://luke-hermes.taildb786a.ts.net:443")).toEqual([]);
+  });
+
+  it("ignores empty and unparseable values", () => {
+    expect(codesFor("")).toEqual([]);
+    expect(codesFor("   ")).toEqual([]);
+    expect(codesFor("not a url")).toEqual([]);
+  });
+
+  it("flags the hermes-agent dashboard port", () => {
+    expect(codesFor("wss://luke-hermes.taildb786a.ts.net:9119")).toContain(
+      "hermes_agent_dashboard_port",
+    );
+  });
+
+  it("flags the hermes-agent JSON-RPC websocket path", () => {
+    expect(codesFor("ws://100.64.0.1:1234/api/ws")).toEqual(["hermes_agent_jsonrpc_path"]);
+    expect(codesFor("ws://100.64.0.1:1234/api/ws/")).toEqual(["hermes_agent_jsonrpc_path"]);
+  });
+
+  it("does not confuse the Studio proxy path with the hermes-agent path", () => {
+    expect(codesFor("ws://localhost:3000/api/gateway/ws")).toEqual([]);
+  });
+
+  it("flags the Hermes OpenAI-compatible API port", () => {
+    expect(codesFor("ws://localhost:8642")).toEqual(["hermes_openai_api_port"]);
+  });
+
+  it("warns when wss:// targets a tailnet port Tailscale cannot terminate TLS on", () => {
+    expect(codesFor("wss://box.ts.net:18789")).toEqual(["tls_on_plain_tailnet_port"]);
+    expect(codesFor("wss://box.ts.net:8443")).toEqual([]);
+    expect(codesFor("ws://box.ts.net:18789")).toEqual([]);
+  });
+
+  it("reports every problem with the URL from the original report", () => {
+    const findings = inspectUpstreamGatewayUrl("wss://luke-hermes.taildb786a.ts.net:9119");
+    expect(findings.map((finding) => finding.code)).toEqual([
+      "hermes_agent_dashboard_port",
+      "tls_on_plain_tailnet_port",
+    ]);
+    expect(hasBlockingUpstreamUrlFinding(findings)).toBe(true);
+  });
+
+  it("treats warning-only results as non-blocking", () => {
+    expect(hasBlockingUpstreamUrlFinding(inspectUpstreamGatewayUrl("wss://box.ts.net:18789"))).toBe(
+      false,
+    );
+  });
+
+  it("keeps the doctor mirror in sync with the app implementation", () => {
+    const urls = [
+      "",
+      "not a url",
+      "ws://localhost:18789",
+      "ws://localhost:8642",
+      "ws://localhost:3000/api/gateway/ws",
+      "ws://100.64.0.1:1234/api/ws",
+      "wss://box.ts.net",
+      "wss://box.ts.net:443",
+      "wss://box.ts.net:8443",
+      "wss://box.ts.net:18789",
+      "wss://ts.net:18789",
+      "wss://luke-hermes.taildb786a.ts.net:9119",
+    ];
+    for (const url of urls) {
+      expect(inspectUpstreamGatewayUrlFromDoctor(url), `mismatch for ${url || "(empty)"}`).toEqual(
+        inspectUpstreamGatewayUrl(url),
+      );
+    }
+  });
+
+  it("surfaces the findings through doctor gateway warnings", () => {
+    const warnings = buildGatewayWarnings({
+      gatewayUrl: "wss://luke-hermes.taildb786a.ts.net:9119",
+    });
+    expect(warnings.some((warning: string) => warning.includes("hermes-agent dashboard"))).toBe(
+      true,
+    );
+    expect(warnings.some((warning: string) => warning.includes("npm run hermes-adapter"))).toBe(
+      true,
+    );
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Why

Pointing the gateway URL at `wss://<tailnet-host>:9119` cannot work, and today it fails as an unexplained 13 second connect timeout with no hint about what to change.

Port `9119` is the hermes-agent dashboard. I stood up a stand-in for it locally and confirmed all three failure modes:

| URL shape | Result |
| --- | --- |
| bare root, as typically configured | `404` on the upgrade — websockets live under `/api/ws` |
| `/api/ws`, no ticket | closed `4401` — off-loopback binds require a single-use 30s ticket |
| `/api/ws` + valid ticket | connects, then speaks JSON-RPC 2.0 |

That last row is the important one. Even with perfect credentials the endpoint answers with `{"jsonrpc":"2.0",...}` and never produces the `hello-ok` that Hermes3D's connect frame is waiting for, so no username, password, or token can rescue it. `wss://` against that port also fails earlier at TLS, since the dashboard serves plain HTTP and Tailscale only terminates TLS on 443/8443/10000.

The working path is unchanged and already documented: `npm run hermes-adapter` speaks the Hermes3D gateway protocol on `18789` and reaches Hermes over the OpenAI-compatible HTTP API on `8642`. I verified that chain end to end against a stub API and got `hello-ok` with `adapterType: "hermes"`.

## What changed

- **`src/lib/gateway/upstreamUrlDiagnostics.ts`** — static inspection of the upstream URL, flagging the hermes-agent dashboard port, the `/api/ws` JSON-RPC path, the OpenAI API port, and `wss://` aimed at a tailnet port Tailscale cannot terminate TLS on. Each finding carries the fix, not just the complaint.
- **Connect screen** — renders findings inline as the URL is typed, so the mismatch shows up before a connect attempt is spent on it.
- **`npm run doctor`** — reports the same findings. The doctor runs under plain node and cannot import TypeScript, so it carries a mirrored copy; a test pins the two implementations to identical output across a table of URLs.
- **Docs** — `TUTORIAL.md` gains a troubleshooting entry for this specific dead end, including the note that the dashboard username/password belong to `HERMES_DASHBOARD_BASIC_AUTH_*` and are unrelated to Hermes3D. `docs/hermes-gateway.md` documents both remote topologies: adapter next to Hermes3D (only the Hermes HTTP API crosses the network) versus adapter next to Hermes behind Tailscale Serve.

A `ui-alert-caution` token was added next to the existing `ui-alert-danger` so the new UI stays inside the guarded color palette rather than reaching for raw Tailwind hues.

## Verification

- `npm run typecheck`, `npm run lint`, `npm run build` all clean; no new lint findings in changed files.
- 13 new tests. Full suite: 1077 passing, with 3 failures in `agentChatPanel-controls` and `agentFleetHydration` that reproduce on `main` with these changes stashed.
- Confirmed the doctor output against the exact reported URL:

```
[WARN] Gateway hints: Port 9119 is the hermes-agent dashboard, which speaks JSON-RPC 2.0
over /api/ws with single-use ticket auth. Hermes3D cannot talk to it. Hermes3D connects
through its own adapter, not the hermes-agent dashboard. Run `npm run hermes-adapter` with
HERMES_API_URL pointing at the Hermes OpenAI-compatible API (port 8642), then connect to
the adapter on port 18789.
```

## Note

This is diagnostics only — it explains the failure rather than making port `9119` connectable. Talking to hermes-agent's JSON-RPC gateway natively would mean a new runtime provider that performs the cookie login, mints a ticket per connect, and translates JSON-RPC methods into the Hermes3D contract. Happy to scope that separately if you'd rather connect without running the adapter.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-a24ea56e-13e1-4c4f-9afd-2e7c56843780?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a24ea56e-13e1-4c4f-9afd-2e7c56843780&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

