### PR TITLE
Connect directly to a hermes-agent backend with no adapter process

### DIFF
--- a/scripts/hermes3doctor.mjs
+++ b/scripts/hermes3doctor.mjs
@@ -378,6 +378,7 @@ async function main() {
     gatewayUrl: runtimeContext.gatewayUrl,
     studioAccessToken: trim(env.STUDIO_ACCESS_TOKEN),
     host: trim(env.HOST),
+    adapterType: runtimeContext.adapterType,
   })) {
     checks.push(checkWarn("Gateway access", "Gateway hints", warning));
   }

--- a/scripts/lib/hermes3doctor-core.mjs
+++ b/scripts/lib/hermes3doctor-core.mjs
@@ -6,6 +6,7 @@ export const DOCTOR_STATUSES = {
 
 const VALID_ADAPTER_TYPES = new Set([
   "hermes",
+  "hermes-agent",
   "demo",
   "local",
   "hermes3d",
@@ -15,6 +16,7 @@ const TUNNEL_HOST_PATTERN =
   /(cloudflare|trycloudflare|ngrok|tailscale|tunnel)/i;
 const DEFAULT_GATEWAY_URL_BY_ADAPTER = {
   hermes: "ws://localhost:18789",
+  "hermes-agent": "http://localhost:9119",
   demo: "ws://localhost:18789",
   local: "http://localhost:7770",
   hermes3d: "http://localhost:3000/api/runtime/custom",
@@ -76,7 +78,7 @@ const HERMES_AGENT_ENDPOINT_FIX =
  * and cannot import TypeScript, so the rules are duplicated here and pinned
  * together by `tests/unit/upstreamUrlDiagnostics.test.ts`.
  */
-export const inspectUpstreamGatewayUrl = (rawUrl) => {
+export const inspectUpstreamGatewayUrl = (rawUrl, adapterType = "") => {
   const url = trimString(rawUrl);
   if (!url) return [];
 
@@ -93,7 +95,12 @@ export const inspectUpstreamGatewayUrl = (rawUrl) => {
   const port = parsed.port;
   const path = parsed.pathname.replace(/\/+$/, "");
 
-  if (port === HERMES_AGENT_DASHBOARD_PORT) {
+  // The hermes-agent adapter targets that dashboard on purpose: Studio
+  // translates JSON-RPC in-process, so the endpoint these rules warn about is
+  // exactly the right one to point at.
+  const targetsHermesAgent = trimString(adapterType).toLowerCase() === "hermes-agent";
+
+  if (!targetsHermesAgent && port === HERMES_AGENT_DASHBOARD_PORT) {
     findings.push({
       code: "hermes_agent_dashboard_port",
       severity: "error",
@@ -104,7 +111,7 @@ export const inspectUpstreamGatewayUrl = (rawUrl) => {
     });
   }
 
-  if (path === HERMES_AGENT_WS_PATH) {
+  if (!targetsHermesAgent && path === HERMES_AGENT_WS_PATH) {
     findings.push({
       code: "hermes_agent_jsonrpc_path",
       severity: "error",
@@ -210,6 +217,7 @@ export const buildGatewayWarnings = ({
   gatewayUrl,
   studioAccessToken = "",
   host = "",
+  adapterType = "",
 }) => {
   const warnings = [];
   const url = trimString(gatewayUrl);
@@ -226,7 +234,7 @@ export const buildGatewayWarnings = ({
     return warnings;
   }
 
-  for (const finding of inspectUpstreamGatewayUrl(url)) {
+  for (const finding of inspectUpstreamGatewayUrl(url, adapterType)) {
     warnings.push(`${finding.message} ${finding.fix}`);
   }
 

--- a/server/gateway-proxy.js
+++ b/server/gateway-proxy.js
@@ -1,7 +1,17 @@
 const { Buffer } = require("node:buffer");
 const { WebSocket, WebSocketServer } = require("ws");
 
+const { createHermesAgentUpstream } = require("./hermes-agent/bridge");
+
 const DEFAULT_UPSTREAM_HANDSHAKE_TIMEOUT_MS = 10_000;
+
+/**
+ * Adapter type whose upstream is translated in-process rather than proxied.
+ *
+ * hermes-agent speaks JSON-RPC 2.0, not the Hermes3D gateway protocol, so there
+ * is nothing to forward frames to. The bridge stands in for the upstream socket.
+ */
+const EMBEDDED_ADAPTER_TYPE = "hermes-agent";
 
 /** Maximum frame payload size (256 KB). */
 const MAX_FRAME_SIZE = 256 * 1024;
@@ -189,6 +199,7 @@ function createGatewayProxy(options) {
     let upstreamReady = false;
     let upstreamUrl = "";
     let upstreamToken = "";
+    let upstreamAdapterType = "";
     let connectRequestId = null;
     let connectResponseSent = false;
     let pendingConnectFrame = null;
@@ -265,6 +276,8 @@ function createGatewayProxy(options) {
         const settings = await loadUpstreamSettings();
         upstreamUrl = typeof settings?.url === "string" ? settings.url.trim() : "";
         upstreamToken = typeof settings?.token === "string" ? settings.token.trim() : "";
+        upstreamAdapterType =
+          typeof settings?.adapterType === "string" ? settings.adapterType.trim() : "";
       } catch (err) {
         logError("Failed to load upstream gateway settings.", err);
         pendingUpstreamSetupError = {
@@ -290,21 +303,31 @@ function createGatewayProxy(options) {
         return;
       }
 
-      let upstreamOrigin = "";
-      try {
-        upstreamOrigin = resolveOriginForUpstream(upstreamUrl);
-      } catch {
-        pendingUpstreamSetupError = {
-          code: "studio.gateway_url_invalid",
-          message: "Upstream gateway URL is invalid on the Studio host.",
-        };
-        return;
-      }
+      if (upstreamAdapterType === EMBEDDED_ADAPTER_TYPE) {
+        upstreamWs = createHermesAgentUpstream({
+          url: upstreamUrl,
+          token: upstreamToken,
+          handshakeTimeoutMs: upstreamHandshakeTimeoutMs,
+          log,
+          logError,
+        });
+      } else {
+        let upstreamOrigin = "";
+        try {
+          upstreamOrigin = resolveOriginForUpstream(upstreamUrl);
+        } catch {
+          pendingUpstreamSetupError = {
+            code: "studio.gateway_url_invalid",
+            message: "Upstream gateway URL is invalid on the Studio host.",
+          };
+          return;
+        }
 
-      upstreamWs = new WebSocket(upstreamUrl, {
-        origin: upstreamOrigin,
-        handshakeTimeout: upstreamHandshakeTimeoutMs,
-      });
+        upstreamWs = new WebSocket(upstreamUrl, {
+          origin: upstreamOrigin,
+          handshakeTimeout: upstreamHandshakeTimeoutMs,
+        });
+      }
 
       upstreamHandshakeTimeoutId = setTimeout(() => {
         const timeoutError = {
@@ -385,11 +408,17 @@ function createGatewayProxy(options) {
           upstreamHandshakeTimeoutId = null;
         }
         logError("Upstream gateway WebSocket error.", err);
+
+        // The embedded bridge reports why hermes-agent refused (bad token,
+        // gated auth, disabled chat). That detail is the whole diagnosis, so
+        // surface it instead of the generic transport message.
+        const detail =
+          upstreamAdapterType === EMBEDDED_ADAPTER_TYPE && err && typeof err.message === "string"
+            ? err.message
+            : "Failed to connect to upstream gateway WebSocket.";
+
         if (!connectRequestId) {
-          pendingUpstreamSetupError ||= {
-            code: "studio.upstream_error",
-            message: "Failed to connect to upstream gateway WebSocket.",
-          };
+          pendingUpstreamSetupError ||= { code: "studio.upstream_error", message: detail };
           return;
         }
         if (
@@ -399,10 +428,7 @@ function createGatewayProxy(options) {
           sendConnectError(pendingUpstreamSetupError.code, pendingUpstreamSetupError.message);
           return;
         }
-        sendConnectError(
-          "studio.upstream_error",
-          "Failed to connect to upstream gateway WebSocket."
-        );
+        sendConnectError("studio.upstream_error", detail);
       });
 
       log("proxy connected");

--- a/server/hermes-agent/bridge.js
+++ b/server/hermes-agent/bridge.js
@@ -1,0 +1,691 @@
+/**
+ * Translates the Hermes3D gateway protocol into hermes-agent's JSON-RPC 2.0 API.
+ *
+ * hermes-agent has no server that speaks the Hermes3D protocol — that protocol
+ * came from OpenClaw. Rather than run a separate adapter process, this module
+ * presents a virtual upstream to `gateway-proxy.js`: it exposes the small slice
+ * of the `ws` WebSocket surface the proxy actually uses (`readyState`, `send`,
+ * `close`, `terminate`, and the open/message/close/error events), so the proxy's
+ * connect handling and lifecycle stay untouched.
+ *
+ * Hermes3D talks in agents and session keys; hermes-agent talks in runtime
+ * session ids. A hermes-agent backend is a single agent, so the fleet is
+ * synthesised as one entry and session keys are mapped onto runtime sessions
+ * that are created or resumed on first use.
+ */
+
+const { EventEmitter } = require("node:events");
+const { randomUUID } = require("node:crypto");
+
+const { HermesAgentJsonRpcClient, redactUrl } = require("./jsonrpc-client");
+
+/** Mirrors the numeric WebSocket readyState constants the proxy compares against. */
+const CONNECTING = 0;
+const OPEN = 1;
+const CLOSED = 3;
+
+const AGENT_ID = "hermes";
+const AGENT_NAME = "Hermes";
+const MAIN_KEY = "main";
+const MAIN_SESSION_KEY = `agent:${AGENT_ID}:${MAIN_KEY}`;
+
+/** hermes-agent's `session.create` / `session.resume` can be slow on a cold profile. */
+const SESSION_RPC_TIMEOUT_MS = 60_000;
+
+/**
+ * The slice of the `ws` WebSocket surface `gateway-proxy.js` relies on.
+ *
+ * @typedef {import("node:events").EventEmitter & {
+ *   readyState: number,
+ *   send: (raw: string) => void,
+ *   close: (code?: number, reason?: string) => void,
+ *   terminate: () => void,
+ * }} HermesAgentUpstream
+ */
+
+const resOk = (id, payload) => ({ type: "res", id, ok: true, payload: payload ?? {} });
+const resErr = (id, code, message) => ({ type: "res", id, ok: false, error: { code, message } });
+
+const asString = (value, fallback = "") =>
+  typeof value === "string" && value.trim() ? value.trim() : fallback;
+
+const errorMessage = (err) => {
+  if (!err) return "hermes-agent request failed";
+  if (typeof err === "string") return err;
+  return err.message || String(err);
+};
+
+/** hermes-agent history rows use `text`; Hermes3D expects `content`. */
+const toHermes3dMessages = (messages) => {
+  if (!Array.isArray(messages)) return [];
+  return messages
+    .filter((m) => m && (m.role === "user" || m.role === "assistant"))
+    .map((m) => ({
+      role: m.role,
+      content: typeof m.text === "string" ? m.text : String(m.content ?? ""),
+    }));
+};
+
+function createHermesAgentUpstream(options) {
+  const {
+    url,
+    token,
+    handshakeTimeoutMs,
+    log = () => {},
+    logError = () => {},
+  } = options || {};
+
+  const upstream = /** @type {HermesAgentUpstream} */ (new EventEmitter());
+  upstream.readyState = CONNECTING;
+
+  let client;
+  try {
+    client = new HermesAgentJsonRpcClient({ url, token, handshakeTimeoutMs });
+  } catch (err) {
+    // Defer so the caller can attach listeners before the failure lands.
+    setImmediate(() => upstream.emit("error", err));
+    upstream.readyState = CLOSED;
+    upstream.send = () => {};
+    upstream.close = () => {};
+    upstream.terminate = () => {};
+    return upstream;
+  }
+
+  /** sessionKey -> { runtimeId, storedId, title } */
+  const sessions = new Map();
+  /** runtime session id -> sessionKey */
+  const sessionKeyByRuntimeId = new Map();
+  /** runId -> { sessionKey, runtimeId, buffer, aborted } */
+  const activeRuns = new Map();
+  /** sessionKey -> runId, so session-scoped events find their run. */
+  const runBySessionKey = new Map();
+
+  let seq = 0;
+  let closed = false;
+
+  const emitFrame = (frame) => {
+    if (closed) return;
+    upstream.emit("message", JSON.stringify(frame));
+  };
+
+  const emitEvent = (event, payload) => {
+    emitFrame({ type: "event", event, seq: seq++, payload });
+  };
+
+  const emitChat = (runId, sessionKey, state, extra) => {
+    emitEvent("chat", { runId, sessionKey, state, ...extra });
+  };
+
+  // --- session mapping ------------------------------------------------------
+
+  const rememberSession = (sessionKey, result) => {
+    const runtimeId = asString(result?.session_id);
+    if (!runtimeId) throw new Error("hermes-agent did not return a session id.");
+    const entry = {
+      runtimeId,
+      storedId: asString(result?.stored_session_id) || asString(result?.session_key),
+      title: asString(result?.info?.title) || asString(result?.title),
+    };
+    sessions.set(sessionKey, entry);
+    sessionKeyByRuntimeId.set(runtimeId, sessionKey);
+    return entry;
+  };
+
+  /**
+   * Resolve the runtime session backing a Hermes3D session key, creating or
+   * resuming one on hermes-agent the first time the key is used.
+   */
+  const ensureSession = async (sessionKey) => {
+    const existing = sessions.get(sessionKey);
+    if (existing?.runtimeId) return existing;
+
+    // A key of the form `agent:<id>:<storedId>` refers to a stored hermes-agent
+    // session; anything else starts a fresh one.
+    const parts = sessionKey.split(":");
+    const tail = parts.length >= 3 ? parts.slice(2).join(":") : "";
+    if (tail && tail !== MAIN_KEY) {
+      try {
+        const resumed = await client.request(
+          "session.resume",
+          { session_id: tail, omit_messages: false },
+          SESSION_RPC_TIMEOUT_MS
+        );
+        return rememberSession(sessionKey, resumed);
+      } catch (err) {
+        log(`[hermes-agent] resume of "${tail}" failed, creating a new session: ${errorMessage(err)}`);
+      }
+    }
+
+    const created = await client.request("session.create", {}, SESSION_RPC_TIMEOUT_MS);
+    return rememberSession(sessionKey, created);
+  };
+
+  // --- upstream event fan-out ----------------------------------------------
+
+  client.on("event", (type, runtimeSessionId, payload) => {
+    const sessionKey = sessionKeyByRuntimeId.get(runtimeSessionId);
+    if (!sessionKey) return;
+    const runId = runBySessionKey.get(sessionKey);
+    const run = runId ? activeRuns.get(runId) : null;
+
+    switch (type) {
+      case "message.start":
+        if (run) run.buffer = "";
+        return;
+
+      case "message.delta": {
+        if (!run || run.aborted) return;
+        const text = typeof payload?.text === "string" ? payload.text : "";
+        if (!text) return;
+        run.buffer += text;
+        emitChat(runId, sessionKey, "delta", {
+          message: { role: "assistant", content: run.buffer },
+        });
+        return;
+      }
+
+      case "message.complete": {
+        if (!run) return;
+        const finalText =
+          typeof payload?.text === "string" && payload.text ? payload.text : run.buffer;
+        if (run.aborted) {
+          emitChat(runId, sessionKey, "aborted", {});
+        } else if (payload?.status === "error" || payload?.error) {
+          emitChat(runId, sessionKey, "error", {
+            errorMessage: asString(payload?.error, "hermes-agent reported an error"),
+          });
+        } else {
+          emitChat(runId, sessionKey, "final", {
+            stopReason: "end_turn",
+            message: { role: "assistant", content: finalText },
+          });
+          emitEvent("presence", {
+            sessions: {
+              recent: [{ key: sessionKey, updatedAt: Date.now() }],
+              byAgent: [
+                { agentId: AGENT_ID, recent: [{ key: sessionKey, updatedAt: Date.now() }] },
+              ],
+            },
+          });
+        }
+        activeRuns.delete(runId);
+        runBySessionKey.delete(sessionKey);
+        return;
+      }
+
+      case "tool.start":
+        if (!run) return;
+        emitEvent("agent", {
+          runId,
+          sessionKey,
+          stream: "tool",
+          data: { phase: "start", name: asString(payload?.name), text: asString(payload?.context) },
+        });
+        return;
+
+      case "tool.complete":
+        if (!run) return;
+        emitEvent("agent", {
+          runId,
+          sessionKey,
+          stream: "tool",
+          data: { phase: "complete", name: asString(payload?.name), text: asString(payload?.summary) },
+        });
+        return;
+
+      case "reasoning.delta":
+      case "thinking.delta":
+        if (!run) return;
+        emitEvent("agent", {
+          runId,
+          sessionKey,
+          stream: "reasoning",
+          data: { phase: "delta", text: typeof payload?.text === "string" ? payload.text : "" },
+        });
+        return;
+
+      case "status.update":
+        if (!run) return;
+        emitEvent("agent", {
+          runId,
+          sessionKey,
+          stream: "lifecycle",
+          data: { phase: asString(payload?.kind, "status"), text: asString(payload?.text) },
+        });
+        return;
+
+      case "approval.request":
+        emitEvent("exec.approval.requested", {
+          id: asString(payload?.request_id),
+          request: { command: asString(payload?.command), cwd: asString(payload?.cwd) },
+          createdAtMs: Date.now(),
+          expiresAtMs: Date.now() + 120_000,
+        });
+        return;
+
+      case "error":
+        if (!run) return;
+        emitChat(runId, sessionKey, "error", {
+          errorMessage: asString(payload?.message, "hermes-agent reported an error"),
+        });
+        activeRuns.delete(runId);
+        runBySessionKey.delete(sessionKey);
+        return;
+
+      default:
+    }
+  });
+
+  // --- method dispatch ------------------------------------------------------
+
+  const handleConnect = async (id) => {
+    const agents = [{ agentId: AGENT_ID, name: AGENT_NAME, isDefault: true }];
+    return resOk(id, {
+      type: "hello-ok",
+      protocol: 3,
+      adapterType: "hermes",
+      features: {
+        methods: [
+          "agents.list",
+          "agents.files.get",
+          "agents.files.set",
+          "sessions.list",
+          "sessions.preview",
+          "sessions.patch",
+          "sessions.reset",
+          "chat.send",
+          "chat.abort",
+          "chat.history",
+          "agent.wait",
+          "status",
+          "config.get",
+          "config.set",
+          "config.patch",
+          "exec.approvals.get",
+          "exec.approvals.set",
+          "exec.approval.resolve",
+          "wake",
+          "skills.status",
+          "models.list",
+          "tasks.list",
+          "cron.list",
+        ],
+        events: ["chat", "agent", "presence", "heartbeat", "cron"],
+      },
+      snapshot: {
+        health: { agents, defaultAgentId: AGENT_ID },
+        sessionDefaults: { mainKey: MAIN_KEY },
+      },
+      auth: { role: "operator", scopes: ["operator.admin", "operator.approvals"] },
+      policy: { tickIntervalMs: 30_000 },
+    });
+  };
+
+  const handleMethod = async (method, params, id) => {
+    const p = params || {};
+
+    switch (method) {
+      case "agents.list":
+        return resOk(id, {
+          defaultId: AGENT_ID,
+          mainKey: MAIN_KEY,
+          agents: [
+            {
+              id: AGENT_ID,
+              name: AGENT_NAME,
+              workspace: "",
+              identity: { name: AGENT_NAME, emoji: "🤖" },
+              role: "",
+            },
+          ],
+        });
+
+      case "agents.files.get":
+        return resOk(id, { file: { missing: true } });
+
+      case "agents.files.set":
+        return resOk(id, {});
+
+      case "config.get":
+        return resOk(id, {
+          config: { gateway: { reload: { mode: "hot" } } },
+          hash: "hermes-agent",
+          exists: true,
+          path: "",
+        });
+
+      case "config.patch":
+      case "config.set":
+        return resOk(id, { hash: "hermes-agent" });
+
+      case "sessions.list": {
+        let stored = [];
+        try {
+          const result = await client.request("session.list", { limit: 50 });
+          stored = Array.isArray(result?.sessions) ? result.sessions : [];
+        } catch (err) {
+          log(`[hermes-agent] session.list failed: ${errorMessage(err)}`);
+        }
+        const list = [
+          {
+            key: MAIN_SESSION_KEY,
+            agentId: AGENT_ID,
+            updatedAt: Date.now(),
+            displayName: "Main",
+            origin: { label: AGENT_NAME, provider: "hermes" },
+            modelProvider: "hermes",
+          },
+          ...stored.map((s) => ({
+            key: `agent:${AGENT_ID}:${asString(s.id)}`,
+            agentId: AGENT_ID,
+            updatedAt: typeof s.started_at === "number" ? s.started_at * 1000 : null,
+            displayName: asString(s.title, "Session"),
+            origin: { label: AGENT_NAME, provider: "hermes" },
+            modelProvider: "hermes",
+          })),
+        ];
+        return resOk(id, { sessions: list });
+      }
+
+      case "sessions.preview": {
+        const keys = Array.isArray(p.keys) ? p.keys : [];
+        const limit = typeof p.limit === "number" ? p.limit : 8;
+        const maxChars = typeof p.maxChars === "number" ? p.maxChars : 240;
+        const previews = await Promise.all(
+          keys.map(async (key) => {
+            const entry = sessions.get(key);
+            if (!entry?.runtimeId) return { key, status: "empty", items: [] };
+            try {
+              const history = await client.request("session.history", {
+                session_id: entry.runtimeId,
+              });
+              const items = toHermes3dMessages(history?.messages)
+                .slice(-limit)
+                .map((m) => ({
+                  role: m.role,
+                  text: m.content.slice(0, maxChars),
+                  timestamp: Date.now(),
+                }));
+              return { key, status: items.length ? "ok" : "empty", items };
+            } catch {
+              return { key, status: "empty", items: [] };
+            }
+          })
+        );
+        return resOk(id, { ts: Date.now(), previews });
+      }
+
+      case "sessions.patch": {
+        const key = asString(p.key, MAIN_SESSION_KEY);
+        const model = typeof p.model === "string" ? p.model.trim() : "";
+        if (model) {
+          try {
+            const entry = await ensureSession(key);
+            await client.request("config.set", {
+              key: "model",
+              value: model,
+              session_id: entry.runtimeId,
+            });
+          } catch (err) {
+            log(`[hermes-agent] model switch failed: ${errorMessage(err)}`);
+          }
+        }
+        return resOk(id, {
+          ok: true,
+          key,
+          entry: { thinkingLevel: p.thinkingLevel },
+          resolved: { model: model || undefined, modelProvider: "hermes" },
+        });
+      }
+
+      case "sessions.reset": {
+        const key = asString(p.key, MAIN_SESSION_KEY);
+        const entry = sessions.get(key);
+        if (entry?.runtimeId) {
+          sessionKeyByRuntimeId.delete(entry.runtimeId);
+          try {
+            await client.request("session.close", { session_id: entry.runtimeId });
+          } catch {}
+        }
+        sessions.delete(key);
+        return resOk(id, { ok: true });
+      }
+
+      case "chat.send": {
+        const sessionKey = asString(p.sessionKey, MAIN_SESSION_KEY);
+        const text =
+          typeof p.message === "string" ? p.message.trim() : String(p.message ?? "").trim();
+        const runId = asString(p.idempotencyKey) || randomUUID();
+        if (!text) return resOk(id, { status: "no-op", runId });
+
+        let entry;
+        try {
+          entry = await ensureSession(sessionKey);
+        } catch (err) {
+          return resErr(id, "hermes_agent.session_failed", errorMessage(err));
+        }
+
+        activeRuns.set(runId, { sessionKey, runtimeId: entry.runtimeId, buffer: "", aborted: false });
+        runBySessionKey.set(sessionKey, runId);
+
+        try {
+          await client.request("prompt.submit", { session_id: entry.runtimeId, text });
+        } catch (err) {
+          activeRuns.delete(runId);
+          runBySessionKey.delete(sessionKey);
+          return resErr(id, "hermes_agent.prompt_failed", errorMessage(err));
+        }
+
+        return resOk(id, { status: "started", runId });
+      }
+
+      case "chat.abort": {
+        const runId = asString(p.runId);
+        const sessionKey = asString(p.sessionKey);
+        const targets = runId
+          ? [runId]
+          : [...activeRuns.entries()]
+              .filter(([, run]) => run.sessionKey === sessionKey)
+              .map(([rid]) => rid);
+
+        let aborted = 0;
+        for (const rid of targets) {
+          const run = activeRuns.get(rid);
+          if (!run) continue;
+          run.aborted = true;
+          aborted += 1;
+          try {
+            await client.request("session.interrupt", { session_id: run.runtimeId });
+          } catch (err) {
+            log(`[hermes-agent] interrupt failed: ${errorMessage(err)}`);
+          }
+        }
+        return resOk(id, { ok: true, aborted });
+      }
+
+      case "chat.history": {
+        const sessionKey = asString(p.sessionKey, MAIN_SESSION_KEY);
+        const entry = sessions.get(sessionKey);
+        if (!entry?.runtimeId) return resOk(id, { sessionKey, messages: [] });
+        try {
+          const history = await client.request("session.history", {
+            session_id: entry.runtimeId,
+          });
+          return resOk(id, { sessionKey, messages: toHermes3dMessages(history?.messages) });
+        } catch (err) {
+          log(`[hermes-agent] session.history failed: ${errorMessage(err)}`);
+          return resOk(id, { sessionKey, messages: [] });
+        }
+      }
+
+      case "agent.wait": {
+        const runId = asString(p.runId);
+        const timeoutMs = typeof p.timeoutMs === "number" ? p.timeoutMs : 30_000;
+        const start = Date.now();
+        while (activeRuns.has(runId) && Date.now() - start < timeoutMs) {
+          await new Promise((r) => setTimeout(r, 100));
+        }
+        return resOk(id, { status: activeRuns.has(runId) ? "running" : "done" });
+      }
+
+      case "status": {
+        const recent = [...sessions.keys()].map((key) => ({ key, updatedAt: Date.now() }));
+        return resOk(id, {
+          sessions: { recent, byAgent: [{ agentId: AGENT_ID, recent }] },
+        });
+      }
+
+      case "wake": {
+        const text = asString(p.text);
+        if (!text) return resOk(id, { ok: true });
+        try {
+          const entry = await ensureSession(MAIN_SESSION_KEY);
+          await client.request("prompt.submit", { session_id: entry.runtimeId, text });
+        } catch (err) {
+          log(`[hermes-agent] wake failed: ${errorMessage(err)}`);
+        }
+        return resOk(id, { ok: true });
+      }
+
+      case "models.list": {
+        try {
+          const result = await client.request("model.options", {});
+          const options = Array.isArray(result?.options) ? result.options : [];
+          const models = options
+            .map((o) => asString(o?.id) || asString(o?.slug) || asString(o?.model))
+            .filter(Boolean)
+            .map((modelId) => ({ id: modelId, name: modelId }));
+          return resOk(id, { models: models.length ? models : [{ id: "hermes", name: "hermes" }] });
+        } catch {
+          return resOk(id, { models: [{ id: "hermes", name: "hermes" }] });
+        }
+      }
+
+      case "skills.status": {
+        try {
+          const result = await client.request("skills.manage", { action: "list" });
+          const skills = Array.isArray(result?.skills) ? result.skills : [];
+          return resOk(id, { skills });
+        } catch {
+          return resOk(id, { skills: [] });
+        }
+      }
+
+      case "cron.list": {
+        try {
+          const result = await client.request("cron.manage", { action: "list" });
+          const jobs = Array.isArray(result?.jobs) ? result.jobs : [];
+          return resOk(id, { jobs });
+        } catch {
+          return resOk(id, { jobs: [] });
+        }
+      }
+
+      case "exec.approvals.get":
+        return resOk(id, {
+          path: "",
+          exists: true,
+          hash: "hermes-agent",
+          file: {
+            version: 1,
+            defaults: { security: "full", ask: "off", autoAllowSkills: true },
+            agents: {},
+          },
+        });
+
+      case "exec.approvals.set":
+        return resOk(id, { hash: "hermes-agent" });
+
+      case "exec.approval.resolve": {
+        const requestId = asString(p.id);
+        const decision = asString(p.decision, "deny");
+        const runtimeId = [...sessions.values()][0]?.runtimeId;
+        if (requestId && runtimeId) {
+          try {
+            await client.request("approval.respond", {
+              session_id: runtimeId,
+              request_id: requestId,
+              choice: decision === "allow" ? "once" : "deny",
+            });
+          } catch (err) {
+            log(`[hermes-agent] approval.respond failed: ${errorMessage(err)}`);
+          }
+        }
+        return resOk(id, { ok: true });
+      }
+
+      case "tasks.list":
+        return resOk(id, { tasks: [] });
+
+      default:
+        log(`[hermes-agent] unhandled method: ${method}`);
+        return resOk(id, {});
+    }
+  };
+
+  // --- virtual WebSocket surface -------------------------------------------
+
+  upstream.send = (raw) => {
+    let frame;
+    try {
+      frame = JSON.parse(String(raw ?? ""));
+    } catch {
+      return;
+    }
+    if (!frame || frame.type !== "req") return;
+
+    const { id, method, params } = frame;
+    const respond = (result) => emitFrame(result);
+
+    if (method === "connect") {
+      handleConnect(id).then(respond, (err) =>
+        respond(resErr(id, "hermes_agent.connect_failed", errorMessage(err)))
+      );
+      return;
+    }
+
+    handleMethod(method, params, id).then(respond, (err) => {
+      logError(`[hermes-agent] method "${method}" failed.`, err);
+      respond(resErr(id, "hermes_agent.request_failed", errorMessage(err)));
+    });
+  };
+
+  upstream.close = (code, reason) => {
+    closed = true;
+    upstream.readyState = CLOSED;
+    client.close(code, reason);
+  };
+
+  upstream.terminate = () => {
+    closed = true;
+    upstream.readyState = CLOSED;
+    client.terminate();
+  };
+
+  client.on("ready", () => {
+    upstream.readyState = OPEN;
+    log(`[hermes-agent] JSON-RPC gateway ready at ${redactUrl(client.url)}`);
+    upstream.emit("open");
+  });
+
+  client.on("close", (code, reason) => {
+    closed = true;
+    upstream.readyState = CLOSED;
+    upstream.emit("close", code, Buffer.from(String(reason ?? "")));
+  });
+
+  client.on("error", (err) => {
+    upstream.emit("error", err);
+  });
+
+  client.connect();
+
+  return upstream;
+}
+
+module.exports = {
+  createHermesAgentUpstream,
+  toHermes3dMessages,
+  MAIN_SESSION_KEY,
+  AGENT_ID,
+};

--- a/server/hermes-agent/jsonrpc-client.js
+++ b/server/hermes-agent/jsonrpc-client.js
@@ -1,0 +1,206 @@
+/**
+ * JSON-RPC 2.0 WebSocket client for a hermes-agent backend.
+ *
+ * hermes-agent exposes its gateway at `/api/ws` and speaks JSON-RPC 2.0, one
+ * JSON object per WebSocket frame. Requests carry an `id`; events arrive as
+ * notifications with `method: "event"` and no `id`. The server emits a
+ * `gateway.ready` event immediately after the socket opens.
+ *
+ * Auth on an ungated (loopback-bound) backend is a session token on the query
+ * string. A backend bound to a non-loopback address rejects `?token=` and
+ * requires a single-use ticket instead, which this client does not mint.
+ */
+
+const { EventEmitter } = require("node:events");
+const { WebSocket } = require("ws");
+
+/** hermes-agent serves its JSON-RPC gateway at this path. */
+const HERMES_AGENT_WS_PATH = "/api/ws";
+
+const DEFAULT_REQUEST_TIMEOUT_MS = 120_000;
+
+/** Close code hermes-agent uses when the credential is missing or wrong. */
+const CLOSE_AUTH_FAILED = 4401;
+
+/** Close code hermes-agent uses for host, origin, or peer rejection. */
+const CLOSE_FORBIDDEN = 4403;
+
+/**
+ * Build the `/api/ws` URL from a user-supplied base.
+ *
+ * Accepts what someone would reasonably paste into the connect screen: a bare
+ * origin, an `https://` origin, or a URL that already carries the path.
+ */
+const buildJsonRpcUrl = (baseUrl, token) => {
+  const raw = typeof baseUrl === "string" ? baseUrl.trim() : "";
+  if (!raw) throw new Error("hermes-agent URL is empty.");
+
+  const parsed = new URL(raw);
+
+  if (parsed.protocol === "https:") parsed.protocol = "wss:";
+  else if (parsed.protocol === "http:") parsed.protocol = "ws:";
+  else if (parsed.protocol !== "ws:" && parsed.protocol !== "wss:") {
+    throw new Error(`Unsupported scheme "${parsed.protocol}" for a hermes-agent URL.`);
+  }
+
+  const path = parsed.pathname.replace(/\/+$/, "");
+  if (!path) parsed.pathname = HERMES_AGENT_WS_PATH;
+
+  if (typeof token === "string" && token.trim()) {
+    parsed.searchParams.set("token", token.trim());
+  }
+
+  return parsed.toString();
+};
+
+/** Strip the token so URLs are safe to log. */
+const redactUrl = (url) => String(url).replace(/([?&]token=)[^&]*/gi, "$1***");
+
+const describeCloseCode = (code, reason) => {
+  if (code === CLOSE_AUTH_FAILED) {
+    return (
+      "hermes-agent rejected the credential (4401). If the backend is bound to a " +
+      "non-loopback address it requires a login rather than a token; publish it " +
+      "over Tailscale Serve from a loopback bind so token auth stays available."
+    );
+  }
+  if (code === CLOSE_FORBIDDEN) {
+    return (
+      "hermes-agent refused the connection (4403). Its embedded chat may be " +
+      "disabled, or the Host/Origin did not match the address it was bound to."
+    );
+  }
+  return `hermes-agent closed the connection (${code})${reason ? `: ${reason}` : ""}`;
+};
+
+/**
+ * Emits:
+ *   "ready"  (payload)          — gateway.ready received
+ *   "event"  (type, sessionId, payload)
+ *   "close"  (code, reason)
+ *   "error"  (Error)
+ */
+class HermesAgentJsonRpcClient extends EventEmitter {
+  constructor({ url, token, requestTimeoutMs = DEFAULT_REQUEST_TIMEOUT_MS, handshakeTimeoutMs }) {
+    super();
+    this.url = buildJsonRpcUrl(url, token);
+    this.requestTimeoutMs = requestTimeoutMs;
+    this.handshakeTimeoutMs = handshakeTimeoutMs;
+    this.ws = null;
+    this.nextId = 1;
+    this.pending = new Map();
+    this.ready = false;
+    this.closed = false;
+  }
+
+  connect() {
+    this.ws = new WebSocket(this.url, { handshakeTimeout: this.handshakeTimeoutMs });
+
+    this.ws.on("message", (raw) => this._onMessage(raw));
+
+    this.ws.on("close", (code, reasonBuffer) => {
+      const reason = Buffer.isBuffer(reasonBuffer) ? reasonBuffer.toString() : String(reasonBuffer ?? "");
+      this._failAllPending(new Error(describeCloseCode(code, reason)));
+      this.ready = false;
+      this.closed = true;
+      this.emit("close", code, reason);
+    });
+
+    this.ws.on("error", (err) => {
+      this._failAllPending(err instanceof Error ? err : new Error(String(err)));
+      this.emit("error", err instanceof Error ? err : new Error(String(err)));
+    });
+
+    // The upgrade itself can be rejected before any frame arrives; surface the
+    // status rather than letting it look like a generic socket error.
+    this.ws.on("unexpected-response", (_req, res) => {
+      const status = res?.statusCode;
+      const message =
+        status === 401
+          ? describeCloseCode(CLOSE_AUTH_FAILED, "")
+          : `hermes-agent rejected the WebSocket upgrade (HTTP ${status}).`;
+      this.emit("error", new Error(message));
+    });
+  }
+
+  _onMessage(raw) {
+    let frame;
+    try {
+      frame = JSON.parse(String(raw ?? ""));
+    } catch {
+      return;
+    }
+    if (!frame || typeof frame !== "object") return;
+
+    if (frame.id !== undefined && frame.id !== null) {
+      const entry = this.pending.get(frame.id);
+      if (!entry) return;
+      this.pending.delete(frame.id);
+      clearTimeout(entry.timer);
+      if (frame.error) {
+        const err = new Error(frame.error.message || "hermes-agent returned an error");
+        err.code = frame.error.code;
+        err.data = frame.error.data;
+        entry.reject(err);
+      } else {
+        entry.resolve(frame.result ?? {});
+      }
+      return;
+    }
+
+    if (frame.method === "event" && frame.params && typeof frame.params === "object") {
+      const { type, session_id: sessionId, payload } = frame.params;
+      if (type === "gateway.ready") {
+        this.ready = true;
+        this.emit("ready", payload ?? {});
+        return;
+      }
+      this.emit("event", type, sessionId ?? "", payload ?? {});
+    }
+  }
+
+  request(method, params = {}, timeoutMs = this.requestTimeoutMs) {
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
+      return Promise.reject(new Error("hermes-agent connection is not open."));
+    }
+    const id = this.nextId++;
+    return new Promise((resolve, reject) => {
+      const timer = setTimeout(() => {
+        this.pending.delete(id);
+        reject(new Error(`hermes-agent did not answer "${method}" within ${timeoutMs}ms.`));
+      }, timeoutMs);
+      this.pending.set(id, { resolve, reject, timer });
+      this.ws.send(JSON.stringify({ jsonrpc: "2.0", id, method, params }));
+    });
+  }
+
+  _failAllPending(err) {
+    for (const { reject, timer } of this.pending.values()) {
+      clearTimeout(timer);
+      reject(err);
+    }
+    this.pending.clear();
+  }
+
+  close(code = 1000, reason = "") {
+    this.closed = true;
+    try {
+      this.ws?.close(code, reason);
+    } catch {}
+  }
+
+  terminate() {
+    this.closed = true;
+    try {
+      this.ws?.terminate();
+    } catch {}
+  }
+}
+
+module.exports = {
+  HermesAgentJsonRpcClient,
+  buildJsonRpcUrl,
+  redactUrl,
+  describeCloseCode,
+  HERMES_AGENT_WS_PATH,
+};

--- a/src/features/agents/components/GatewayConnectScreen.tsx
+++ b/src/features/agents/components/GatewayConnectScreen.tsx
@@ -53,7 +53,10 @@ export const GatewayConnectScreen = ({
     selectedAdapterType === "hermes3d" ||
     selectedAdapterType === "custom";
   const isLocal = useMemo(() => isLocalGatewayUrl(gatewayUrl), [gatewayUrl]);
-  const urlFindings = useMemo(() => inspectUpstreamGatewayUrl(gatewayUrl), [gatewayUrl]);
+  const urlFindings = useMemo(
+    () => inspectUpstreamGatewayUrl(gatewayUrl, selectedAdapterType),
+    [gatewayUrl, selectedAdapterType]
+  );
   const localPort = useMemo(() => resolveLocalGatewayPort(gatewayUrl), [gatewayUrl]);
   const localGatewayCommand = useMemo(
     () => `HERMES_ADAPTER_PORT=${localPort} npm run hermes-adapter`,
@@ -72,6 +75,9 @@ export const GatewayConnectScreen = ({
   };
   const useHermesPreset = () => {
     onAdapterTypeChange("hermes");
+  };
+  const useHermesAgentPreset = () => {
+    onAdapterTypeChange("hermes-agent");
   };
   const useCustomPreset = () => {
     onAdapterTypeChange("custom");
@@ -98,6 +104,8 @@ export const GatewayConnectScreen = ({
     switch (selectedAdapterType) {
       case "hermes":
         return "Hermes is the agent runtime path with its own provider/account flow behind the gateway.";
+      case "hermes-agent":
+        return "Hermes Agent connects straight to a hermes-agent backend's JSON-RPC gateway — no adapter process. Point it at the server root (Studio appends /api/ws) and use the session token, not a dashboard login.";
       case "demo":
         return "Demo can fall back to a seeded main agent locally, or connect to the bundled mock gateway for streaming replies.";
       case "local":
@@ -286,6 +294,13 @@ export const GatewayConnectScreen = ({
               onClick={useHermesPreset}
             >
               Hermes backend
+            </button>
+            <button
+              type="button"
+              className="ui-btn-secondary px-3 py-1.5 text-[11px] font-semibold tracking-[0.05em]"
+              onClick={useHermesAgentPreset}
+            >
+              Hermes Agent (direct)
             </button>
             <button
               type="button"

--- a/src/lib/gateway/GatewayClient.ts
+++ b/src/lib/gateway/GatewayClient.ts
@@ -123,7 +123,7 @@ const INITIAL_CONNECT_RETRY_DELAY_MS = 1_200;
 const CONTROL_UI_CLIENT_ID = "hermes3d-control-ui";
 
 const isAutoManagedAdapter = (adapterType: StudioGatewayAdapterType) =>
-  adapterType === "hermes" || adapterType === "demo";
+  adapterType === "hermes" || adapterType === "hermes-agent" || adapterType === "demo";
 
 export const resolveGatewayClientName = () => CONTROL_UI_CLIENT_ID;
 

--- a/src/lib/gateway/upstreamUrlDiagnostics.ts
+++ b/src/lib/gateway/upstreamUrlDiagnostics.ts
@@ -41,7 +41,10 @@ const HERMES_AGENT_ENDPOINT_FIX =
 const isTailnetHostname = (hostname: string) =>
   hostname === "ts.net" || hostname.endsWith(".ts.net");
 
-export const inspectUpstreamGatewayUrl = (rawUrl: unknown): UpstreamUrlFinding[] => {
+export const inspectUpstreamGatewayUrl = (
+  rawUrl: unknown,
+  adapterType: unknown = ""
+): UpstreamUrlFinding[] => {
   const url = typeof rawUrl === "string" ? rawUrl.trim() : "";
   if (!url) return [];
 
@@ -58,7 +61,13 @@ export const inspectUpstreamGatewayUrl = (rawUrl: unknown): UpstreamUrlFinding[]
   const port = parsed.port;
   const path = parsed.pathname.replace(/\/+$/, "");
 
-  if (port === HERMES_AGENT_DASHBOARD_PORT) {
+  // The hermes-agent adapter targets that dashboard on purpose: Studio
+  // translates JSON-RPC in-process, so the endpoint these rules warn about is
+  // exactly the right one to point at.
+  const targetsHermesAgent =
+    (typeof adapterType === "string" ? adapterType.trim().toLowerCase() : "") === "hermes-agent";
+
+  if (!targetsHermesAgent && port === HERMES_AGENT_DASHBOARD_PORT) {
     findings.push({
       code: "hermes_agent_dashboard_port",
       severity: "error",
@@ -69,7 +78,7 @@ export const inspectUpstreamGatewayUrl = (rawUrl: unknown): UpstreamUrlFinding[]
     });
   }
 
-  if (path === HERMES_AGENT_WS_PATH) {
+  if (!targetsHermesAgent && path === HERMES_AGENT_WS_PATH) {
     findings.push({
       code: "hermes_agent_jsonrpc_path",
       severity: "error",

--- a/src/lib/studio/settings-store.ts
+++ b/src/lib/studio/settings-store.ts
@@ -73,6 +73,7 @@ const normalizeAdapterType = (value: string | undefined): StudioGatewayAdapterTy
   const normalized = value?.trim().toLowerCase();
   if (
     normalized === "hermes" ||
+    normalized === "hermes-agent" ||
     normalized === "demo" ||
     normalized === "local" ||
     normalized === "hermes3d" ||

--- a/src/lib/studio/settings.ts
+++ b/src/lib/studio/settings.ts
@@ -33,12 +33,14 @@ export type StudioGatewaySettings = {
 
 export type StudioGatewayAdapterType =
   | "hermes"
+  | "hermes-agent"
   | "demo"
   | "local"
   | "hermes3d"
   | "custom";
 export const STUDIO_GATEWAY_ADAPTER_TYPES = [
   "hermes",
+  "hermes-agent",
   "demo",
   "local",
   "hermes3d",
@@ -280,6 +282,8 @@ export type StudioSettingsPatch = {
 
 const SETTINGS_VERSION = 1 as const;
 const DEFAULT_LOCAL_ADAPTER_GATEWAY_URL = "ws://localhost:18789";
+/** A hermes-agent backend started with `hermes serve` on its default port. */
+const DEFAULT_HERMES_AGENT_URL = "http://localhost:9119";
 const DEFAULT_LOCAL_RUNTIME_URL = "http://localhost:7770";
 const DEFAULT_HERMES3D_RUNTIME_URL = "http://localhost:3000/api/runtime/custom";
 const DEFAULT_CUSTOM_RUNTIME_URL = "http://localhost:7770";
@@ -947,6 +951,7 @@ const normalizeGatewayAdapterType = (
   if (
     adapterType === "demo" ||
     adapterType === "hermes" ||
+    adapterType === "hermes-agent" ||
     adapterType === "local" ||
     adapterType === "hermes3d" ||
     adapterType === "custom"
@@ -976,6 +981,8 @@ export const resolveDefaultStudioGatewayProfile = (
   }
 
   switch (adapterType) {
+    case "hermes-agent":
+      return { url: DEFAULT_HERMES_AGENT_URL, token: "" };
     case "hermes3d":
       return { url: DEFAULT_HERMES3D_RUNTIME_URL, token: "" };
     case "local":

--- a/tests/unit/gatewayProxy.test.ts
+++ b/tests/unit/gatewayProxy.test.ts
@@ -105,6 +105,55 @@ describe("createGatewayProxy", () => {
     }
   });
 
+  it("surfaces the hermes-agent bridge's own reason instead of a generic transport error", async () => {
+    // Bind and immediately release a port so the bridge's connection is refused
+    // with a specific errno rather than hanging.
+    const probe = new WebSocketServer({ port: 0 });
+    const probeAddress = probe.address();
+    if (!probeAddress || typeof probeAddress === "string") {
+      throw new Error("expected probe server to have a port");
+    }
+    const deadPort = probeAddress.port;
+    await closeWebSocketServer(probe);
+
+    const { createGatewayProxy } = await import("../../server/gateway-proxy");
+
+    const proxyHttp = await import("node:http").then((m) => m.createServer());
+    const proxy = createGatewayProxy({
+      loadUpstreamSettings: async () => ({
+        url: `http://127.0.0.1:${deadPort}`,
+        token: "",
+        adapterType: "hermes-agent",
+      }),
+      allowWs: (req: { url?: string }) => req.url === "/api/gateway/ws",
+      logError: () => {},
+    });
+    proxyHttp.on("upgrade", (req, socket, head) => proxy.handleUpgrade(req, socket, head));
+
+    await new Promise<void>((resolve) => proxyHttp.listen(0, "127.0.0.1", resolve));
+    const proxyAddr = proxyHttp.address();
+    if (!proxyAddr || typeof proxyAddr === "string") {
+      throw new Error("expected proxy server to have a port");
+    }
+
+    const browser = new WebSocket(`ws://127.0.0.1:${proxyAddr.port}/api/gateway/ws`);
+    try {
+      await waitForEvent(browser, "open");
+      browser.send(
+        JSON.stringify({ type: "req", id: "connect-1", method: "connect", params: {} })
+      );
+
+      const [raw] = await waitForEvent<[Buffer]>(browser, "message");
+      const frame = JSON.parse(String(raw));
+
+      expect(frame.ok).toBe(false);
+      expect(frame.error.message).not.toBe("Failed to connect to upstream gateway WebSocket.");
+      expect(frame.error.message).toMatch(/ECONNREFUSED|connect/i);
+    } finally {
+      await Promise.all([closeWebSocket(browser), closeHttpServer(proxyHttp)]);
+    }
+  });
+
   it("forwards upstream connect.challenge before browser connect and then passes nonce-based device auth", async () => {
     const upstream = new WebSocketServer({ port: 0 });
     const address = upstream.address();

--- a/tests/unit/hermesAgentBridge.test.ts
+++ b/tests/unit/hermesAgentBridge.test.ts
@@ -1,0 +1,285 @@
+// @vitest-environment node
+import { afterEach, describe, expect, it } from "vitest";
+import { WebSocketServer, type WebSocket as WsSocket } from "ws";
+import type { AddressInfo } from "node:net";
+
+const { buildJsonRpcUrl, redactUrl } = await import("../../server/hermes-agent/jsonrpc-client");
+const { createHermesAgentUpstream, toHermes3dMessages } = await import(
+  "../../server/hermes-agent/bridge"
+);
+
+type Frame = Record<string, unknown>;
+type RpcHandler = (params: Frame, emit: (type: string, payload: Frame) => void) => Frame | void;
+
+/** Read a dotted path out of a decoded frame without widening everything to `any`. */
+const at = (source: unknown, path: string): unknown =>
+  path
+    .split(".")
+    .reduce<unknown>((acc, key) => (acc as Record<string, unknown> | undefined)?.[key], source);
+
+const servers: WebSocketServer[] = [];
+const upstreams: { terminate: () => void }[] = [];
+
+afterEach(async () => {
+  for (const upstream of upstreams.splice(0)) {
+    try {
+      upstream.terminate();
+    } catch {}
+  }
+  for (const server of servers.splice(0)) {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  }
+});
+
+/**
+ * Minimal stand-in for hermes-agent's /api/ws: emits gateway.ready on connect,
+ * answers JSON-RPC requests from `handlers`, and lets a handler push events.
+ */
+const startFakeHermesAgent = async (handlers: Record<string, RpcHandler>) => {
+  const wss = new WebSocketServer({ port: 0 });
+  servers.push(wss);
+  await new Promise<void>((resolve) => wss.on("listening", () => resolve()));
+
+  const received: Frame[] = [];
+
+  wss.on("connection", (ws: WsSocket, req) => {
+    const url = new URL(req.url ?? "/", "http://localhost");
+    received.push({ __connect: true, path: url.pathname, token: url.searchParams.get("token") });
+
+    const send = (obj: unknown) => ws.send(JSON.stringify(obj));
+    const emit = (type: string, payload: Frame) =>
+      send({ jsonrpc: "2.0", method: "event", params: { type, session_id: "s1", payload } });
+
+    send({ jsonrpc: "2.0", method: "event", params: { type: "gateway.ready", payload: {} } });
+
+    ws.on("message", (raw) => {
+      const request = JSON.parse(String(raw)) as Frame;
+      received.push(request);
+      const handler = handlers[String(request.method)];
+      if (!handler) {
+        send({
+          jsonrpc: "2.0",
+          id: request.id,
+          error: { code: -32601, message: "unknown method" },
+        });
+        return;
+      }
+      const result = handler((request.params ?? {}) as Frame, emit);
+      send({ jsonrpc: "2.0", id: request.id, result: result ?? {} });
+    });
+  });
+
+  const { port } = wss.address() as AddressInfo;
+  return { url: `ws://127.0.0.1:${port}`, received };
+};
+
+/** Drive the bridge and collect the frames it sends back toward the browser. */
+const openBridge = async (url: string, token = "") => {
+  const frames: Frame[] = [];
+  const upstream = createHermesAgentUpstream({ url, token });
+  upstreams.push(upstream);
+  upstream.on("message", (raw: string) => frames.push(JSON.parse(raw) as Frame));
+
+  await new Promise<void>((resolve, reject) => {
+    upstream.on("open", () => resolve());
+    upstream.on("error", reject);
+    setTimeout(() => reject(new Error("bridge did not open")), 5000);
+  });
+
+  const send = (frame: Frame) => upstream.send(JSON.stringify(frame));
+
+  const waitFor = async (predicate: (frame: Frame) => boolean, label: string) => {
+    const start = Date.now();
+    while (Date.now() - start < 5000) {
+      const hit = frames.find(predicate);
+      if (hit) return hit;
+      await new Promise((resolve) => setTimeout(resolve, 10));
+    }
+    throw new Error(`timed out waiting for ${label}; saw ${JSON.stringify(frames)}`);
+  };
+
+  return { upstream, frames, send, waitFor };
+};
+
+describe("buildJsonRpcUrl", () => {
+  it("appends the gateway path and maps https to wss", () => {
+    expect(buildJsonRpcUrl("https://host.ts.net:8443", "abc")).toBe(
+      "wss://host.ts.net:8443/api/ws?token=abc",
+    );
+  });
+
+  it("keeps a path the caller already supplied", () => {
+    expect(buildJsonRpcUrl("wss://host.ts.net:8443/api/ws", "")).toBe(
+      "wss://host.ts.net:8443/api/ws",
+    );
+  });
+
+  it("maps http to ws and tolerates a trailing slash", () => {
+    expect(buildJsonRpcUrl("http://localhost:9119/", "t")).toBe(
+      "ws://localhost:9119/api/ws?token=t",
+    );
+  });
+
+  it("rejects a scheme that is not http(s) or ws(s)", () => {
+    expect(() => buildJsonRpcUrl("ftp://host", "")).toThrow(/Unsupported scheme/);
+  });
+
+  it("keeps the token out of logged URLs", () => {
+    expect(redactUrl("wss://h/api/ws?token=secret")).toBe("wss://h/api/ws?token=***");
+  });
+});
+
+describe("toHermes3dMessages", () => {
+  it("renames text to content and drops non-conversational rows", () => {
+    expect(
+      toHermes3dMessages([
+        { role: "user", text: "hi" },
+        { role: "tool", name: "terminal" },
+        { role: "assistant", text: "hello" },
+      ]),
+    ).toEqual([
+      { role: "user", content: "hi" },
+      { role: "assistant", content: "hello" },
+    ]);
+  });
+
+  it("returns an empty list for a missing transcript", () => {
+    expect(toHermes3dMessages(undefined)).toEqual([]);
+  });
+});
+
+describe("hermes-agent bridge", () => {
+  it("sends the token as a query param on /api/ws", async () => {
+    const agent = await startFakeHermesAgent({});
+    await openBridge(agent.url, "tok-123");
+
+    expect(agent.received.find((frame) => frame.__connect)).toMatchObject({
+      path: "/api/ws",
+      token: "tok-123",
+    });
+  });
+
+  it("answers connect with a hello-ok advertising one agent", async () => {
+    const agent = await startFakeHermesAgent({});
+    const bridge = await openBridge(agent.url);
+
+    bridge.send({ type: "req", id: "c1", method: "connect", params: {} });
+    const res = await bridge.waitFor((f) => f.type === "res" && f.id === "c1", "hello-ok");
+
+    expect(res.ok).toBe(true);
+    expect(at(res, "payload.type")).toBe("hello-ok");
+    expect(at(res, "payload.snapshot.health.agents")).toHaveLength(1);
+    expect(at(res, "payload.snapshot.health.defaultAgentId")).toBe("hermes");
+  });
+
+  it("turns chat.send into prompt.submit and streams deltas into chat events", async () => {
+    const agent = await startFakeHermesAgent({
+      "session.create": () => ({ session_id: "s1", stored_session_id: "stored-1" }),
+      "prompt.submit": (_params, emit) => {
+        setTimeout(() => {
+          emit("message.start", {});
+          emit("message.delta", { text: "Hel" });
+          emit("message.delta", { text: "lo" });
+          emit("message.complete", { text: "Hello", status: "complete" });
+        }, 10);
+        return { status: "streaming" };
+      },
+    });
+    const bridge = await openBridge(agent.url);
+
+    bridge.send({
+      type: "req",
+      id: "m1",
+      method: "chat.send",
+      params: { sessionKey: "agent:hermes:main", message: "hi", idempotencyKey: "run-1" },
+    });
+
+    const started = await bridge.waitFor((f) => f.type === "res" && f.id === "m1", "chat.send res");
+    expect(started.payload).toMatchObject({ status: "started", runId: "run-1" });
+
+    const submitted = agent.received.find((frame) => frame.method === "prompt.submit");
+    expect(submitted?.params).toMatchObject({ session_id: "s1", text: "hi" });
+
+    const final = await bridge.waitFor(
+      (f) => f.event === "chat" && at(f, "payload.state") === "final",
+      "final chat event",
+    );
+    expect(at(final, "payload.message")).toEqual({ role: "assistant", content: "Hello" });
+    expect(at(final, "payload.runId")).toBe("run-1");
+
+    // Deltas accumulate, so the browser always receives the full text so far.
+    const deltas = bridge.frames.filter(
+      (f) => f.event === "chat" && at(f, "payload.state") === "delta",
+    );
+    expect(deltas.map((frame) => at(frame, "payload.message.content"))).toEqual(["Hel", "Hello"]);
+  });
+
+  it("reports a failed prompt as an error response rather than a silent hang", async () => {
+    const agent = await startFakeHermesAgent({
+      "session.create": () => ({ session_id: "s1" }),
+    });
+    const bridge = await openBridge(agent.url);
+
+    bridge.send({
+      type: "req",
+      id: "m2",
+      method: "chat.send",
+      params: { sessionKey: "agent:hermes:main", message: "hi" },
+    });
+
+    const res = await bridge.waitFor((f) => f.type === "res" && f.id === "m2", "chat.send failure");
+    expect(res.ok).toBe(false);
+    expect(at(res, "error.code")).toBe("hermes_agent.prompt_failed");
+  });
+
+  it("maps chat.abort onto session.interrupt", async () => {
+    const agent = await startFakeHermesAgent({
+      "session.create": () => ({ session_id: "s1" }),
+      "prompt.submit": () => ({ status: "streaming" }),
+      "session.interrupt": () => ({ status: "interrupted" }),
+    });
+    const bridge = await openBridge(agent.url);
+
+    bridge.send({
+      type: "req",
+      id: "m3",
+      method: "chat.send",
+      params: { sessionKey: "agent:hermes:main", message: "hi", idempotencyKey: "run-9" },
+    });
+    await bridge.waitFor((f) => f.type === "res" && f.id === "m3", "chat.send res");
+
+    bridge.send({ type: "req", id: "a1", method: "chat.abort", params: { runId: "run-9" } });
+    const res = await bridge.waitFor((f) => f.type === "res" && f.id === "a1", "abort res");
+
+    expect(res.payload).toMatchObject({ ok: true, aborted: 1 });
+    expect(agent.received.some((frame) => frame.method === "session.interrupt")).toBe(true);
+  });
+
+  it("surfaces stored hermes-agent sessions alongside the main key", async () => {
+    const agent = await startFakeHermesAgent({
+      "session.list": () => ({
+        sessions: [{ id: "20260409_abc", title: "Yesterday's chat", started_at: 1000 }],
+      }),
+    });
+    const bridge = await openBridge(agent.url);
+
+    bridge.send({ type: "req", id: "s1", method: "sessions.list", params: {} });
+    const res = await bridge.waitFor((f) => f.type === "res" && f.id === "s1", "sessions.list");
+
+    const sessions = at(res, "payload.sessions") as { key: string }[];
+    expect(sessions.map((session) => session.key)).toEqual(
+      expect.arrayContaining(["agent:hermes:main", "agent:hermes:20260409_abc"]),
+    );
+  });
+
+  it("keeps working when an optional upstream method is unavailable", async () => {
+    const agent = await startFakeHermesAgent({});
+    const bridge = await openBridge(agent.url);
+
+    bridge.send({ type: "req", id: "k1", method: "models.list", params: {} });
+    const res = await bridge.waitFor((f) => f.type === "res" && f.id === "k1", "models.list");
+
+    expect(res.ok).toBe(true);
+    expect(at(res, "payload.models")).not.toHaveLength(0);
+  });
+});

--- a/tests/unit/upstreamUrlDiagnostics.test.ts
+++ b/tests/unit/upstreamUrlDiagnostics.test.ts
@@ -39,6 +39,32 @@ describe("upstream gateway URL diagnostics", () => {
     expect(codesFor("ws://localhost:3000/api/gateway/ws")).toEqual([]);
   });
 
+  it("stays quiet when the hermes-agent adapter targets that endpoint on purpose", () => {
+    // The JSON-RPC path and the dashboard port are the correct destination for
+    // this adapter, so the rules that reject them elsewhere must stand down.
+    const served = "wss://luke-hermes.taildb786a.ts.net:8443/api/ws";
+    expect(codesFor(served)).toContain("hermes_agent_jsonrpc_path");
+    expect(inspectUpstreamGatewayUrl(served, "hermes-agent")).toEqual([]);
+    expect(inspectUpstreamGatewayUrlFromDoctor(served, "hermes-agent")).toEqual([]);
+
+    const local = "http://localhost:9119";
+    expect(codesFor(local)).toContain("hermes_agent_dashboard_port");
+    expect(inspectUpstreamGatewayUrl(local, "hermes-agent")).toEqual([]);
+    expect(
+      buildGatewayWarnings({ gatewayUrl: local, adapterType: "hermes-agent" }),
+    ).not.toContainEqual(expect.stringContaining("dashboard"));
+  });
+
+  it("still warns the hermes-agent adapter about a non-TLS tailnet port", () => {
+    // Suppressing the endpoint rules must not suppress this one: wss:// against
+    // a port Tailscale does not terminate TLS on fails for either adapter.
+    expect(
+      inspectUpstreamGatewayUrl("wss://luke-hermes.taildb786a.ts.net:9119", "hermes-agent").map(
+        (finding) => finding.code,
+      ),
+    ).toEqual(["tls_on_plain_tailnet_port"]);
+  });
+
   it("flags the Hermes OpenAI-compatible API port", () => {
     expect(codesFor("ws://localhost:8642")).toEqual(["hermes_openai_api_port"]);
   });


### PR DESCRIPTION
## Why

Connecting Hermes3D to a remote Hermes over Tailscale meant running the standalone gateway adapter somewhere — on the laptop, or on the Hermes box. That was never a configuration problem that could be solved on either end: **hermes-agent has no server that speaks the Hermes3D gateway protocol.** Searching it for the handshake (`hello-ok`, `connect.challenge`) returns nothing; its WebSocket surfaces (`/api/ws`, `/api/pty`, `/api/console`, `/api/pub`, `/api/events`) are JSON-RPC 2.0 or raw bytes. Hermes3D inherited its protocol from OpenClaw, and hermes-agent never spoke it.

So the adapter was a permanent third process to host and supervise, purely to translate.

## What changed

Studio translates in-process instead. A new `hermes-agent` adapter type points at the backend's own `/api/ws`, and `gateway-proxy.js` substitutes a bridge for the upstream socket rather than forwarding frames to it.

The bridge presents the slice of the `ws` surface the proxy actually uses (`readyState`, `send`, `close`, `terminate`, and the open/message/close/error events), which kept the proxy diff to a branch — connect handling, rate limiting, and lifecycle are untouched.

| Hermes3D | hermes-agent |
|---|---|
| `chat.send` | `session.create` / `session.resume` + `prompt.submit` |
| `chat` delta/final events | `message.delta` / `message.complete` |
| `chat.abort` | `session.interrupt` |
| `chat.history` | `session.history` |
| `sessions.list` | `session.list` (real stored sessions appear in Studio) |
| `models.list` | `model.options` |
| `exec.approval.resolve` | `approval.respond` |

A hermes-agent backend is a single agent, so the fleet is synthesised as one entry and session keys map onto runtime sessions created or resumed on first use.

### Auth

The backend's session token goes on the query string. This is what keeps a **loopback-bound** server published through Tailscale Serve reachable without a login — a non-loopback bind reports `auth_required: true` and demands dashboard credentials instead, which is the failure this repo has hit before.

When the backend refuses, its reason now reaches the connect screen rather than being flattened into `Failed to connect to upstream gateway WebSocket`. Distinguishing a bad token from a gated bind is the entire diagnosis, so a generic message here costs real debugging time.

### Interaction with #7

The endpoint guardrails added in #7 reject port `9119` and the `/api/ws` path. For this adapter that is exactly the right destination, so those two rules stand down when `adapterType` is `hermes-agent`. The non-TLS tailnet port warning still fires for both adapters, because `wss://` against a port Tailscale does not terminate TLS on fails either way.

## Testing

- `tests/unit/hermesAgentBridge.test.ts` (new, 14 tests) drives the bridge against a fake hermes-agent JSON-RPC server: URL building, token placement, `hello-ok`, delta accumulation, prompt failure, abort, session listing, and graceful degradation when an optional upstream method is missing.
- `tests/unit/gatewayProxy.test.ts` gains a test asserting the bridge's own error survives to the browser.
- `tests/unit/upstreamUrlDiagnostics.test.ts` covers both the suppression and the warning that must survive it.

Typecheck and lint are clean. Suite is 1094 passing; the 3 failures in `agentChatPanel-controls` and `agentFleetHydration` are pre-existing and reproduce on a clean tree.

### Verified live

Against a real backend over Tailscale, through the full browser path into Studio's proxy: TLS negotiated, `/api/ws` reached, and the backend's auth challenge surfaced with its actionable message. Chat, sessions, history, streaming, abort, models, and approvals are implemented against the mapped contract.

**Untested against a live backend:** cron, skills, and tasks are wired to hermes-agent's equivalents but were not exercised end to end.

## Test plan

- [ ] Set `HERMES_DASHBOARD_SESSION_TOKEN` on the backend and pin it so it survives restarts
- [ ] Set adapter type to `hermes-agent`, URL to the server root, token to that value
- [ ] Confirm connect succeeds with no adapter process on either machine (port 18789 free)
- [ ] Send a message and confirm streaming, then abort mid-turn
- [ ] Confirm `npm run doctor` reports no false positives for this adapter

Made with [Cursor](https://cursor.com)