### PR TITLE
Replace real tailnet hostnames in tests with placeholders

### DIFF
--- a/tests/unit/gatewayConnectScreen-urlFindings.test.ts
+++ b/tests/unit/gatewayConnectScreen-urlFindings.test.ts
@@ -27,7 +27,7 @@ describe("GatewayConnectScreen upstream URL findings", () => {
   });
 
   it("warns before connecting when pointed at the hermes-agent dashboard port", () => {
-    renderScreen("wss://luke-hermes.taildb786a.ts.net:9119");
+    renderScreen("wss://box.ts.net:9119");
 
     const dashboardFinding = screen.getByTestId("gateway-url-finding-hermes_agent_dashboard_port");
     expect(dashboardFinding.textContent).toMatch(/JSON-RPC 2\.0/);
@@ -36,7 +36,7 @@ describe("GatewayConnectScreen upstream URL findings", () => {
   });
 
   it("stays quiet for a valid adapter URL", () => {
-    renderScreen("wss://luke-hermes.taildb786a.ts.net");
+    renderScreen("wss://box.ts.net");
 
     expect(screen.queryByLabelText("Gateway URL warnings")).toBeNull();
   });

--- a/tests/unit/hermesAgentBridge.test.ts
+++ b/tests/unit/hermesAgentBridge.test.ts
@@ -162,7 +162,7 @@ describe("loopback Host fallback", () => {
 
     // 127.0.0.1 resolves, but the Host header carries a name the backend rejects.
     const client = new HermesAgentJsonRpcClient({ url: `ws://127.0.0.1:${port}`, token: "t" });
-    client.hostHeader = "luke-hermes.taildb786a.ts.net";
+    client.hostHeader = "box.ts.net";
     client.loopbackHostFallback = true;
 
     const ready = new Promise<void>((resolve, reject) => {
@@ -173,7 +173,7 @@ describe("loopback Host fallback", () => {
     client.connect();
     await ready;
 
-    expect(hostsSeen[0]).toBe("luke-hermes.taildb786a.ts.net");
+    expect(hostsSeen[0]).toBe("box.ts.net");
     expect(hostsSeen[1]).toBe("localhost");
     expect(client.usedLoopbackHost).toBe(true);
     client.terminate();
@@ -200,7 +200,7 @@ describe("loopback Host fallback", () => {
 
     const { HermesAgentJsonRpcClient } = await import("../../server/hermes-agent/jsonrpc-client");
     const client = new HermesAgentJsonRpcClient({ url: `ws://127.0.0.1:${port}`, token: "t" });
-    client.hostHeader = "luke-hermes.taildb786a.ts.net";
+    client.hostHeader = "box.ts.net";
 
     const ready = new Promise<void>((resolve, reject) => {
       client.on("ready", () => resolve());
@@ -210,7 +210,7 @@ describe("loopback Host fallback", () => {
     client.connect();
     await ready;
 
-    expect(hostsSeen[0]).toBe("luke-hermes.taildb786a.ts.net");
+    expect(hostsSeen[0]).toBe("box.ts.net");
     expect(hostsSeen[1]).toBe("localhost");
     client.terminate();
   });

--- a/tests/unit/upstreamUrlDiagnostics.test.ts
+++ b/tests/unit/upstreamUrlDiagnostics.test.ts
@@ -14,8 +14,8 @@ const codesFor = (url: string) => inspectUpstreamGatewayUrl(url).map((finding) =
 describe("upstream gateway URL diagnostics", () => {
   it("accepts the adapter endpoints Hermes3D actually speaks to", () => {
     expect(codesFor("ws://localhost:18789")).toEqual([]);
-    expect(codesFor("wss://luke-hermes.taildb786a.ts.net")).toEqual([]);
-    expect(codesFor("wss://luke-hermes.taildb786a.ts.net:443")).toEqual([]);
+    expect(codesFor("wss://box.ts.net")).toEqual([]);
+    expect(codesFor("wss://box.ts.net:443")).toEqual([]);
   });
 
   it("ignores empty and unparseable values", () => {
@@ -25,7 +25,7 @@ describe("upstream gateway URL diagnostics", () => {
   });
 
   it("flags the hermes-agent dashboard port", () => {
-    expect(codesFor("wss://luke-hermes.taildb786a.ts.net:9119")).toContain(
+    expect(codesFor("wss://box.ts.net:9119")).toContain(
       "hermes_agent_dashboard_port",
     );
   });
@@ -42,7 +42,7 @@ describe("upstream gateway URL diagnostics", () => {
   it("stays quiet when the hermes-agent adapter targets that endpoint on purpose", () => {
     // The JSON-RPC path and the dashboard port are the correct destination for
     // this adapter, so the rules that reject them elsewhere must stand down.
-    const served = "wss://luke-hermes.taildb786a.ts.net:8443/api/ws";
+    const served = "wss://box.ts.net:8443/api/ws";
     expect(codesFor(served)).toContain("hermes_agent_jsonrpc_path");
     expect(inspectUpstreamGatewayUrl(served, "hermes-agent")).toEqual([]);
     expect(inspectUpstreamGatewayUrlFromDoctor(served, "hermes-agent")).toEqual([]);
@@ -59,7 +59,7 @@ describe("upstream gateway URL diagnostics", () => {
     // Suppressing the endpoint rules must not suppress this one: wss:// against
     // a port Tailscale does not terminate TLS on fails for either adapter.
     expect(
-      inspectUpstreamGatewayUrl("wss://luke-hermes.taildb786a.ts.net:9119", "hermes-agent").map(
+      inspectUpstreamGatewayUrl("wss://box.ts.net:9119", "hermes-agent").map(
         (finding) => finding.code,
       ),
     ).toEqual(["tls_on_plain_tailnet_port"]);
@@ -76,7 +76,7 @@ describe("upstream gateway URL diagnostics", () => {
   });
 
   it("reports every problem with the URL from the original report", () => {
-    const findings = inspectUpstreamGatewayUrl("wss://luke-hermes.taildb786a.ts.net:9119");
+    const findings = inspectUpstreamGatewayUrl("wss://box.ts.net:9119");
     expect(findings.map((finding) => finding.code)).toEqual([
       "hermes_agent_dashboard_port",
       "tls_on_plain_tailnet_port",
@@ -103,7 +103,7 @@ describe("upstream gateway URL diagnostics", () => {
       "wss://box.ts.net:8443",
       "wss://box.ts.net:18789",
       "wss://ts.net:18789",
-      "wss://luke-hermes.taildb786a.ts.net:9119",
+      "wss://box.ts.net:9119",
     ];
     for (const url of urls) {
       expect(inspectUpstreamGatewayUrlFromDoctor(url), `mismatch for ${url || "(empty)"}`).toEqual(
@@ -114,7 +114,7 @@ describe("upstream gateway URL diagnostics", () => {
 
   it("surfaces the findings through doctor gateway warnings", () => {
     const warnings = buildGatewayWarnings({
-      gatewayUrl: "wss://luke-hermes.taildb786a.ts.net:9119",
+      gatewayUrl: "wss://box.ts.net:9119",
     });
     expect(warnings.some((warning: string) => warning.includes("hermes-agent dashboard"))).toBe(
       true,

--- a/tests/unit/useGatewayConnection.test.ts
+++ b/tests/unit/useGatewayConnection.test.ts
@@ -204,11 +204,11 @@ describe("useGatewayConnection", () => {
         settings: {
           version: 1,
           gateway: {
-            url: "wss://pi5.myth-coho.ts.net",
+            url: "wss://box.ts.net",
             token: "shared-token",
             adapterType: "hermes",
             lastKnownGood: {
-              url: "wss://pi5.myth-coho.ts.net",
+              url: "wss://box.ts.net",
               token: "shared-token",
               adapterType: "hermes",
             },
@@ -238,7 +238,7 @@ describe("useGatewayConnection", () => {
     await waitFor(() => {
       expect(captured.url).toBe("ws://localhost:3000/api/gateway/ws");
     });
-    expect(captured.authScopeKey).toBe("wss://pi5.myth-coho.ts.net");
+    expect(captured.authScopeKey).toBe("wss://box.ts.net");
     expect(captured.clientName).toBe("hermes3d-control-ui");
   });
 


### PR DESCRIPTION
## Summary

Four test files pinned real Tailscale MagicDNS names as fixture hosts, publishing machine names and tailnet ids in a public repo. Two distinct real tailnets were embedded this way:

- `luke-hermes.taildb786a.ts.net` — `upstreamUrlDiagnostics`, `hermesAgentBridge`, `gatewayConnectScreen-urlFindings`
- `pi5.myth-coho.ts.net` — `useGatewayConnection`

None of the assertions depend on the specific host; they exercise port, scheme, and Host-header rules. All occurrences now use `box.ts.net`, the placeholder the diagnostics suite already used elsewhere.

## No credential exposure

Checked the full history rather than just the working tree:

- Session token, tailnet IP, and local home paths: **0 commits** each.
- `.env` is gitignored and untracked; only `.env.example` is committed.

## Test plan

- [x] `npx vitest run` on all four suites — 61/61 pass
- [x] Tree-wide rescan finds no real host, tailnet, IP, token, or username
- [x] Remaining `.ts.net` references are all placeholders (`box`, `host`, `your-host`, `demo.tailnet`)

Made with [Cursor](https://cursor.com)