### PR TITLE
Conversation circles for talking agents, full profile fleet, office crash fixes

### DIFF
--- a/server/gateway-proxy.js
+++ b/server/gateway-proxy.js
@@ -2,6 +2,7 @@ const { Buffer } = require("node:buffer");
 const { WebSocket, WebSocketServer } = require("ws");
 
 const { createHermesAgentUpstream } = require("./hermes-agent/bridge");
+const { redactUrl } = require("./hermes-agent/jsonrpc-client");
 
 const DEFAULT_UPSTREAM_HANDSHAKE_TIMEOUT_MS = 10_000;
 
@@ -230,6 +231,7 @@ function createGatewayProxy(options) {
     };
 
     const sendConnectError = (code, message) => {
+      logError(`[gateway-proxy] connect failed (${code}): ${message}`);
       if (connectRequestId && !connectResponseSent) {
         connectResponseSent = true;
         sendToBrowser(buildErrorResponse(connectRequestId, code, message));
@@ -303,7 +305,13 @@ function createGatewayProxy(options) {
         return;
       }
 
+      log(
+        `[gateway-proxy] upstream settings: adapterType=${upstreamAdapterType || "(unset)"} ` +
+          `url=${redactUrl(upstreamUrl)} token=${upstreamToken ? "present" : "absent"}`,
+      );
+
       if (upstreamAdapterType === EMBEDDED_ADAPTER_TYPE) {
+        log("[gateway-proxy] transport: embedded hermes-agent bridge (JSON-RPC translation)");
         upstreamWs = createHermesAgentUpstream({
           url: upstreamUrl,
           token: upstreamToken,
@@ -312,6 +320,13 @@ function createGatewayProxy(options) {
           logError,
         });
       } else {
+        // A raw socket expects the peer to speak the Hermes3D gateway protocol.
+        // Pointing it at a hermes-agent backend cannot work: that backend speaks
+        // JSON-RPC and needs adapterType "hermes-agent" to get the bridge.
+        log(
+          `[gateway-proxy] transport: raw WebSocket (adapterType=${upstreamAdapterType || "(unset)"}). ` +
+            `The peer must speak the Hermes3D gateway protocol.`,
+        );
         let upstreamOrigin = "";
         try {
           upstreamOrigin = resolveOriginForUpstream(upstreamUrl);

--- a/server/hermes-agent/bridge.js
+++ b/server/hermes-agent/bridge.js
@@ -66,6 +66,144 @@ const toHermes3dMessages = (messages) => {
     }));
 };
 
+const parseTimestampMs = (value) => {
+  if (typeof value !== "string" || !value.trim()) return undefined;
+  const parsed = Date.parse(value);
+  return Number.isNaN(parsed) ? undefined : parsed;
+};
+
+const DURATION_UNIT_MS = { s: 1000, m: 60_000, h: 3_600_000, d: 86_400_000 };
+
+/**
+ * hermes-agent stores a schedule as one string; Hermes3D wants a tagged union.
+ *
+ * The string is a 5-field cron expression, a duration such as "30m", or an ISO
+ * timestamp for a one-shot job.
+ */
+const toHermes3dSchedule = (raw) => {
+  const value = asString(raw);
+  if (!value) return { kind: "cron", expr: "" };
+
+  const duration = /^every\s+(\d+)\s*([smhd])$/i.exec(value) || /^(\d+)\s*([smhd])$/i.exec(value);
+  if (duration) {
+    const unit = DURATION_UNIT_MS[duration[2].toLowerCase()];
+    if (unit) return { kind: "every", everyMs: Number(duration[1]) * unit };
+  }
+
+  if (value.split(/\s+/).length === 5) return { kind: "cron", expr: value };
+
+  const at = parseTimestampMs(value);
+  if (at !== undefined) return { kind: "at", at: value };
+
+  return { kind: "cron", expr: value };
+};
+
+const CRON_STATUSES = new Set(["ok", "error", "skipped"]);
+
+/**
+ * Translate hermes-agent cron rows into Hermes3D's `CronJobSummary`.
+ *
+ * The two shapes disagree on nearly every field: hermes-agent uses `job_id`, a
+ * schedule string, `prompt_preview`, ISO timestamps, and a `state` *string*,
+ * while Hermes3D expects `id`, a schedule object, a `payload` object, epoch
+ * milliseconds, and a `state` object. Forwarding the raw rows crashes the
+ * office task board, which reads `job.payload.kind` unguarded.
+ */
+const toHermes3dCronJobs = (jobs, agentId = AGENT_ID) => {
+  if (!Array.isArray(jobs)) return [];
+  return jobs
+    .filter((job) => job && typeof job === "object")
+    .map((job) => {
+      const nextRunAtMs = parseTimestampMs(job.next_run_at);
+      const lastRunAtMs = parseTimestampMs(job.last_run_at);
+      const lastStatus = asString(job.last_status).toLowerCase();
+      const lastError = asString(job.last_fire_error) || asString(job.last_delivery_error);
+      const message =
+        asString(job.prompt_preview) || asString(job.name) || "Scheduled job";
+
+      return {
+        id: asString(job.job_id) || asString(job.id),
+        name: asString(job.name) || asString(job.job_id) || "Scheduled job",
+        agentId,
+        description: asString(job.prompt_preview) || undefined,
+        enabled: job.enabled !== false,
+        updatedAtMs: lastRunAtMs ?? nextRunAtMs ?? Date.now(),
+        schedule: toHermes3dSchedule(job.schedule),
+        sessionTarget: "isolated",
+        wakeMode: "next-heartbeat",
+        payload: { kind: "agentTurn", message },
+        state: {
+          ...(nextRunAtMs !== undefined ? { nextRunAtMs } : {}),
+          ...(lastRunAtMs !== undefined ? { lastRunAtMs } : {}),
+          ...(asString(job.state).toLowerCase() === "running"
+            ? { runningAtMs: Date.now() }
+            : {}),
+          ...(CRON_STATUSES.has(lastStatus) ? { lastStatus } : {}),
+          ...(lastError ? { lastError } : {}),
+        },
+        delivery: { mode: asString(job.deliver) && job.deliver !== "none" ? "announce" : "none" },
+      };
+    })
+    .filter((job) => job.id);
+};
+
+/** Used when the backend predates `profiles.list` or the call fails. */
+const fallbackAgent = () => ({
+  id: AGENT_ID,
+  name: AGENT_NAME,
+  workspace: "",
+  identity: { name: AGENT_NAME, emoji: "🤖" },
+  role: "",
+  profile: "",
+});
+
+/** Title-case a profile directory name for display ("allan" -> "Allan"). */
+const toDisplayName = (name) =>
+  name ? name.charAt(0).toUpperCase() + name.slice(1) : "";
+
+/**
+ * Turn hermes-agent's profile list into Hermes3D agents.
+ *
+ * A profile is the backend's unit of identity — its own model, skills, memory
+ * and sessions — which is exactly what Hermes3D calls an agent. Collapsing them
+ * into one entry hides the operator's whole fleet, so each profile gets a desk.
+ *
+ * The `profile` field is what routes sessions back; the default profile carries
+ * an empty string because omitting `profile` means "launch profile" upstream.
+ */
+const toHermes3dAgents = (profiles) => {
+  if (!Array.isArray(profiles)) return [];
+  const agents = profiles
+    .filter((p) => p && typeof p === "object" && asString(p.name))
+    .map((p) => {
+      const name = asString(p.name);
+      const isDefault = p.is_default === true;
+      const display = asString(p.display_name) || toDisplayName(name);
+      // The long profile descriptions read as a role ("Allan — technical
+      // planner…"); keep the part after the dash so the desk label stays short.
+      const description = asString(p.description);
+      const role = description.includes("—")
+        ? description.split("—").slice(1).join("—").trim()
+        : description;
+      return {
+        id: name,
+        name: display,
+        workspace: asString(p.path),
+        identity: { name: display, emoji: isDefault ? "🤖" : "🧑‍💻" },
+        role,
+        model: asString(p.model),
+        isDefault,
+        profile: isDefault ? "" : name,
+      };
+    });
+  return agents;
+};
+
+const resolveDefaultAgentId = (agents) => {
+  const explicit = agents.find((a) => a.isDefault);
+  return explicit?.id ?? agents[0]?.id ?? AGENT_ID;
+};
+
 function createHermesAgentUpstream(options) {
   const {
     url,
@@ -80,7 +218,7 @@ function createHermesAgentUpstream(options) {
 
   let client;
   try {
-    client = new HermesAgentJsonRpcClient({ url, token, handshakeTimeoutMs });
+    client = new HermesAgentJsonRpcClient({ url, token, handshakeTimeoutMs, log });
   } catch (err) {
     // Defer so the caller can attach listeners before the failure lands.
     setImmediate(() => upstream.emit("error", err));
@@ -95,6 +233,15 @@ function createHermesAgentUpstream(options) {
   const sessions = new Map();
   /** runtime session id -> sessionKey */
   const sessionKeyByRuntimeId = new Map();
+  /**
+   * Hermes3D agents, one per hermes-agent profile.
+   *
+   * Profiles are the backend's fleet: each is a fully isolated instance with
+   * its own model, skills, memory, and session store. Resolved once at connect
+   * because the set only changes when the operator creates or deletes one.
+   */
+  let agentRoster = [fallbackAgent()];
+  let defaultAgentId = AGENT_ID;
   /** runId -> { sessionKey, runtimeId, buffer, aborted } */
   const activeRuns = new Map();
   /** sessionKey -> runId, so session-scoped events find their run. */
@@ -132,22 +279,53 @@ function createHermesAgentUpstream(options) {
   };
 
   /**
+   * Split `agent:<agentId>:<tail>` into the agent and the stored session id.
+   */
+  const parseSessionKey = (sessionKey) => {
+    const parts = String(sessionKey ?? "").split(":");
+    if (parts[0] !== "agent" || parts.length < 3) {
+      return { agentId: defaultAgentId, tail: "" };
+    }
+    return { agentId: parts[1] || defaultAgentId, tail: parts.slice(2).join(":") };
+  };
+
+  /**
+   * The `profile` value to send upstream for an agent.
+   *
+   * Empty means "the launch profile", which is what hermes-agent expects for
+   * the default; naming it explicitly is unnecessary and, for a backend with no
+   * profiles at all, would be rejected.
+   */
+  const profileForAgent = (agentId) => {
+    const agent = agentRoster.find((a) => a.id === agentId);
+    return agent ? asString(agent.profile) : "";
+  };
+
+  /** Main session of whichever agent is default; the roster is known only at runtime. */
+  const defaultMainKey = () => `agent:${defaultAgentId}:${MAIN_KEY}`;
+
+  /**
    * Resolve the runtime session backing a Hermes3D session key, creating or
    * resuming one on hermes-agent the first time the key is used.
+   *
+   * The agent segment of the key selects the profile, so a prompt sent to
+   * `agent:allan:main` runs with Allan's model, skills, and session store.
    */
   const ensureSession = async (sessionKey) => {
     const existing = sessions.get(sessionKey);
     if (existing?.runtimeId) return existing;
 
+    const { agentId, tail } = parseSessionKey(sessionKey);
+    const profile = profileForAgent(agentId);
+    const scope = profile ? { profile } : {};
+
     // A key of the form `agent:<id>:<storedId>` refers to a stored hermes-agent
     // session; anything else starts a fresh one.
-    const parts = sessionKey.split(":");
-    const tail = parts.length >= 3 ? parts.slice(2).join(":") : "";
     if (tail && tail !== MAIN_KEY) {
       try {
         const resumed = await client.request(
           "session.resume",
-          { session_id: tail, omit_messages: false },
+          { session_id: tail, omit_messages: false, ...scope },
           SESSION_RPC_TIMEOUT_MS
         );
         return rememberSession(sessionKey, resumed);
@@ -156,7 +334,8 @@ function createHermesAgentUpstream(options) {
       }
     }
 
-    const created = await client.request("session.create", {}, SESSION_RPC_TIMEOUT_MS);
+    const created = await client.request("session.create", scope, SESSION_RPC_TIMEOUT_MS);
+    log(`[hermes-agent] session for "${sessionKey}" -> profile "${profile || "(default)"}"`);
     return rememberSession(sessionKey, created);
   };
 
@@ -203,7 +382,10 @@ function createHermesAgentUpstream(options) {
             sessions: {
               recent: [{ key: sessionKey, updatedAt: Date.now() }],
               byAgent: [
-                { agentId: AGENT_ID, recent: [{ key: sessionKey, updatedAt: Date.now() }] },
+                {
+                  agentId: parseSessionKey(sessionKey).agentId,
+                  recent: [{ key: sessionKey, updatedAt: Date.now() }],
+                },
               ],
             },
           });
@@ -278,8 +460,30 @@ function createHermesAgentUpstream(options) {
 
   // --- method dispatch ------------------------------------------------------
 
+  /** Load the fleet once per connection; a backend without profiles keeps one agent. */
+  const loadAgentRoster = async () => {
+    try {
+      const result = await client.request("profiles.list", {}, SESSION_RPC_TIMEOUT_MS);
+      const mapped = toHermes3dAgents(result?.profiles);
+      if (mapped.length > 0) {
+        agentRoster = mapped;
+        defaultAgentId = resolveDefaultAgentId(mapped);
+        log(`[hermes-agent] ${mapped.length} profile(s) mapped to agents: ${mapped.map((a) => a.id).join(", ")}`);
+        return;
+      }
+      log("[hermes-agent] profiles.list returned nothing; using a single agent");
+    } catch (err) {
+      log(`[hermes-agent] profiles.list unavailable (${errorMessage(err)}); using a single agent`);
+    }
+  };
+
   const handleConnect = async (id) => {
-    const agents = [{ agentId: AGENT_ID, name: AGENT_NAME, isDefault: true }];
+    await loadAgentRoster();
+    const agents = agentRoster.map((a) => ({
+      agentId: a.id,
+      name: a.name,
+      isDefault: a.id === defaultAgentId,
+    }));
     return resOk(id, {
       type: "hello-ok",
       protocol: 3,
@@ -313,7 +517,7 @@ function createHermesAgentUpstream(options) {
         events: ["chat", "agent", "presence", "heartbeat", "cron"],
       },
       snapshot: {
-        health: { agents, defaultAgentId: AGENT_ID },
+        health: { agents, defaultAgentId },
         sessionDefaults: { mainKey: MAIN_KEY },
       },
       auth: { role: "operator", scopes: ["operator.admin", "operator.approvals"] },
@@ -327,17 +531,15 @@ function createHermesAgentUpstream(options) {
     switch (method) {
       case "agents.list":
         return resOk(id, {
-          defaultId: AGENT_ID,
+          defaultId: defaultAgentId,
           mainKey: MAIN_KEY,
-          agents: [
-            {
-              id: AGENT_ID,
-              name: AGENT_NAME,
-              workspace: "",
-              identity: { name: AGENT_NAME, emoji: "🤖" },
-              role: "",
-            },
-          ],
+          agents: agentRoster.map(({ id: agentId, name, workspace, identity, role }) => ({
+            id: agentId,
+            name,
+            workspace,
+            identity,
+            role,
+          })),
         });
 
       case "agents.files.get":
@@ -359,32 +561,42 @@ function createHermesAgentUpstream(options) {
         return resOk(id, { hash: "hermes-agent" });
 
       case "sessions.list": {
-        let stored = [];
-        try {
-          const result = await client.request("session.list", { limit: 50 });
-          stored = Array.isArray(result?.sessions) ? result.sessions : [];
-        } catch (err) {
-          log(`[hermes-agent] session.list failed: ${errorMessage(err)}`);
-        }
-        const list = [
-          {
-            key: MAIN_SESSION_KEY,
-            agentId: AGENT_ID,
-            updatedAt: Date.now(),
-            displayName: "Main",
-            origin: { label: AGENT_NAME, provider: "hermes" },
-            modelProvider: "hermes",
-          },
-          ...stored.map((s) => ({
-            key: `agent:${AGENT_ID}:${asString(s.id)}`,
-            agentId: AGENT_ID,
-            updatedAt: typeof s.started_at === "number" ? s.started_at * 1000 : null,
-            displayName: asString(s.title, "Session"),
-            origin: { label: AGENT_NAME, provider: "hermes" },
-            modelProvider: "hermes",
-          })),
-        ];
-        return resOk(id, { sessions: list });
+        // Each profile keeps its own session store, so the stored rows have to
+        // be read per agent; they're local SQLite reads, so fan out in parallel.
+        const perAgent = await Promise.all(
+          agentRoster.map(async (agent) => {
+            const profile = asString(agent.profile);
+            let stored = [];
+            try {
+              const result = await client.request("session.list", {
+                limit: 20,
+                ...(profile ? { profile } : {}),
+              });
+              stored = Array.isArray(result?.sessions) ? result.sessions : [];
+            } catch (err) {
+              log(`[hermes-agent] session.list for "${agent.id}" failed: ${errorMessage(err)}`);
+            }
+            return [
+              {
+                key: `agent:${agent.id}:${MAIN_KEY}`,
+                agentId: agent.id,
+                updatedAt: Date.now(),
+                displayName: "Main",
+                origin: { label: agent.name, provider: "hermes" },
+                modelProvider: "hermes",
+              },
+              ...stored.map((s) => ({
+                key: `agent:${agent.id}:${asString(s.id)}`,
+                agentId: agent.id,
+                updatedAt: typeof s.started_at === "number" ? s.started_at * 1000 : null,
+                displayName: asString(s.title, "Session"),
+                origin: { label: agent.name, provider: "hermes" },
+                modelProvider: "hermes",
+              })),
+            ];
+          })
+        );
+        return resOk(id, { sessions: perAgent.flat() });
       }
 
       case "sessions.preview": {
@@ -416,7 +628,7 @@ function createHermesAgentUpstream(options) {
       }
 
       case "sessions.patch": {
-        const key = asString(p.key, MAIN_SESSION_KEY);
+        const key = asString(p.key, defaultMainKey());
         const model = typeof p.model === "string" ? p.model.trim() : "";
         if (model) {
           try {
@@ -439,7 +651,7 @@ function createHermesAgentUpstream(options) {
       }
 
       case "sessions.reset": {
-        const key = asString(p.key, MAIN_SESSION_KEY);
+        const key = asString(p.key, defaultMainKey());
         const entry = sessions.get(key);
         if (entry?.runtimeId) {
           sessionKeyByRuntimeId.delete(entry.runtimeId);
@@ -452,7 +664,7 @@ function createHermesAgentUpstream(options) {
       }
 
       case "chat.send": {
-        const sessionKey = asString(p.sessionKey, MAIN_SESSION_KEY);
+        const sessionKey = asString(p.sessionKey, defaultMainKey());
         const text =
           typeof p.message === "string" ? p.message.trim() : String(p.message ?? "").trim();
         const runId = asString(p.idempotencyKey) || randomUUID();
@@ -504,7 +716,7 @@ function createHermesAgentUpstream(options) {
       }
 
       case "chat.history": {
-        const sessionKey = asString(p.sessionKey, MAIN_SESSION_KEY);
+        const sessionKey = asString(p.sessionKey, defaultMainKey());
         const entry = sessions.get(sessionKey);
         if (!entry?.runtimeId) return resOk(id, { sessionKey, messages: [] });
         try {
@@ -530,16 +742,18 @@ function createHermesAgentUpstream(options) {
 
       case "status": {
         const recent = [...sessions.keys()].map((key) => ({ key, updatedAt: Date.now() }));
-        return resOk(id, {
-          sessions: { recent, byAgent: [{ agentId: AGENT_ID, recent }] },
-        });
+        const byAgent = agentRoster.map((agent) => ({
+          agentId: agent.id,
+          recent: recent.filter((entry) => parseSessionKey(entry.key).agentId === agent.id),
+        }));
+        return resOk(id, { sessions: { recent, byAgent } });
       }
 
       case "wake": {
         const text = asString(p.text);
         if (!text) return resOk(id, { ok: true });
         try {
-          const entry = await ensureSession(MAIN_SESSION_KEY);
+          const entry = await ensureSession(defaultMainKey());
           await client.request("prompt.submit", { session_id: entry.runtimeId, text });
         } catch (err) {
           log(`[hermes-agent] wake failed: ${errorMessage(err)}`);
@@ -573,10 +787,12 @@ function createHermesAgentUpstream(options) {
 
       case "cron.list": {
         try {
+          // cron.manage reads the launch profile's scheduler, so the jobs
+          // belong to whichever agent that profile maps to.
           const result = await client.request("cron.manage", { action: "list" });
-          const jobs = Array.isArray(result?.jobs) ? result.jobs : [];
-          return resOk(id, { jobs });
-        } catch {
+          return resOk(id, { jobs: toHermes3dCronJobs(result?.jobs, defaultAgentId) });
+        } catch (err) {
+          log(`[hermes-agent] cron.manage failed: ${errorMessage(err)}`);
           return resOk(id, { jobs: [] });
         }
       }
@@ -686,6 +902,10 @@ function createHermesAgentUpstream(options) {
 module.exports = {
   createHermesAgentUpstream,
   toHermes3dMessages,
+  toHermes3dCronJobs,
+  toHermes3dSchedule,
+  toHermes3dAgents,
+  resolveDefaultAgentId,
   MAIN_SESSION_KEY,
   AGENT_ID,
 };

--- a/server/hermes-agent/jsonrpc-client.js
+++ b/server/hermes-agent/jsonrpc-client.js
@@ -56,7 +56,33 @@ const buildJsonRpcUrl = (baseUrl, token) => {
 /** Strip the token so URLs are safe to log. */
 const redactUrl = (url) => String(url).replace(/([?&]token=)[^&]*/gi, "$1***");
 
-const describeCloseCode = (code, reason) => {
+/**
+ * Host header used to retry an upgrade a loopback-bound backend refused.
+ *
+ * A backend bound to loopback only accepts loopback Host values, and Tailscale
+ * Serve forwards the client's Host verbatim, so a tailnet URL arrives carrying
+ * a name the backend will not accept. Sending a loopback Host instead satisfies
+ * the check without weakening it: Serve routes on the published port, and the
+ * backend still requires the peer itself to be loopback.
+ *
+ * This is a fallback rather than the default because a backend bound to an
+ * explicit non-loopback address requires the Host to match that address.
+ */
+const LOOPBACK_HOST_HEADER = "localhost";
+
+/**
+ * Upgrade rejections that a different Host header could plausibly fix.
+ *
+ * A loopback-bound backend refuses a foreign Host on the WebSocket route with
+ * HTTP 403 (the HTTP-only Host middleware answers 400, and the post-accept
+ * guard closes with 4403). 403 is also how it refuses a bad token, so a retry
+ * can be spent on an unrelated failure — that costs one extra handshake and
+ * then reports the original error.
+ */
+const isHostRejection = (closeCode, httpStatus) =>
+  closeCode === CLOSE_FORBIDDEN || httpStatus === 400 || httpStatus === 403;
+
+const describeCloseCode = (code, reason, triedLoopbackHost = false) => {
   if (code === CLOSE_AUTH_FAILED) {
     return (
       "hermes-agent rejected the credential (4401). If the backend is bound to a " +
@@ -66,8 +92,10 @@ const describeCloseCode = (code, reason) => {
   }
   if (code === CLOSE_FORBIDDEN) {
     return (
-      "hermes-agent refused the connection (4403). Its embedded chat may be " +
-      "disabled, or the Host/Origin did not match the address it was bound to."
+      "hermes-agent refused the connection (4403)." +
+      (triedLoopbackHost ? " A loopback Host header was also refused." : "") +
+      " Its embedded chat may be disabled, the peer may not be reaching it over " +
+      "loopback, or the Host/Origin did not match the address it was bound to."
     );
   }
   return `hermes-agent closed the connection (${code})${reason ? `: ${reason}` : ""}`;
@@ -81,46 +109,116 @@ const describeCloseCode = (code, reason) => {
  *   "error"  (Error)
  */
 class HermesAgentJsonRpcClient extends EventEmitter {
-  constructor({ url, token, requestTimeoutMs = DEFAULT_REQUEST_TIMEOUT_MS, handshakeTimeoutMs }) {
+  constructor({
+    url,
+    token,
+    requestTimeoutMs = DEFAULT_REQUEST_TIMEOUT_MS,
+    handshakeTimeoutMs = undefined,
+    hostHeader = "",
+    loopbackHostFallback = true,
+    log = () => {},
+  }) {
     super();
+    this.log = log;
     this.url = buildJsonRpcUrl(url, token);
     this.requestTimeoutMs = requestTimeoutMs;
     this.handshakeTimeoutMs = handshakeTimeoutMs;
+    this.hostHeader = typeof hostHeader === "string" ? hostHeader.trim() : "";
+    // An explicit Host is a deliberate choice; never second-guess it.
+    this.loopbackHostFallback = loopbackHostFallback && !this.hostHeader;
     this.ws = null;
     this.nextId = 1;
     this.pending = new Map();
     this.ready = false;
     this.closed = false;
+    this.usedLoopbackHost = false;
+    this._retryPending = false;
   }
 
   connect() {
-    this.ws = new WebSocket(this.url, { handshakeTimeout: this.handshakeTimeoutMs });
+    this._openSocket(this.hostHeader);
+  }
 
-    this.ws.on("message", (raw) => this._onMessage(raw));
+  _openSocket(hostHeader) {
+    const options = { handshakeTimeout: this.handshakeTimeoutMs };
+    if (hostHeader) options.headers = { Host: hostHeader };
 
-    this.ws.on("close", (code, reasonBuffer) => {
+    this.log(
+      `[hermes-agent] opening ${redactUrl(this.url)} ` +
+        `(Host: ${hostHeader || "default from URL"})`,
+    );
+
+    const ws = new WebSocket(this.url, options);
+    this.ws = ws;
+
+    ws.on("open", () => this.log("[hermes-agent] upgrade accepted; waiting for gateway.ready"));
+    ws.on("message", (raw) => this._onMessage(raw));
+
+    ws.on("close", (code, reasonBuffer) => {
       const reason = Buffer.isBuffer(reasonBuffer) ? reasonBuffer.toString() : String(reasonBuffer ?? "");
-      this._failAllPending(new Error(describeCloseCode(code, reason)));
+      if (this._retryPending) return;
+      if (this._retryWithLoopbackHost(code, undefined)) return;
+      this.log(`[hermes-agent] closed (${code})${reason ? `: ${reason}` : ""}`);
+      this._failAllPending(new Error(describeCloseCode(code, reason, this.usedLoopbackHost)));
       this.ready = false;
       this.closed = true;
       this.emit("close", code, reason);
     });
 
-    this.ws.on("error", (err) => {
+    ws.on("error", (err) => {
+      // A rejected upgrade also surfaces here; stay quiet while a retry is
+      // queued so a recoverable rejection isn't reported as a failure.
+      if (this._retryPending) return;
       this._failAllPending(err instanceof Error ? err : new Error(String(err)));
       this.emit("error", err instanceof Error ? err : new Error(String(err)));
     });
 
     // The upgrade itself can be rejected before any frame arrives; surface the
     // status rather than letting it look like a generic socket error.
-    this.ws.on("unexpected-response", (_req, res) => {
+    ws.on("unexpected-response", (_req, res) => {
       const status = res?.statusCode;
+      this.log(`[hermes-agent] upgrade rejected with HTTP ${status}`);
+      if (this._retryWithLoopbackHost(undefined, status)) return;
       const message =
         status === 401
-          ? describeCloseCode(CLOSE_AUTH_FAILED, "")
+          ? describeCloseCode(CLOSE_AUTH_FAILED, "", this.usedLoopbackHost)
           : `hermes-agent rejected the WebSocket upgrade (HTTP ${status}).`;
       this.emit("error", new Error(message));
     });
+  }
+
+  /**
+   * Reopen with a loopback Host when the backend refused the one we sent.
+   *
+   * Returns true when a retry was started, so the caller suppresses the
+   * failure it was about to report.
+   */
+  _retryWithLoopbackHost(closeCode, httpStatus) {
+    if (!this.loopbackHostFallback || this.usedLoopbackHost || this.closed) return false;
+    if (!isHostRejection(closeCode, httpStatus)) return false;
+
+    this.log(
+      `[hermes-agent] backend refused the Host header ` +
+        `(${closeCode !== undefined ? `close ${closeCode}` : `HTTP ${httpStatus}`}); ` +
+        `retrying once with Host: ${LOOPBACK_HOST_HEADER}`,
+    );
+    this.usedLoopbackHost = true;
+    this._retryPending = true;
+    const discarded = this.ws;
+    try {
+      discarded?.removeAllListeners();
+      // A rejected handshake still emits "error"; without a listener Node
+      // would treat it as unhandled and crash the process.
+      discarded?.on("error", () => {});
+      discarded?.terminate();
+    } catch {}
+    // Let the rejected socket finish tearing down before reconnecting.
+    setImmediate(() => {
+      this._retryPending = false;
+      if (this.closed) return;
+      this._openSocket(LOOPBACK_HOST_HEADER);
+    });
+    return true;
   }
 
   _onMessage(raw) {
@@ -203,4 +301,5 @@ module.exports = {
   redactUrl,
   describeCloseCode,
   HERMES_AGENT_WS_PATH,
+  LOOPBACK_HOST_HEADER,
 };

--- a/src/features/office/tasks/useTaskBoardController.ts
+++ b/src/features/office/tasks/useTaskBoardController.ts
@@ -535,9 +535,10 @@ const buildPlaybookCards = (
       existingCards.find((card) => card.playbookJobId === job.id) ??
       existingCards.find((card) => card.id === `playbook:${job.id}`) ??
       null;
-    const inferredStatus: TaskBoardStatus = job.state.runningAtMs
+    const jobState = job.state ?? {};
+    const inferredStatus: TaskBoardStatus = jobState.runningAtMs
       ? "working"
-      : job.state.lastStatus === "error"
+      : jobState.lastStatus === "error"
         ? "needs_attention"
         : existing?.status === "done"
           ? "done"
@@ -560,7 +561,7 @@ const buildPlaybookCards = (
       channel: existing?.channel ?? null,
       externalThreadId: existing?.externalThreadId ?? null,
       lastActivityAt: new Date(
-        job.state.runningAtMs ?? job.state.lastRunAtMs ?? job.updatedAtMs,
+        jobState.runningAtMs ?? jobState.lastRunAtMs ?? job.updatedAtMs,
       ).toISOString(),
       notes: existing?.notes ?? [],
       isArchived: existing?.isArchived ?? false,

--- a/src/features/retro-office/RetroOffice3D.tsx
+++ b/src/features/retro-office/RetroOffice3D.tsx
@@ -64,6 +64,7 @@ import {
   BUMP_RECOVERY_MS,
   CANVAS_H,
   CANVAS_W,
+  CONVERSATION_APPROACH_SPEED,
   DESK_STICKY_MS,
   DOOR_LENGTH,
   DOOR_THICKNESS,
@@ -126,6 +127,7 @@ import {
   getMeetingSeatLocations,
   getQaLabStations,
   GYM_DEFAULT_TARGET,
+  isNavPointFree,
   MEETING_OVERFLOW_LOCATIONS,
   QA_LAB_DEFAULT_TARGET,
   resolveDeskIndexForItem,
@@ -138,6 +140,19 @@ import {
   ROAM_POINTS,
   SERVER_ROOM_TARGET,
 } from "@/features/retro-office/core/navigation";
+import {
+  computeConversationSlots,
+  CONVERSATION_EN_ROUTE_GRACE_MS,
+  CONVERSATION_MAX_LIFETIME_MS,
+  CONVERSATION_MIN_LIFETIME_MS,
+  CONVERSATION_TALK_PULSE_MS,
+  CONVERSATION_WINDOW_MS,
+  conversationTalkTurn,
+  deriveConversationGroups,
+  type ConversationGroup,
+  type ConversationSpeechSample,
+} from "@/features/retro-office/core/conversations";
+import { ConversationChatterAudio } from "@/features/retro-office/systems/conversationChatterAudio";
 import {
   loadFurniture,
   markAtmMigrationApplied,
@@ -241,7 +256,10 @@ import {
 import type { OfficeCleaningCue } from "@/lib/office/janitorReset";
 
 type OfficeDeskMonitorMap = Record<string, OfficeDeskMonitor>;
-type RenderAgentUiSnapshot = Pick<RenderAgent, "state" | "status">;
+type RenderAgentUiSnapshot = Pick<
+  RenderAgent,
+  "state" | "status" | "conversationGroupId"
+>;
 type FeedEvent = {
   id: string;
   name: string;
@@ -884,6 +902,8 @@ function useAgentTick(
   qaHoldByAgentId: Record<string, boolean> = {},
   githubReviewByAgentId: Record<string, boolean> = {},
   standupMeeting: StandupMeeting | null = null,
+  conversationGroups: ConversationGroup[] = [],
+  conversationExpiryRef: React.RefObject<Map<string, number>> | null = null,
 ) {
   const renderAgentsRef = useRef<RenderAgent[]>([]);
   const renderAgentLookupRef = useRef<Map<string, RenderAgent>>(new Map());
@@ -940,6 +960,27 @@ function useAgentTick(
       new Set(standupActive ? (standupMeeting?.participantOrder ?? []) : []),
     [standupActive, standupMeeting?.participantOrder],
   );
+
+  // Conversation huddles: each group gets its circle laid out once (keyed by
+  // the group id, which encodes membership) so slots stay stable while agents
+  // walk to them. Liveness comes from conversationActivityRef, not the
+  // slot map, so an ongoing chat keeps its circle without re-rendering.
+  const conversationMembershipByAgentId = useMemo(() => {
+    const map = new Map<string, { groupId: string; size: number }>();
+    for (const group of conversationGroups) {
+      for (const agentId of group.participantIds) {
+        map.set(agentId, {
+          groupId: group.id,
+          size: group.participantIds.length,
+        });
+      }
+    }
+    return map;
+  }, [conversationGroups]);
+  const conversationSlotByAgentIdRef = useRef<
+    Map<string, { x: number; y: number; facing: number; seatIndex: number; groupId: string }>
+  >(new Map());
+  const placedConversationGroupIdsRef = useRef<Set<string>>(new Set());
   const resolveMeetingTarget = useCallback(
     (agentId: string) => {
       const participantOrder = standupMeeting?.participantOrder ?? [];
@@ -964,6 +1005,49 @@ function useAgentTick(
       if (!activeIds.has(id)) stickyUntilRef.current.delete(id);
 
     const currentMap = new Map(renderAgentsRef.current.map((a) => [a.id, a]));
+
+    // Lay out circles for conversation groups that don't have one yet, and
+    // drop placements for groups that ended or changed membership.
+    {
+      const liveGroupIds = new Set(conversationGroups.map((group) => group.id));
+      for (const groupId of placedConversationGroupIdsRef.current) {
+        if (!liveGroupIds.has(groupId)) {
+          placedConversationGroupIdsRef.current.delete(groupId);
+        }
+      }
+      for (const [agentId, slot] of conversationSlotByAgentIdRef.current) {
+        if (!liveGroupIds.has(slot.groupId)) {
+          conversationSlotByAgentIdRef.current.delete(agentId);
+        }
+      }
+      for (const group of conversationGroups) {
+        if (placedConversationGroupIdsRef.current.has(group.id)) continue;
+        const participants = group.participantIds
+          .map((agentId) => {
+            const current = currentMap.get(agentId);
+            return current
+              ? { id: agentId, x: current.x, y: current.y }
+              : null;
+          })
+          .filter((entry): entry is { id: string; x: number; y: number } =>
+            Boolean(entry),
+          );
+        if (participants.length < 2) continue;
+        const grid = getNavGrid();
+        const slots = computeConversationSlots({
+          participants,
+          isFree: (x, y) => isNavPointFree(grid, x, y),
+        });
+        for (const [agentId, slot] of slots) {
+          conversationSlotByAgentIdRef.current.set(agentId, {
+            ...slot,
+            groupId: group.id,
+          });
+        }
+        placedConversationGroupIdsRef.current.add(group.id);
+      }
+    }
+
     const next: RenderAgent[] = [];
 
     agents.forEach((agent, idx) => {
@@ -1108,9 +1192,31 @@ function useAgentTick(
             ? "working"
             : "idle";
 
+      const conversationMembership = conversationMembershipByAgentId.get(
+        agent.id,
+      );
+      const conversationSlot = conversationMembership
+        ? conversationSlotByAgentIdRef.current.get(agent.id)
+        : undefined;
+
       let ns: Partial<RenderAgent> = {};
       if (existing) {
         ns = { ...existing };
+        if (!conversationMembership && existing.conversationGroupId) {
+          ns.conversationGroupId = undefined;
+          ns.conversationTargetX = undefined;
+          ns.conversationTargetY = undefined;
+          ns.conversationFacing = undefined;
+          ns.conversationSeatIndex = undefined;
+          ns.conversationSize = undefined;
+          ns.conversationReplanAtMs = undefined;
+          ns.walkSpeed =
+            existing.conversationPreviousWalkSpeed ?? existing.walkSpeed;
+          ns.conversationPreviousWalkSpeed = undefined;
+          if (existing.interactionTarget === "conversation") {
+            ns.interactionTarget = undefined;
+          }
+        }
         if (explicitMeetingHold && meetingTarget) {
           ns.pingPongUntil = undefined;
           ns.pingPongTargetX = undefined;
@@ -1151,6 +1257,63 @@ function useAgentTick(
               ? "sitting"
               : "walking";
           ns.facing = meetingTarget.facing;
+        } else if (conversationMembership && conversationSlot) {
+          // Agents talking between themselves gather into a circle. Standup
+          // outranks a huddle; a huddle outranks room holds and desk work.
+          ns.pingPongUntil = undefined;
+          ns.pingPongTargetX = undefined;
+          ns.pingPongTargetY = undefined;
+          ns.pingPongFacing = undefined;
+          ns.pingPongPartnerId = undefined;
+          ns.pingPongTableUid = undefined;
+          ns.pingPongSide = undefined;
+          ns.walkSpeed =
+            existing.pingPongPreviousWalkSpeed ?? existing.walkSpeed;
+          ns.pingPongPreviousWalkSpeed = undefined;
+          ns.interactionTarget = "conversation";
+          ns.conversationGroupId = conversationSlot.groupId;
+          ns.conversationTargetX = conversationSlot.x;
+          ns.conversationTargetY = conversationSlot.y;
+          ns.conversationFacing = conversationSlot.facing;
+          ns.conversationSeatIndex = conversationSlot.seatIndex;
+          ns.conversationSize = conversationMembership.size;
+          ns.conversationPreviousWalkSpeed =
+            existing.conversationPreviousWalkSpeed ?? existing.walkSpeed;
+          ns.walkSpeed = Math.max(
+            ns.walkSpeed ?? WALK_SPEED,
+            CONVERSATION_APPROACH_SPEED,
+          );
+          ns.phoneBoothStage = undefined;
+          ns.serverRoomStage = undefined;
+          ns.gymStage = undefined;
+          ns.qaLabStage = undefined;
+          ns.qaLabStationType = undefined;
+          ns.workoutStyle = undefined;
+          const targetChanged =
+            existing.targetX !== conversationSlot.x ||
+            existing.targetY !== conversationSlot.y ||
+            existing.conversationGroupId !== conversationSlot.groupId;
+          ns.targetX = conversationSlot.x;
+          ns.targetY = conversationSlot.y;
+          const arrivedAtCircle =
+            Math.hypot(
+              existing.x - conversationSlot.x,
+              existing.y - conversationSlot.y,
+            ) < 15;
+          if (targetChanged) {
+            ns.path = planPath(
+              existing.x,
+              existing.y,
+              conversationSlot.x,
+              conversationSlot.y,
+            );
+            ns.state = arrivedAtCircle ? "standing" : "walking";
+          } else if (arrivedAtCircle) {
+            ns.state = "standing";
+          }
+          // Not arrived and target unchanged: the tick owns movement; forcing
+          // "walking" here would flap agents whose slot is briefly unreachable.
+          if (arrivedAtCircle) ns.facing = conversationSlot.facing;
         } else if (explicitGymHold) {
           const gymRoute = resolveGymRoute(
             existing.x,
@@ -1741,9 +1904,12 @@ function useAgentTick(
   }, [
     agents,
     assignedDeskIndexByAgentId,
+    conversationGroups,
+    conversationMembershipByAgentId,
     deskHoldByAgentId,
     deskLocations,
     furnitureRef,
+    getNavGrid,
     gymHoldByAgentId,
     gymWorkoutLocations,
     smsBoothHoldByAgentId,
@@ -1854,6 +2020,77 @@ function useAgentTick(
           frame: agent.frame + 1,
         };
       }
+      // Conversation huddle upkeep. Liveness comes from the expiry ref so an
+      // ongoing chat keeps the circle without any React re-render.
+      const conversationLive =
+        agent.conversationGroupId !== undefined &&
+        (conversationExpiryRef?.current?.get(agent.conversationGroupId) ?? 0) >
+          now;
+      if (agent.conversationGroupId !== undefined && !conversationLive) {
+        return {
+          ...agent,
+          conversationGroupId: undefined,
+          conversationTargetX: undefined,
+          conversationTargetY: undefined,
+          conversationFacing: undefined,
+          conversationSeatIndex: undefined,
+          conversationSize: undefined,
+          conversationReplanAtMs: undefined,
+          walkSpeed: agent.conversationPreviousWalkSpeed ?? agent.walkSpeed,
+          conversationPreviousWalkSpeed: undefined,
+          interactionTarget:
+            agent.interactionTarget === "conversation"
+              ? undefined
+              : agent.interactionTarget,
+          bumpTalkUntil: undefined,
+          targetX: agent.x,
+          targetY: agent.y,
+          path: [],
+          state: "standing" as const,
+          frame: agent.frame + 1,
+        };
+      }
+      // A huddle must not dissolve while its members are still walking over —
+      // on slow machines the walk can outlast the speech window. Extend the
+      // group's life in small slices; the refresh loop enforces the hard cap.
+      if (
+        conversationLive &&
+        agent.conversationGroupId !== undefined &&
+        agent.state === "walking"
+      ) {
+        const expiryMap = conversationExpiryRef?.current;
+        const current = expiryMap?.get(agent.conversationGroupId) ?? 0;
+        if (expiryMap && current < now + CONVERSATION_EN_ROUTE_GRACE_MS) {
+          expiryMap.set(
+            agent.conversationGroupId,
+            now + CONVERSATION_EN_ROUTE_GRACE_MS,
+          );
+        }
+      }
+      // Collision escapes and idle wander can overwrite the walk target;
+      // steer the agent back to its circle slot.
+      if (
+        conversationLive &&
+        agent.conversationTargetX !== undefined &&
+        agent.conversationTargetY !== undefined &&
+        (agent.targetX !== agent.conversationTargetX ||
+          agent.targetY !== agent.conversationTargetY)
+      ) {
+        return {
+          ...agent,
+          targetX: agent.conversationTargetX,
+          targetY: agent.conversationTargetY,
+          path: astar(
+            agent.x,
+            agent.y,
+            agent.conversationTargetX,
+            agent.conversationTargetY,
+            grid,
+          ),
+          state: "walking" as const,
+          frame: agent.frame + 1,
+        };
+      }
       const baseSpeed = agent.walkSpeed ?? WALK_SPEED;
       const speed =
         agent.status === "working" && agent.state !== "sitting"
@@ -1873,6 +2110,7 @@ function useAgentTick(
         ny = agent.y,
         nf = agent.facing,
         npath = path;
+      let conversationTalkPulse = false;
 
       if (dist > speed) {
         nx = agent.x + (dx / dist) * speed;
@@ -1913,6 +2151,48 @@ function useAgentTick(
             ny = agent.pingPongTargetY ?? ny;
             nf = agent.pingPongFacing ?? nf;
             ns = "standing";
+          } else if (conversationLive && agent.conversationTargetX !== undefined) {
+            const slotY = agent.conversationTargetY ?? ny;
+            const distToSlot = Math.hypot(
+              agent.conversationTargetX - nx,
+              slotY - ny,
+            );
+            if (distToSlot > 15 && (agent.conversationReplanAtMs ?? 0) <= now) {
+              // Path exhausted away from the slot (blocked route, earlier
+              // detour): retry occasionally instead of standing stranded.
+              // When A* finds no route (nav-grid pocket), beeline — a brief
+              // clip beats a participant who never joins the huddle.
+              const planned = astar(
+                nx,
+                ny,
+                agent.conversationTargetX,
+                slotY,
+                grid,
+              );
+              return {
+                ...agent,
+                x: nx,
+                y: ny,
+                conversationReplanAtMs: now + 1_500,
+                targetX: agent.conversationTargetX,
+                targetY: slotY,
+                path:
+                  planned.length > 0
+                    ? planned
+                    : [{ x: agent.conversationTargetX, y: slotY }],
+                state: "walking" as const,
+                frame: agent.frame + 1,
+              };
+            }
+            // Standing in the huddle: face the centre and take talking turns
+            // so the chatter bubble hops around the circle.
+            nf = agent.conversationFacing ?? nf;
+            ns = "standing";
+            conversationTalkPulse = conversationTalkTurn(
+              now,
+              agent.conversationSeatIndex ?? 0,
+              agent.conversationSize ?? 2,
+            );
           } else if (agent.status === "working") {
             if (
               agent.interactionTarget === "sms_booth" &&
@@ -2181,6 +2461,9 @@ function useAgentTick(
         facing: nf,
         state: ns,
         path: npath,
+        ...(conversationTalkPulse
+          ? { bumpTalkUntil: now + CONVERSATION_TALK_PULSE_MS }
+          : {}),
         frame: agent.frame + 1,
       };
     });
@@ -2618,6 +2901,151 @@ export function RetroOffice3D({
   const suppressSceneSpeechBubbles =
     standupMeeting?.phase === "gathering" ||
     standupMeeting?.phase === "in_progress";
+
+  // --- Agent-to-agent conversation huddles -------------------------------
+  // Speech samples (completed replies + live streaming) feed the grouping;
+  // when two or more agents talk in the same window they gather in a circle.
+  const conversationSamplesRef = useRef<Map<string, ConversationSpeechSample>>(
+    new Map(),
+  );
+  const conversationExpiryRef = useRef<Map<string, number>>(new Map());
+  const conversationKnownGroupsRef = useRef<
+    Map<string, { group: ConversationGroup; formedAtMs: number }>
+  >(new Map());
+  const conversationSignatureRef = useRef("");
+  const [conversationGroups, setConversationGroups] = useState<
+    ConversationGroup[]
+  >([]);
+  const conversationAgentNamesById = useMemo(() => {
+    const names: Record<string, string> = {};
+    for (const agent of agents) names[agent.id] = agent.name;
+    return names;
+  }, [agents]);
+
+  useEffect(() => {
+    const latest = feedEvents[0];
+    if (!latest || latest.kind !== "reply") return;
+    const text = latest.text.trim();
+    if (!text) return;
+    conversationSamplesRef.current.set(latest.id, {
+      agentId: latest.id,
+      text,
+      atMs: Date.now(),
+    });
+  }, [feedEvents]);
+
+  useEffect(() => {
+    const now = Date.now();
+    for (const [agentId, text] of Object.entries(
+      streamingTextByAgentId ?? {},
+    )) {
+      if (typeof text === "string" && text.trim()) {
+        conversationSamplesRef.current.set(agentId, {
+          agentId,
+          text: text.trim(),
+          atMs: now,
+        });
+      }
+    }
+  }, [streamingTextByAgentId]);
+
+  useEffect(() => {
+    const refresh = () => {
+      const now = Date.now();
+      const derived = deriveConversationGroups({
+        samples: [...conversationSamplesRef.current.values()],
+        agentNamesById: conversationAgentNamesById,
+        nowMs: now,
+        suppressed: suppressSceneSpeechBubbles,
+      });
+      const known = conversationKnownGroupsRef.current;
+      if (suppressSceneSpeechBubbles) known.clear();
+      for (const group of derived) {
+        const entry = known.get(group.id);
+        if (entry) {
+          entry.group = group;
+          continue;
+        }
+        // A grown conversation supersedes the smaller huddle it absorbed.
+        for (const [otherId, other] of known) {
+          if (
+            otherId !== group.id &&
+            other.group.participantIds.every((id) =>
+              group.participantIds.includes(id),
+            )
+          ) {
+            known.delete(otherId);
+          }
+        }
+        known.set(group.id, { group, formedAtMs: now });
+      }
+      // A huddle lives until its speech window lapses, but never less than the
+      // minimum lifetime — otherwise a one-shot mention dissolves the circle
+      // while distant participants are still walking over. The movement tick
+      // extends the expiry while members are en route (merge with max), and a
+      // hard ceiling keeps an unreachable slot from pinning a huddle forever.
+      const expiry = conversationExpiryRef.current;
+      const groups: ConversationGroup[] = [];
+      for (const [groupId, entry] of known) {
+        const hardCapAt = entry.formedAtMs + CONVERSATION_MAX_LIFETIME_MS;
+        const keepAliveUntil = Math.min(
+          Math.max(
+            entry.group.lastActivityMs + CONVERSATION_WINDOW_MS,
+            entry.formedAtMs + CONVERSATION_MIN_LIFETIME_MS,
+            expiry.get(groupId) ?? 0,
+          ),
+          hardCapAt,
+        );
+        if (keepAliveUntil <= now) {
+          known.delete(groupId);
+          expiry.delete(groupId);
+          continue;
+        }
+        groups.push(entry.group);
+        expiry.set(groupId, keepAliveUntil);
+      }
+      for (const groupId of expiry.keys()) {
+        if (!known.has(groupId)) expiry.delete(groupId);
+      }
+      groups.sort((a, b) => a.id.localeCompare(b.id));
+      // Only re-render (and re-run the movement effect) when membership
+      // changes; liveness flows through the expiry ref every second.
+      const signature = groups.map((group) => group.id).join("|");
+      if (signature !== conversationSignatureRef.current) {
+        conversationSignatureRef.current = signature;
+        setConversationGroups(groups);
+      }
+    };
+    refresh();
+    const timer = window.setInterval(refresh, 1_000);
+    return () => window.clearInterval(timer);
+  }, [
+    conversationAgentNamesById,
+    feedEvents,
+    streamingTextByAgentId,
+    suppressSceneSpeechBubbles,
+  ]);
+
+  // Soft murmur while any huddle is active; browsers require a user gesture
+  // before audio can start, so unlock on the first pointer interaction.
+  const chatterAudioRef = useRef<ConversationChatterAudio | null>(null);
+  useEffect(() => {
+    if (!chatterAudioRef.current) {
+      chatterAudioRef.current = new ConversationChatterAudio();
+    }
+    chatterAudioRef.current.setActiveConversationCount(
+      conversationGroups.length,
+    );
+  }, [conversationGroups]);
+  useEffect(() => {
+    const unlock = () => chatterAudioRef.current?.unlock();
+    window.addEventListener("pointerdown", unlock);
+    return () => {
+      window.removeEventListener("pointerdown", unlock);
+      chatterAudioRef.current?.dispose();
+      chatterAudioRef.current = null;
+    };
+  }, []);
   // New Idea 2: camera preset target ref (shared into Canvas).
   const cameraPresetRef = useRef<{
     pos: [number, number, number];
@@ -2897,6 +3325,8 @@ export function RetroOffice3D({
     resolvedQaHoldByAgentId,
     resolvedGithubReviewByAgentId,
     standupMeeting,
+    conversationGroups,
+    conversationExpiryRef,
   );
   useEffect(() => {
     const syncRenderAgentUi = () => {
@@ -2905,6 +3335,7 @@ export function RetroOffice3D({
         next[agent.id] = {
           state: agent.state,
           status: agent.status,
+          conversationGroupId: agent.conversationGroupId,
         };
       }
       // Keep the previous object when nothing changed so idle frames do not
@@ -2916,7 +3347,12 @@ export function RetroOffice3D({
           for (const id of previousIds) {
             const before = previous[id];
             const after = next[id];
-            if (!after || before.state !== after.state || before.status !== after.status) {
+            if (
+              !after ||
+              before.state !== after.state ||
+              before.status !== after.status ||
+              before.conversationGroupId !== after.conversationGroupId
+            ) {
               identical = false;
               break;
             }
@@ -5200,6 +5636,33 @@ export function RetroOffice3D({
     return () => clearTimeout(timer);
   }, [spotlightAgentId]);
 
+  // Flag huddle participants with a chat mood chip when a conversation forms.
+  useEffect(() => {
+    if (conversationGroups.length === 0) return;
+    const now = Date.now();
+    setMoodByAgentId((prev) => {
+      const next = { ...prev };
+      for (const group of conversationGroups) {
+        for (const agentId of group.participantIds) {
+          next[agentId] = { emoji: "💬", ts: now };
+        }
+      }
+      return next;
+    });
+    const timer = window.setTimeout(() => {
+      setMoodByAgentId((prev) => {
+        const next = { ...prev };
+        for (const group of conversationGroups) {
+          for (const agentId of group.participantIds) {
+            if (next[agentId]?.emoji === "💬") delete next[agentId];
+          }
+        }
+        return next;
+      });
+    }, 4_000);
+    return () => window.clearTimeout(timer);
+  }, [conversationGroups]);
+
   const lastOfficeCenterSignalRef = useRef(officeCenterSignal);
 
   useEffect(() => {
@@ -5970,7 +6433,20 @@ export function RetroOffice3D({
 
       {/* Agent roster — compact top summary with overflow panel. */}
       {!readOnly && !immersiveOverlayActive ? (
-        <div className="absolute top-10 left-1/2 z-20 -translate-x-1/2">
+        <div
+          className="absolute top-10 left-1/2 z-20 -translate-x-1/2"
+          data-conversation-groups={conversationGroups
+            .map((group) => group.id)
+            .join("|")}
+          data-conversation-standing={Object.entries(renderAgentUiById)
+            .filter(
+              ([, snapshot]) =>
+                snapshot.conversationGroupId && snapshot.state === "standing",
+            )
+            .map(([agentId]) => agentId)
+            .sort()
+            .join("|")}
+        >
           <div className="flex items-center gap-2 rounded-full border border-amber-900/25 bg-[#1c1610]/92 px-2 py-2 shadow-lg backdrop-blur-sm">
             <div className="flex items-center -space-x-1.5">
               {compactRosterAgents.map((agent) => {

--- a/src/features/retro-office/core/constants.ts
+++ b/src/features/retro-office/core/constants.ts
@@ -42,5 +42,9 @@ export const WORLD_W = CANVAS_W * SCALE;
 export const WORLD_H = CANVAS_H * SCALE;
 export const PING_PONG_SESSION_MS = 60_000;
 export const PING_PONG_APPROACH_SPEED = WALK_SPEED * 1.8;
+// Conversations are timeboxed by the speech window, so distant participants
+// hurry over; at plain WALK_SPEED an agent crossing the office would arrive
+// after the chat already ended.
+export const CONVERSATION_APPROACH_SPEED = WALK_SPEED * 2.2;
 export const PING_PONG_BALL_RADIUS = 0.055;
 export const PING_PONG_TABLE_SURFACE_Y = 0.465;

--- a/src/features/retro-office/core/conversations.ts
+++ b/src/features/retro-office/core/conversations.ts
@@ -1,0 +1,324 @@
+import { CANVAS_H, CANVAS_W } from "@/features/retro-office/core/constants";
+
+/**
+ * Agent-to-agent conversation detection and huddle placement.
+ *
+ * When Hermes bots talk between themselves, several agents produce speech in
+ * the same time window (and usually address each other by name). This module
+ * turns that raw speech activity into conversation groups, and lays each group
+ * out as a circle of standing slots so the participants visibly gather and face
+ * one another. Everything here is pure so the grouping and geometry are
+ * testable without a scene.
+ */
+
+export interface ConversationSpeechSample {
+  agentId: string;
+  text: string;
+  atMs: number;
+}
+
+export interface ConversationGroup {
+  /** Sorted participant ids joined with "+" — stable across recomputes. */
+  id: string;
+  participantIds: string[];
+  lastActivityMs: number;
+}
+
+export interface ConversationSlot {
+  x: number;
+  y: number;
+  facing: number;
+  seatIndex: number;
+}
+
+/** How long after the last message a conversation is considered alive. */
+export const CONVERSATION_WINDOW_MS = 25_000;
+
+/**
+ * Minimum time a huddle exists once formed. A single mention gives only one
+ * speech sample; without this floor the circle would dissolve while distant
+ * participants are still walking over.
+ */
+export const CONVERSATION_MIN_LIFETIME_MS = 45_000;
+
+/**
+ * While members are still walking to the circle the scene keeps extending the
+ * huddle's life in slices of this size, so slow machines (or long walks) don't
+ * dissolve a conversation before it visibly happens.
+ */
+export const CONVERSATION_EN_ROUTE_GRACE_MS = 12_000;
+
+/** Hard ceiling on a huddle's life from formation, extensions included. */
+export const CONVERSATION_MAX_LIFETIME_MS = 150_000;
+
+/** Arc distance between neighbours on the circle, in canvas units. */
+export const CONVERSATION_SLOT_SPACING = 34;
+
+/** Minimum huddle radius so two agents don't stand nose-to-nose. */
+export const CONVERSATION_MIN_RADIUS = 26;
+
+/** How long one agent "speaks" before the turn passes around the circle. */
+export const CONVERSATION_TALK_TURN_MS = 1_600;
+
+/** Bubble duration for a single talk pulse. */
+export const CONVERSATION_TALK_PULSE_MS = 900;
+
+const FIRST_NAME_MIN_LENGTH = 3;
+
+const escapeRegExp = (value: string) =>
+  value.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+
+const buildNameMatchers = (agentNamesById: Record<string, string>) => {
+  const matchers = new Map<string, RegExp>();
+  for (const [agentId, name] of Object.entries(agentNamesById)) {
+    const firstName = (name ?? "").trim().split(/\s+/)[0] ?? "";
+    if (firstName.length < FIRST_NAME_MIN_LENGTH) continue;
+    matchers.set(agentId, new RegExp(`\\b${escapeRegExp(firstName)}\\b`, "i"));
+  }
+  return matchers;
+};
+
+/** Union-find over mention edges; returns connected components of size >= 2. */
+const connectedComponents = (edges: [string, string][]): string[][] => {
+  const parent = new Map<string, string>();
+  const find = (node: string): string => {
+    let root = node;
+    while (parent.get(root) !== root) root = parent.get(root) ?? root;
+    let cursor = node;
+    while (parent.get(cursor) !== root) {
+      const next = parent.get(cursor) ?? root;
+      parent.set(cursor, root);
+      cursor = next;
+    }
+    return root;
+  };
+  for (const [a, b] of edges) {
+    if (!parent.has(a)) parent.set(a, a);
+    if (!parent.has(b)) parent.set(b, b);
+    const rootA = find(a);
+    const rootB = find(b);
+    if (rootA !== rootB) parent.set(rootA, rootB);
+  }
+  const byRoot = new Map<string, string[]>();
+  for (const node of parent.keys()) {
+    const root = find(node);
+    const bucket = byRoot.get(root);
+    if (bucket) bucket.push(node);
+    else byRoot.set(root, [node]);
+  }
+  return [...byRoot.values()];
+};
+
+/**
+ * Group agents that are talking between themselves.
+ *
+ * Mentions are the strong signal: a speaker naming another agent links the two
+ * (and pulls the named agent over even before it answers). Without mentions,
+ * two or more agents speaking inside the same window are treated as one
+ * water-cooler huddle — there is no addressee metadata to split them further.
+ * Standup meetings already gather everyone, so grouping is suppressed there.
+ */
+export const deriveConversationGroups = (options: {
+  samples: ConversationSpeechSample[];
+  agentNamesById: Record<string, string>;
+  nowMs: number;
+  windowMs?: number;
+  suppressed?: boolean;
+}): ConversationGroup[] => {
+  const {
+    samples,
+    agentNamesById,
+    nowMs,
+    windowMs = CONVERSATION_WINDOW_MS,
+    suppressed = false,
+  } = options;
+  if (suppressed) return [];
+
+  const active = samples.filter(
+    (sample) =>
+      sample.text.trim() !== "" &&
+      nowMs - sample.atMs <= windowMs &&
+      sample.atMs <= nowMs + 1_000 &&
+      agentNamesById[sample.agentId] !== undefined,
+  );
+  if (active.length === 0) return [];
+
+  const lastSpokeAtByAgentId = new Map<string, number>();
+  for (const sample of active) {
+    lastSpokeAtByAgentId.set(
+      sample.agentId,
+      Math.max(lastSpokeAtByAgentId.get(sample.agentId) ?? 0, sample.atMs),
+    );
+  }
+
+  const matchers = buildNameMatchers(agentNamesById);
+  const mentionEdges: [string, string][] = [];
+  for (const sample of active) {
+    for (const [otherId, matcher] of matchers) {
+      if (otherId === sample.agentId) continue;
+      if (matcher.test(sample.text)) mentionEdges.push([sample.agentId, otherId]);
+    }
+  }
+
+  const speakerIds = [...lastSpokeAtByAgentId.keys()];
+  const memberships =
+    mentionEdges.length > 0
+      ? connectedComponents(mentionEdges)
+      : speakerIds.length >= 2
+        ? [speakerIds]
+        : [];
+
+  return memberships
+    .filter((ids) => ids.length >= 2)
+    .map((ids) => {
+      const participantIds = [...ids].sort();
+      const lastActivityMs = participantIds.reduce(
+        (max, id) => Math.max(max, lastSpokeAtByAgentId.get(id) ?? 0),
+        0,
+      );
+      return { id: participantIds.join("+"), participantIds, lastActivityMs };
+    })
+    .sort((a, b) => a.id.localeCompare(b.id));
+};
+
+// Rings of candidate centres, nearest first; the outer rings let a huddle
+// escape a whole blocked furniture cluster rather than just a single desk.
+const CENTER_CANDIDATE_OFFSETS: [number, number][] = [
+  [0, 0],
+  [45, 0],
+  [-45, 0],
+  [0, 45],
+  [0, -45],
+  [70, 70],
+  [-70, 70],
+  [70, -70],
+  [-70, -70],
+  [110, 0],
+  [-110, 0],
+  [0, 110],
+  [0, -110],
+  [150, 0],
+  [-150, 0],
+  [0, 150],
+  [0, -150],
+  [150, 150],
+  [-150, 150],
+  [150, -150],
+  [-150, -150],
+  [210, 0],
+  [-210, 0],
+  [0, 210],
+  [0, -210],
+];
+
+const clamp = (value: number, low: number, high: number) =>
+  Math.min(high, Math.max(low, value));
+
+/**
+ * Lay a conversation group out as a circle of standing slots.
+ *
+ * The circle is centred near the participants' centroid, nudged to the first
+ * candidate spot where every slot is walkable, so huddles don't form inside
+ * desks or walls. Agents are assigned slots in the order of their bearing from
+ * the centre, which keeps walking paths from crossing. Facing uses the scene's
+ * rotation convention (`atan2(dx, dy)` toward the centre).
+ */
+export const computeConversationSlots = (options: {
+  participants: { id: string; x: number; y: number }[];
+  isFree?: (x: number, y: number) => boolean;
+  canvasWidth?: number;
+  canvasHeight?: number;
+}): Map<string, ConversationSlot> => {
+  const {
+    participants,
+    isFree = () => true,
+    canvasWidth = CANVAS_W,
+    canvasHeight = CANVAS_H,
+  } = options;
+  const count = participants.length;
+  const slots = new Map<string, ConversationSlot>();
+  if (count < 2) return slots;
+
+  const margin = 60;
+  const centroidX = clamp(
+    participants.reduce((sum, p) => sum + p.x, 0) / count,
+    margin,
+    canvasWidth - margin,
+  );
+  const centroidY = clamp(
+    participants.reduce((sum, p) => sum + p.y, 0) / count,
+    margin,
+    canvasHeight - margin,
+  );
+  const radius = Math.max(
+    CONVERSATION_MIN_RADIUS,
+    (CONVERSATION_SLOT_SPACING * count) / (2 * Math.PI),
+  );
+
+  const slotPointsAt = (cx: number, cy: number) =>
+    Array.from({ length: count }, (_, index) => {
+      const angle = -Math.PI / 2 + (index * 2 * Math.PI) / count;
+      return {
+        x: cx + radius * Math.cos(angle),
+        y: cy + radius * Math.sin(angle),
+      };
+    });
+
+  // Prefer the first fully free candidate; otherwise take the one with the
+  // most walkable slots so a crowded floor still yields a usable circle.
+  let centerX = centroidX;
+  let centerY = centroidY;
+  let bestFreeCount = -1;
+  for (const [offsetX, offsetY] of CENTER_CANDIDATE_OFFSETS) {
+    const cx = clamp(centroidX + offsetX, margin, canvasWidth - margin);
+    const cy = clamp(centroidY + offsetY, margin, canvasHeight - margin);
+    const points = slotPointsAt(cx, cy);
+    const freeCount =
+      (isFree(cx, cy) ? 1 : 0) +
+      points.reduce((sum, point) => sum + (isFree(point.x, point.y) ? 1 : 0), 0);
+    if (freeCount > bestFreeCount) {
+      bestFreeCount = freeCount;
+      centerX = cx;
+      centerY = cy;
+    }
+    if (freeCount === count + 1) break;
+  }
+
+  const points = slotPointsAt(centerX, centerY);
+  // Hand out slots in bearing order so nobody walks through the circle.
+  const ordered = [...participants].sort((a, b) => {
+    const bearingA = Math.atan2(a.y - centerY, a.x - centerX);
+    const bearingB = Math.atan2(b.y - centerY, b.x - centerX);
+    return bearingA - bearingB || a.id.localeCompare(b.id);
+  });
+  const pointsByBearing = [...points].sort((a, b) => {
+    const bearingA = Math.atan2(a.y - centerY, a.x - centerX);
+    const bearingB = Math.atan2(b.y - centerY, b.x - centerX);
+    return bearingA - bearingB;
+  });
+
+  ordered.forEach((participant, index) => {
+    const point = pointsByBearing[index] ?? points[index];
+    slots.set(participant.id, {
+      x: Math.round(point.x),
+      y: Math.round(point.y),
+      facing: Math.atan2(centerX - point.x, centerY - point.y),
+      seatIndex: index,
+    });
+  });
+  return slots;
+};
+
+/**
+ * Whose turn it is to "speak" in the huddle — rotates around the circle so the
+ * chatter bubbles alternate instead of everyone talking at once.
+ */
+export const conversationTalkTurn = (
+  nowMs: number,
+  seatIndex: number,
+  groupSize: number,
+  turnMs: number = CONVERSATION_TALK_TURN_MS,
+): boolean => {
+  if (groupSize <= 0) return false;
+  return Math.floor(nowMs / turnMs) % groupSize === seatIndex % groupSize;
+};

--- a/src/features/retro-office/core/navigation.ts
+++ b/src/features/retro-office/core/navigation.ts
@@ -115,6 +115,16 @@ export function buildNavGrid(furniture: FurnitureItem[]): NavGrid {
   return grid;
 }
 
+/** True when the nav cell containing (x, y) is inside the grid and unblocked. */
+export const isNavPointFree = (grid: NavGrid, x: number, y: number): boolean => {
+  const column = Math.floor(x / GRID_CELL);
+  const row = Math.floor(y / GRID_CELL);
+  if (column < 0 || column >= GRID_COLS || row < 0 || row >= GRID_ROWS) {
+    return false;
+  }
+  return grid[row * GRID_COLS + column] === 0;
+};
+
 export function astar(
   sx: number,
   sy: number,

--- a/src/features/retro-office/core/types.ts
+++ b/src/features/retro-office/core/types.ts
@@ -52,6 +52,14 @@ export type RenderAgent = SceneActor & {
   pingPongTableUid?: string;
   pingPongSide?: 0 | 1;
   pingPongPreviousWalkSpeed?: number;
+  conversationGroupId?: string;
+  conversationTargetX?: number;
+  conversationTargetY?: number;
+  conversationFacing?: number;
+  conversationSeatIndex?: number;
+  conversationSize?: number;
+  conversationPreviousWalkSpeed?: number;
+  conversationReplanAtMs?: number;
   interactionTarget?: OfficeInteractionTargetId;
   smsBoothStage?: "door_outer" | "door_inner" | "typing";
   phoneBoothStage?: "door_outer" | "door_inner" | "receiver";

--- a/src/features/retro-office/objects/agents.tsx
+++ b/src/features/retro-office/objects/agents.tsx
@@ -15,6 +15,7 @@ import type {
 import { AgentModelProps } from "@/features/retro-office/objects/types";
 
 const MAX_NAMEPLATE_TEXT_LENGTH = 10;
+const MAX_SUBTITLE_TEXT_LENGTH = 20;
 const MAX_SPEECH_BUBBLE_TEXT_LENGTH = 180;
 const MAX_SPEECH_BUBBLE_LINES = 4;
 
@@ -24,6 +25,30 @@ const formatAgentNameplateText = (value: string): string => {
   if (normalized.length <= MAX_NAMEPLATE_TEXT_LENGTH) return normalized;
   const [firstName] = normalized.split(" ");
   return firstName || normalized;
+};
+
+/**
+ * Compress a role description to one short nameplate line.
+ *
+ * Agent roles arrive as full sentences ("technical planner and business
+ * systems analyst for Smartways. Converts Jira tickets into…"); rendered raw
+ * they wrap into a wall of text above every agent. Keep the first clause,
+ * clamped at a word boundary, so the plate stays a single line.
+ */
+export const formatAgentSubtitleText = (value: string): string => {
+  const normalized = value.replace(/\s+/g, " ").trim();
+  if (!normalized) return "";
+  const clause =
+    normalized.split(/(?:\.\s+|\s+[—–]\s+)/)[0]?.replace(/[.;\s]+$/, "") ||
+    normalized;
+  if (clause.length <= MAX_SUBTITLE_TEXT_LENGTH) return clause;
+  const cut = clause.slice(0, MAX_SUBTITLE_TEXT_LENGTH);
+  const lastSpace = cut.lastIndexOf(" ");
+  const head = (lastSpace > 8 ? cut.slice(0, lastSpace) : cut).replace(
+    /[\s,;:]+$/,
+    "",
+  );
+  return `${head}…`;
 };
 
 const flattenSpeechBubbleMarkdown = (value: string) =>
@@ -674,7 +699,8 @@ export const AgentModel = memo(function AgentModel({
     : "transparent";
   const speechBubbleBorderInset = activeSpeechBubble ? 0.03 : 0;
   const nameplateText = name ? formatAgentNameplateText(name) : "";
-  const subtitleText = typeof subtitle === "string" ? subtitle.trim() : "";
+  const subtitleText =
+    typeof subtitle === "string" ? formatAgentSubtitleText(subtitle) : "";
   const nameplateFontSize =
     nameplateText.length > 9 ? 0.118 : nameplateText.length > 7 ? 0.13 : 0.144;
 
@@ -1149,7 +1175,7 @@ export const AgentModel = memo(function AgentModel({
           {subtitleText ? (
             <Text
               position={[-0.02, -0.085, 0.001]}
-              fontSize={0.082}
+              fontSize={0.062}
               color="#8ab4ff"
               anchorX="center"
               anchorY="middle"

--- a/src/features/retro-office/systems/NavigationSystem.tsx
+++ b/src/features/retro-office/systems/NavigationSystem.tsx
@@ -44,6 +44,11 @@ export function applyAgentCollisionBumps({
       continue;
     if (moved[i].pingPongUntil !== undefined && moved[i].state !== "walking")
       continue;
+    // Conversation members are exempt while walking to and standing in the
+    // huddle: circle slots are spaced wider than the bump distance, and a
+    // bump's escape-reroute would trap approaching members in a loop of
+    // freeze, escape, and walk-back at the circle's edge.
+    if (moved[i].conversationGroupId !== undefined) continue;
     if (moved[i].bumpedUntil !== undefined) continue;
     if ((moved[i].collisionCooldownUntil ?? 0) > now) continue;
     let sx = 0,

--- a/src/features/retro-office/systems/conversationChatterAudio.ts
+++ b/src/features/retro-office/systems/conversationChatterAudio.ts
@@ -1,0 +1,136 @@
+/**
+ * Soft synthesized murmur played while agents huddle in a conversation.
+ *
+ * No audio assets: each "utterance" is one or two short filtered triangle
+ * blips with randomized pitch, so a circle of talking agents sounds like
+ * distant chatter. Browsers keep an AudioContext suspended until a user
+ * gesture, so the scene calls `unlock()` from a pointer handler; until then
+ * scheduling runs silently and simply produces no sound.
+ */
+
+export interface ChatterBlipPlan {
+  delayMs: number;
+  frequencyHz: number;
+  durationMs: number;
+  gain: number;
+  syllables: 1 | 2;
+}
+
+/** Randomized-but-bounded plan; extracted for tests. */
+export const planChatterBlip = (random: () => number = Math.random): ChatterBlipPlan => ({
+  delayMs: 260 + random() * 640,
+  frequencyHz: 165 + random() * 190,
+  durationMs: 70 + random() * 90,
+  gain: 0.024 + random() * 0.02,
+  syllables: random() < 0.4 ? 2 : 1,
+});
+
+export class ConversationChatterAudio {
+  private context: AudioContext | null = null;
+  private timer: ReturnType<typeof setTimeout> | null = null;
+  private activeConversationCount = 0;
+  private disposed = false;
+
+  setActiveConversationCount(count: number) {
+    if (this.disposed) return;
+    const next = Math.max(0, count);
+    const wasIdle = this.activeConversationCount === 0;
+    this.activeConversationCount = next;
+    if (next > 0 && wasIdle && this.timer === null) this.scheduleNext();
+    if (next === 0) this.stopTimer();
+  }
+
+  /** Call from a user-gesture handler so the browser lets audio start. */
+  unlock() {
+    if (this.disposed) return;
+    const context = this.ensureContext();
+    if (context && context.state === "suspended") {
+      void context.resume().catch(() => {});
+    }
+  }
+
+  dispose() {
+    this.disposed = true;
+    this.stopTimer();
+    if (this.context && this.context.state !== "closed") {
+      void this.context.close().catch(() => {});
+    }
+    this.context = null;
+  }
+
+  private ensureContext(): AudioContext | null {
+    if (this.context) return this.context;
+    if (typeof window === "undefined") return null;
+    const Ctor =
+      window.AudioContext ??
+      (window as { webkitAudioContext?: typeof AudioContext }).webkitAudioContext;
+    if (!Ctor) return null;
+    try {
+      this.context = new Ctor();
+    } catch {
+      this.context = null;
+    }
+    return this.context;
+  }
+
+  private stopTimer() {
+    if (this.timer !== null) {
+      clearTimeout(this.timer);
+      this.timer = null;
+    }
+  }
+
+  private scheduleNext() {
+    if (this.disposed || this.activeConversationCount === 0) {
+      this.timer = null;
+      return;
+    }
+    const plan = planChatterBlip();
+    // More simultaneous conversations chatter a bit more often.
+    const delay = plan.delayMs / Math.sqrt(this.activeConversationCount);
+    this.timer = setTimeout(() => {
+      this.playBlip(plan);
+      this.scheduleNext();
+    }, delay);
+  }
+
+  private playBlip(plan: ChatterBlipPlan) {
+    if (this.disposed || this.activeConversationCount === 0) return;
+    const context = this.ensureContext();
+    if (!context || context.state !== "running") return;
+
+    const startAt = context.currentTime + 0.01;
+    const playSyllable = (at: number, frequency: number) => {
+      const oscillator = context.createOscillator();
+      const gainNode = context.createGain();
+      const filter = context.createBiquadFilter();
+      const duration = plan.durationMs / 1000;
+
+      oscillator.type = "triangle";
+      oscillator.frequency.setValueAtTime(frequency, at);
+      oscillator.frequency.exponentialRampToValueAtTime(
+        Math.max(60, frequency * 0.78),
+        at + duration,
+      );
+      filter.type = "lowpass";
+      filter.frequency.setValueAtTime(900, at);
+      gainNode.gain.setValueAtTime(0.0001, at);
+      gainNode.gain.exponentialRampToValueAtTime(plan.gain, at + duration * 0.25);
+      gainNode.gain.exponentialRampToValueAtTime(0.0001, at + duration);
+
+      oscillator.connect(filter);
+      filter.connect(gainNode);
+      gainNode.connect(context.destination);
+      oscillator.start(at);
+      oscillator.stop(at + duration + 0.02);
+    };
+
+    playSyllable(startAt, plan.frequencyHz);
+    if (plan.syllables === 2) {
+      playSyllable(
+        startAt + plan.durationMs / 1000 + 0.05,
+        plan.frequencyHz * 1.22,
+      );
+    }
+  }
+}

--- a/src/lib/cron/types.ts
+++ b/src/lib/cron/types.ts
@@ -106,7 +106,8 @@ const formatEveryMs = (everyMs: number) => {
   return `${everyMs}ms`;
 };
 
-export const formatCronSchedule = (schedule: CronSchedule) => {
+export const formatCronSchedule = (schedule: CronSchedule | null | undefined) => {
+  if (!schedule) return "";
   if (schedule.kind === "every") {
     return `Every ${formatEveryMs(schedule.everyMs)}`;
   }
@@ -118,9 +119,12 @@ export const formatCronSchedule = (schedule: CronSchedule) => {
   return `At: ${atDate.toLocaleString()}`;
 };
 
-export const formatCronPayload = (payload: CronPayload) => {
-  if (payload.kind === "systemEvent") return payload.text;
-  return payload.message;
+export const formatCronPayload = (payload: CronPayload | null | undefined) => {
+  // A gateway can hand back a job row without a payload; one malformed row
+  // must not take down every view that renders a job.
+  if (!payload) return "";
+  if (payload.kind === "systemEvent") return payload.text ?? "";
+  return payload.message ?? "";
 };
 
 export const formatCronJobDisplay = (job: CronJobSummary) => {

--- a/src/lib/gateway/GatewayClient.ts
+++ b/src/lib/gateway/GatewayClient.ts
@@ -172,6 +172,7 @@ const normalizeLocalGatewayDefaults = (value: unknown): StudioGatewaySettings | 
   const adapterType =
     raw.adapterType === "demo" ||
     raw.adapterType === "hermes" ||
+    raw.adapterType === "hermes-agent" ||
     raw.adapterType === "local" ||
     raw.adapterType === "hermes3d" ||
     raw.adapterType === "custom"
@@ -197,7 +198,14 @@ const normalizeGatewayProfilesPublic = (
   if (!value || typeof value !== "object") return undefined;
   const raw = value as Partial<Record<StudioGatewayAdapterType, StudioGatewayProfilePublic>>;
   const profiles: Partial<Record<StudioGatewayAdapterType, { url: string; token: string }>> = {};
-  for (const adapterType of ["hermes", "demo", "local", "hermes3d", "custom"] as const) {
+  for (const adapterType of [
+    "hermes",
+    "hermes-agent",
+    "demo",
+    "local",
+    "hermes3d",
+    "custom",
+  ] as const) {
     const profile = normalizeGatewayProfilePublic(raw[adapterType]);
     if (profile) {
       profiles[adapterType] = profile;

--- a/src/lib/office/places.ts
+++ b/src/lib/office/places.ts
@@ -7,6 +7,7 @@ export const OFFICE_INTERACTION_TARGETS = [
   "qa_lab",
   "sms_booth",
   "phone_booth",
+  "conversation",
 ] as const;
 
 export type OfficeInteractionTargetId =

--- a/tests/unit/hermesAgentBridge.test.ts
+++ b/tests/unit/hermesAgentBridge.test.ts
@@ -129,6 +129,292 @@ describe("buildJsonRpcUrl", () => {
   });
 });
 
+describe("loopback Host fallback", () => {
+  /**
+   * Stands in for a loopback-bound hermes-agent behind Tailscale Serve, which
+   * forwards the client's Host verbatim: the tailnet name is refused with 4403
+   * and only a loopback Host gets through.
+   */
+  const startHostStrictAgent = async () => {
+    const wss = new WebSocketServer({ port: 0 });
+    servers.push(wss);
+    await new Promise<void>((resolve) => wss.on("listening", () => resolve()));
+
+    const hostsSeen: string[] = [];
+    wss.on("connection", (ws: WsSocket, req) => {
+      const host = String(req.headers.host ?? "");
+      hostsSeen.push(host);
+      const hostOnly = host.split(":")[0].toLowerCase();
+      if (!["localhost", "127.0.0.1", "::1"].includes(hostOnly)) {
+        ws.close(4403, "host_mismatch");
+        return;
+      }
+      ws.send(JSON.stringify({ jsonrpc: "2.0", method: "event", params: { type: "gateway.ready", payload: {} } }));
+    });
+
+    const { port } = wss.address() as AddressInfo;
+    return { port, hostsSeen };
+  };
+
+  it("retries with a loopback Host when the backend refuses the forwarded one", async () => {
+    const { port, hostsSeen } = await startHostStrictAgent();
+    const { HermesAgentJsonRpcClient } = await import("../../server/hermes-agent/jsonrpc-client");
+
+    // 127.0.0.1 resolves, but the Host header carries a name the backend rejects.
+    const client = new HermesAgentJsonRpcClient({ url: `ws://127.0.0.1:${port}`, token: "t" });
+    client.hostHeader = "luke-hermes.taildb786a.ts.net";
+    client.loopbackHostFallback = true;
+
+    const ready = new Promise<void>((resolve, reject) => {
+      client.on("ready", () => resolve());
+      client.on("close", (code: number) => reject(new Error(`closed ${code}`)));
+      setTimeout(() => reject(new Error("never became ready")), 5000);
+    });
+    client.connect();
+    await ready;
+
+    expect(hostsSeen[0]).toBe("luke-hermes.taildb786a.ts.net");
+    expect(hostsSeen[1]).toBe("localhost");
+    expect(client.usedLoopbackHost).toBe(true);
+    client.terminate();
+  });
+
+  it("retries when the upgrade is refused with HTTP 403 before accepting", async () => {
+    // How a loopback-bound hermes-agent actually refuses a foreign Host on
+    // /api/ws: the handshake is rejected outright rather than accepted-then-closed.
+    const hostsSeen: string[] = [];
+    const wss = new WebSocketServer({
+      port: 0,
+      verifyClient: ({ req }, done) => {
+        const host = String(req.headers.host ?? "");
+        hostsSeen.push(host);
+        done(host.split(":")[0].toLowerCase() === "localhost", 403);
+      },
+    });
+    servers.push(wss);
+    await new Promise<void>((resolve) => wss.on("listening", () => resolve()));
+    wss.on("connection", (ws: WsSocket) => {
+      ws.send(JSON.stringify({ jsonrpc: "2.0", method: "event", params: { type: "gateway.ready", payload: {} } }));
+    });
+    const { port } = wss.address() as AddressInfo;
+
+    const { HermesAgentJsonRpcClient } = await import("../../server/hermes-agent/jsonrpc-client");
+    const client = new HermesAgentJsonRpcClient({ url: `ws://127.0.0.1:${port}`, token: "t" });
+    client.hostHeader = "luke-hermes.taildb786a.ts.net";
+
+    const ready = new Promise<void>((resolve, reject) => {
+      client.on("ready", () => resolve());
+      client.on("error", (e: Error) => reject(e));
+      setTimeout(() => reject(new Error("never became ready")), 5000);
+    });
+    client.connect();
+    await ready;
+
+    expect(hostsSeen[0]).toBe("luke-hermes.taildb786a.ts.net");
+    expect(hostsSeen[1]).toBe("localhost");
+    client.terminate();
+  });
+
+  it("gives up after one retry rather than looping", async () => {
+    const wss = new WebSocketServer({ port: 0 });
+    servers.push(wss);
+    await new Promise<void>((resolve) => wss.on("listening", () => resolve()));
+    let attempts = 0;
+    wss.on("connection", (ws: WsSocket) => {
+      attempts += 1;
+      ws.close(4403, "host_mismatch");
+    });
+    const { port } = wss.address() as AddressInfo;
+
+    const { HermesAgentJsonRpcClient } = await import("../../server/hermes-agent/jsonrpc-client");
+    const client = new HermesAgentJsonRpcClient({ url: `ws://127.0.0.1:${port}`, token: "t" });
+
+    const closed = new Promise<number>((resolve) => client.on("close", (code: number) => resolve(code)));
+    client.connect();
+    expect(await closed).toBe(4403);
+    expect(attempts).toBe(2);
+  });
+});
+
+describe("profiles as agents", () => {
+  // Verbatim rows from a live hermes-agent `profiles.list`.
+  const backendProfiles = [
+    {
+      name: "default",
+      path: "/Users/lukeai1/.hermes",
+      is_default: true,
+      model: "claude-haiku-4-5-20251001",
+      description: "",
+      display_name: "",
+    },
+    {
+      name: "allan",
+      path: "/Users/lukeai1/.hermes/profiles/allan",
+      is_default: false,
+      model: "claude-haiku-4-5-20251001",
+      description:
+        "Allan — technical planner and business systems analyst for Smartways. Converts Jira tickets into plans.",
+      display_name: "",
+    },
+    {
+      name: "andrew",
+      path: "/Users/lukeai1/.hermes/profiles/andrew",
+      is_default: false,
+      model: "claude-opus-4-8",
+      description: "Andrew — senior full-stack software developer for Smartways.",
+      display_name: "",
+    },
+  ];
+
+  it("gives every profile its own agent", async () => {
+    const { toHermes3dAgents } = await import("../../server/hermes-agent/bridge");
+    const agents = toHermes3dAgents(backendProfiles);
+    expect(agents.map((a) => a.id)).toEqual(["default", "allan", "andrew"]);
+    expect(agents.map((a) => a.name)).toEqual(["Default", "Allan", "Andrew"]);
+  });
+
+  it("routes non-default agents by profile and leaves the default unnamed", async () => {
+    const { toHermes3dAgents } = await import("../../server/hermes-agent/bridge");
+    const [def, allan] = toHermes3dAgents(backendProfiles);
+    // An empty profile means "launch profile" upstream; naming it is wrong.
+    expect(def.profile).toBe("");
+    expect(allan.profile).toBe("allan");
+  });
+
+  it("uses the description after the dash as the role", async () => {
+    const { toHermes3dAgents } = await import("../../server/hermes-agent/bridge");
+    const allan = toHermes3dAgents(backendProfiles)[1];
+    expect(allan.role.startsWith("technical planner")).toBe(true);
+  });
+
+  it("picks the flagged profile as the default agent", async () => {
+    const { toHermes3dAgents, resolveDefaultAgentId } = await import(
+      "../../server/hermes-agent/bridge"
+    );
+    expect(resolveDefaultAgentId(toHermes3dAgents(backendProfiles))).toBe("default");
+  });
+
+  it("ignores unusable rows", async () => {
+    const { toHermes3dAgents } = await import("../../server/hermes-agent/bridge");
+    expect(toHermes3dAgents([null, {}, "x", { name: "" }])).toEqual([]);
+    expect(toHermes3dAgents(undefined)).toEqual([]);
+  });
+
+  it("advertises every profile and creates sessions against the right one", async () => {
+    const createCalls: Frame[] = [];
+    const agent = await startFakeHermesAgent({
+      "profiles.list": () => ({ profiles: backendProfiles }),
+      "session.create": (params) => {
+        createCalls.push(params);
+        return { session_id: `rt-${createCalls.length}` };
+      },
+      "prompt.submit": () => ({}),
+    });
+    const bridge = await openBridge(agent.url);
+
+    bridge.send({ type: "req", id: "c1", method: "connect", params: {} });
+    await bridge.waitFor((f) => f.type === "res" && f.id === "c1", "hello-ok");
+
+    bridge.send({ type: "req", id: "a1", method: "agents.list", params: {} });
+    const listed = await bridge.waitFor((f) => f.type === "res" && f.id === "a1", "agents.list");
+    expect((at(listed, "payload.agents") as unknown[]).length).toBe(3);
+
+    // A prompt aimed at Allan's desk must run under Allan's profile.
+    bridge.send({
+      type: "req",
+      id: "s1",
+      method: "chat.send",
+      params: { sessionKey: "agent:allan:main", message: "hi" },
+    });
+    await bridge.waitFor((f) => f.type === "res" && f.id === "s1", "chat.send");
+    expect(createCalls.at(-1)).toEqual({ profile: "allan" });
+
+    // The default agent must NOT send a profile — that means "launch profile".
+    bridge.send({
+      type: "req",
+      id: "s2",
+      method: "chat.send",
+      params: { sessionKey: "agent:default:main", message: "hi" },
+    });
+    await bridge.waitFor((f) => f.type === "res" && f.id === "s2", "chat.send default");
+    expect(createCalls.at(-1)).toEqual({});
+  });
+
+  it("falls back to a single agent when the backend has no profiles.list", async () => {
+    const agent = await startFakeHermesAgent({});
+    const bridge = await openBridge(agent.url);
+    bridge.send({ type: "req", id: "c1", method: "connect", params: {} });
+    const res = await bridge.waitFor((f) => f.type === "res" && f.id === "c1", "hello-ok");
+    expect((at(res, "payload.snapshot.health.agents") as unknown[]).length).toBe(1);
+    expect(at(res, "payload.snapshot.health.defaultAgentId")).toBe("hermes");
+  });
+});
+
+describe("toHermes3dCronJobs", () => {
+  // Verbatim row shape returned by a live hermes-agent `cron.manage` list.
+  const agentJob = {
+    job_id: "f43da87997a8",
+    name: "Daily token spend - morning briefing",
+    prompt_preview: "Run `hermes insights --days 1` and extract today's data.",
+    schedule: "0 7 * * *",
+    repeat: "forever",
+    deliver: "origin",
+    next_run_at: "2026-08-19T07:00:00-05:00",
+    last_run_at: "2026-08-18T07:00:40.472539-05:00",
+    last_status: "ok",
+    last_delivery_error: null,
+    last_fire_error: null,
+    enabled: true,
+    state: "scheduled",
+  };
+
+  it("fills in the fields the office task board reads unguarded", async () => {
+    const { toHermes3dCronJobs } = await import("../../server/hermes-agent/bridge");
+    const [job] = toHermes3dCronJobs([agentJob]);
+
+    // These four are exactly what crashed the office page when forwarded raw.
+    expect(job.id).toBe("f43da87997a8");
+    expect(job.payload).toEqual({ kind: "agentTurn", message: agentJob.prompt_preview });
+    expect(job.schedule).toEqual({ kind: "cron", expr: "0 7 * * *" });
+    expect(typeof job.state).toBe("object");
+    expect(job.state.lastStatus).toBe("ok");
+    expect(job.state.nextRunAtMs).toBe(Date.parse(agentJob.next_run_at));
+    expect(Number.isFinite(job.updatedAtMs)).toBe(true);
+  });
+
+  it("marks a running job so the board can show it as working", async () => {
+    const { toHermes3dCronJobs } = await import("../../server/hermes-agent/bridge");
+    const [job] = toHermes3dCronJobs([{ ...agentJob, state: "running" }]);
+    expect(typeof job.state.runningAtMs).toBe("number");
+  });
+
+  it("surfaces a failure so the board can flag it", async () => {
+    const { toHermes3dCronJobs } = await import("../../server/hermes-agent/bridge");
+    const [job] = toHermes3dCronJobs([
+      { ...agentJob, last_status: "error", last_fire_error: "boom" },
+    ]);
+    expect(job.state.lastStatus).toBe("error");
+    expect(job.state.lastError).toBe("boom");
+  });
+
+  it("drops rows with no id and tolerates junk", async () => {
+    const { toHermes3dCronJobs } = await import("../../server/hermes-agent/bridge");
+    expect(toHermes3dCronJobs([{}, null, "nope", { name: "no id" }])).toEqual([]);
+    expect(toHermes3dCronJobs(undefined)).toEqual([]);
+  });
+
+  it("reads the other schedule spellings hermes-agent emits", async () => {
+    const { toHermes3dSchedule } = await import("../../server/hermes-agent/bridge");
+    expect(toHermes3dSchedule("30m")).toEqual({ kind: "every", everyMs: 1_800_000 });
+    expect(toHermes3dSchedule("every 2h")).toEqual({ kind: "every", everyMs: 7_200_000 });
+    expect(toHermes3dSchedule("0 9 * * *")).toEqual({ kind: "cron", expr: "0 9 * * *" });
+    expect(toHermes3dSchedule("2026-06-01T09:00:00Z")).toEqual({
+      kind: "at",
+      at: "2026-06-01T09:00:00Z",
+    });
+  });
+});
+
 describe("toHermes3dMessages", () => {
   it("renames text to content and drops non-conversational rows", () => {
     expect(

--- a/tests/unit/officeConversations.test.ts
+++ b/tests/unit/officeConversations.test.ts
@@ -1,0 +1,237 @@
+// @vitest-environment node
+import { describe, expect, it } from "vitest";
+
+import {
+  computeConversationSlots,
+  CONVERSATION_MIN_RADIUS,
+  conversationTalkTurn,
+  deriveConversationGroups,
+} from "../../src/features/retro-office/core/conversations";
+import { planChatterBlip } from "../../src/features/retro-office/systems/conversationChatterAudio";
+import { formatAgentSubtitleText } from "../../src/features/retro-office/objects/agents";
+
+const NAMES = {
+  allan: "Allan",
+  owen: "Owen",
+  rev: "Rev",
+  samuel: "Samuel",
+};
+
+const NOW = 1_000_000;
+
+describe("deriveConversationGroups", () => {
+  it("groups two agents speaking inside the same window", () => {
+    const groups = deriveConversationGroups({
+      samples: [
+        { agentId: "allan", text: "Plan is ready.", atMs: NOW - 4_000 },
+        { agentId: "owen", text: "Reviewing it now.", atMs: NOW - 1_000 },
+      ],
+      agentNamesById: NAMES,
+      nowMs: NOW,
+    });
+    expect(groups).toHaveLength(1);
+    expect(groups[0].participantIds).toEqual(["allan", "owen"]);
+    expect(groups[0].id).toBe("allan+owen");
+    expect(groups[0].lastActivityMs).toBe(NOW - 1_000);
+  });
+
+  it("does not form a group for a single speaker with no mentions", () => {
+    const groups = deriveConversationGroups({
+      samples: [{ agentId: "allan", text: "Working on it.", atMs: NOW }],
+      agentNamesById: NAMES,
+      nowMs: NOW,
+    });
+    expect(groups).toEqual([]);
+  });
+
+  it("pulls a mentioned agent into the huddle before it has replied", () => {
+    const groups = deriveConversationGroups({
+      samples: [
+        { agentId: "allan", text: "Owen, can you gate this release?", atMs: NOW },
+      ],
+      agentNamesById: NAMES,
+      nowMs: NOW,
+    });
+    expect(groups).toHaveLength(1);
+    expect(groups[0].participantIds).toEqual(["allan", "owen"]);
+  });
+
+  it("splits separate mention threads into separate circles", () => {
+    const groups = deriveConversationGroups({
+      samples: [
+        { agentId: "allan", text: "Owen, thoughts?", atMs: NOW - 2_000 },
+        { agentId: "owen", text: "Allan, agreed.", atMs: NOW - 1_500 },
+        { agentId: "rev", text: "Samuel, fix the CI first.", atMs: NOW - 1_000 },
+        { agentId: "samuel", text: "On it, Rev.", atMs: NOW - 500 },
+      ],
+      agentNamesById: NAMES,
+      nowMs: NOW,
+    });
+    expect(groups.map((group) => group.id)).toEqual([
+      "allan+owen",
+      "rev+samuel",
+    ]);
+  });
+
+  it("expires speech outside the window", () => {
+    const groups = deriveConversationGroups({
+      samples: [
+        { agentId: "allan", text: "Old news.", atMs: NOW - 60_000 },
+        { agentId: "owen", text: "Fresh reply.", atMs: NOW - 1_000 },
+      ],
+      agentNamesById: NAMES,
+      nowMs: NOW,
+    });
+    expect(groups).toEqual([]);
+  });
+
+  it("is suppressed during a standup meeting", () => {
+    const groups = deriveConversationGroups({
+      samples: [
+        { agentId: "allan", text: "Status.", atMs: NOW },
+        { agentId: "owen", text: "Status.", atMs: NOW },
+      ],
+      agentNamesById: NAMES,
+      nowMs: NOW,
+      suppressed: true,
+    });
+    expect(groups).toEqual([]);
+  });
+
+  it("ignores speakers the office does not know about", () => {
+    const groups = deriveConversationGroups({
+      samples: [
+        { agentId: "ghost", text: "Boo.", atMs: NOW },
+        { agentId: "allan", text: "Hm.", atMs: NOW },
+      ],
+      agentNamesById: NAMES,
+      nowMs: NOW,
+    });
+    expect(groups).toEqual([]);
+  });
+});
+
+describe("computeConversationSlots", () => {
+  const participants = [
+    { id: "allan", x: 300, y: 300 },
+    { id: "owen", x: 420, y: 320 },
+  ];
+
+  it("places every participant on a circle around the shared centre", () => {
+    const slots = computeConversationSlots({ participants });
+    expect(slots.size).toBe(2);
+    const [a, b] = [...slots.values()];
+    const distance = Math.hypot(a.x - b.x, a.y - b.y);
+    // Two slots sit on opposite sides of the circle.
+    expect(distance).toBeGreaterThanOrEqual(CONVERSATION_MIN_RADIUS * 2 - 2);
+    expect(distance).toBeLessThanOrEqual(CONVERSATION_MIN_RADIUS * 2 + 2);
+  });
+
+  it("faces each slot toward the centre", () => {
+    const slots = computeConversationSlots({ participants });
+    const points = [...slots.values()];
+    const centerX = (points[0].x + points[1].x) / 2;
+    const centerY = (points[0].y + points[1].y) / 2;
+    for (const slot of points) {
+      const expected = Math.atan2(centerX - slot.x, centerY - slot.y);
+      expect(slot.facing).toBeCloseTo(expected, 5);
+    }
+  });
+
+  it("assigns distinct seat indexes", () => {
+    const four = [
+      { id: "a", x: 100, y: 100 },
+      { id: "b", x: 200, y: 100 },
+      { id: "c", x: 100, y: 200 },
+      { id: "d", x: 200, y: 200 },
+    ];
+    const slots = computeConversationSlots({ participants: four });
+    expect(new Set([...slots.values()].map((slot) => slot.seatIndex)).size).toBe(
+      4,
+    );
+  });
+
+  it("moves the circle to walkable ground when the centroid is blocked", () => {
+    // Everything within 40 units of the centroid (360, 310) is blocked.
+    const blockedZone = (x: number, y: number) =>
+      Math.hypot(x - 360, y - 310) > 120;
+    const slots = computeConversationSlots({
+      participants,
+      isFree: blockedZone,
+    });
+    for (const slot of slots.values()) {
+      expect(blockedZone(slot.x, slot.y)).toBe(true);
+    }
+  });
+
+  it("returns nothing for fewer than two participants", () => {
+    expect(
+      computeConversationSlots({ participants: [{ id: "a", x: 0, y: 0 }] })
+        .size,
+    ).toBe(0);
+  });
+});
+
+describe("conversationTalkTurn", () => {
+  it("rotates the speaking turn around the circle", () => {
+    const size = 3;
+    const turnMs = 1_600;
+    for (let seat = 0; seat < size; seat += 1) {
+      const at = seat * turnMs + 10;
+      for (let other = 0; other < size; other += 1) {
+        expect(conversationTalkTurn(at, other, size, turnMs)).toBe(
+          other === seat,
+        );
+      }
+    }
+  });
+
+  it("never fires for an empty group", () => {
+    expect(conversationTalkTurn(0, 0, 0)).toBe(false);
+  });
+});
+
+describe("planChatterBlip", () => {
+  it("stays within audible-but-quiet bounds", () => {
+    for (const roll of [0, 0.25, 0.5, 0.75, 0.999]) {
+      const plan = planChatterBlip(() => roll);
+      expect(plan.delayMs).toBeGreaterThanOrEqual(260);
+      expect(plan.delayMs).toBeLessThanOrEqual(900);
+      expect(plan.frequencyHz).toBeGreaterThanOrEqual(165);
+      expect(plan.frequencyHz).toBeLessThanOrEqual(355);
+      expect(plan.durationMs).toBeGreaterThanOrEqual(70);
+      expect(plan.durationMs).toBeLessThanOrEqual(160);
+      expect(plan.gain).toBeLessThanOrEqual(0.044);
+      expect([1, 2]).toContain(plan.syllables);
+    }
+  });
+});
+
+describe("formatAgentSubtitleText", () => {
+  it("keeps a short role untouched", () => {
+    expect(formatAgentSubtitleText("release gatekeeper")).toBe(
+      "release gatekeeper",
+    );
+  });
+
+  it("keeps only the first clause of a long description", () => {
+    expect(
+      formatAgentSubtitleText(
+        "technical planner and business systems analyst for Smartways. Converts Jira tickets into concrete implementation plans.",
+      ),
+    ).toBe("technical planner…");
+  });
+
+  it("cuts at a word boundary instead of mid-word", () => {
+    expect(
+      formatAgentSubtitleText(
+        "senior full-stack software developer for Smartways",
+      ),
+    ).toBe("senior full-stack…");
+  });
+
+  it("collapses whitespace and handles empties", () => {
+    expect(formatAgentSubtitleText("   ")).toBe("");
+    expect(formatAgentSubtitleText("qa\n  lead")).toBe("qa lead");
+  });
+});


### PR DESCRIPTION
## Summary
- Agents that talk between themselves (simultaneous speech, or one naming a teammate) now gather into a circle, face each other, take visible talking turns, and a soft synthesized chatter murmur plays while the huddle is active (Web Audio, unlocked on first pointer gesture). Huddles never dissolve while members are still walking over, circle members are exempt from the collision bumps that trapped them at the circle's edge, and unreachable slots fall back to a beeline.
- Every hermes-agent profile is now its own agent in the office (11-agent fleet instead of one hardcoded "Hermes"), with prompts routed to the right profile via session keys and cron jobs translated into the shape the task board expects — forwarding them raw white-screened /office.
- Role subtitles above agents are clamped to one short line instead of wrapping full profile descriptions into a wall of text.
- The JSON-RPC client retries with a loopback Host when a loopback-bound backend behind Tailscale Serve refuses the forwarded one, and the gateway proxy logs its transport decisions.

## Test plan
- [x] 84 unit tests green across the bridge, conversations, cron, diagnostics, and task-board suites (19 new for conversation grouping/geometry, 12 new for profile mapping and cron translation)
- [x] Live end-to-end against a real hermes-agent over Tailscale: a reply mentioning two teammates formed the group, all three agents walked to the circle and settled standing on their slots, zero page errors
- [x] /office and / load clean with the real 11-profile fleet connected
- [x] tsc --noEmit clean; eslint clean on changed files (pre-existing RetroOffice3D errors unchanged)

Made with [Cursor](https://cursor.com)