### PR TITLE
Make the office react to conversations held in other clients

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ Prerequisite:
 - For a no-framework local office demo, run the bundled demo gateway instead.
 - If you need a full cross-machine setup guide (Hermes + Tailscale + Hermes3D), follow [`TUTORIAL.md`](TUTORIAL.md).
 - To connect to a remote `hermes-agent` backend with no adapter process, follow [`docs/hermes-agent-tailscale.md`](docs/hermes-agent-tailscale.md).
+- To make the office react to chats you have elsewhere (desktop app, TUI, CLI), install the optional bridge plugin in [`docs/office-conversation-bridge.md`](docs/office-conversation-bridge.md).
 
 Run from source:
 
@@ -284,6 +285,7 @@ See [`.env.example`](.env.example) for the full local development template.
 - [`ARCHITECTURE.md`](ARCHITECTURE.md): system boundaries, data flow, and major trade-offs.
 - [`TUTORIAL.md`](TUTORIAL.md): detailed step-by-step setup for Hermes + Tailscale + Hermes3D.
 - [`docs/hermes-agent-tailscale.md`](docs/hermes-agent-tailscale.md): connect to a remote `hermes-agent` over Tailscale with no adapter process.
+- [`docs/office-conversation-bridge.md`](docs/office-conversation-bridge.md): optional plugin that makes the office react to chats you have in the desktop app, TUI, or CLI.
 - [`docs/multi-agent-beta.md`](docs/multi-agent-beta.md): remote office beta setup, connection modes, and limitations.
 - [`docs/runtime-profiles.md`](docs/runtime-profiles.md): saved backend/runtime profiles and the current HTTP runtime seam.
 - [`CODE_DOCUMENTATION.md`](CODE_DOCUMENTATION.md): practical code map, extension points, and contributor onboarding order.

--- a/docs/office-conversation-bridge.md
+++ b/docs/office-conversation-bridge.md
@@ -1,0 +1,142 @@
+# Showing outside conversations in the office
+
+Hermes3D is a visualiser, not a chat client. When you talk to your agents
+somewhere else — the Hermes desktop app, the TUI, the CLI — the office has no
+way to know it happened, so the characters keep working at their desks while a
+group chat scrolls past on another screen.
+
+This optional plugin closes that gap. Install it into your backend and the
+office reacts to conversations you have anywhere: the agents that replied walk
+away from their desks, gather in a circle, face each other, and take turns
+talking while the huddle lasts.
+
+It is observation only. The plugin never changes a turn, never delays one, and
+never adds a tool — so it costs nothing in prompt tokens and cannot break a
+conversation. If the office is closed, or the backend is not reachable, it
+silently does nothing.
+
+## Requirements
+
+- The `hermes-agent` backend, connected to Hermes3D through the **Hermes Agent
+  (direct)** backend type. See
+  [`hermes-agent-tailscale.md`](hermes-agent-tailscale.md) for that setup.
+- A pinned `HERMES_DASHBOARD_SESSION_TOKEN`. An unpinned backend mints a random
+  token every start, which nothing else can know. The installer warns you if it
+  is missing; pin one with:
+
+```bash
+echo "HERMES_DASHBOARD_SESSION_TOKEN=$(openssl rand -hex 32)" >> ~/.hermes/.env
+```
+
+## Install
+
+Run the installer from your Hermes3D checkout, on the machine that runs the
+backend:
+
+```bash
+./plugins/hermes3d-office-bridge/install.sh
+```
+
+Then restart the backend (`hermes serve …`) so the plugin loads.
+
+Plugins are scoped to a `HERMES_HOME`, and every Hermes profile has its own, so
+a plugin installed only in the default home stays silent for every other agent.
+The installer copies the plugin into the default home **and each profile**, and
+enables it in all of them. Re-running it is safe.
+
+To remove it:
+
+```bash
+./plugins/hermes3d-office-bridge/install.sh --uninstall
+```
+
+## How it works
+
+```
+desktop app / TUI / CLI
+        │  you send a group message
+        ▼
+   hermes-agent  ── post_llm_call ──▶  plugin  ──▶  ws://127.0.0.1:9119/api/pub
+                                                            │  channel: hermes3d
+                                                            ▼
+Hermes3D server  ◀── ws://…/api/events ── dashboard event bus
+        │  office.speech
+        ▼
+    the office     agents gather into a circle
+```
+
+The reason a plugin is needed at all: message events on the JSON-RPC gateway go
+only to the client that submitted the prompt. An office watching from the
+outside sees session activity but never the text, so it cannot tell who spoke.
+The plugin republishes each finished turn on the dashboard's event bus, which
+fans out to every subscriber.
+
+A published frame carries the profile that spoke, the reply text, the session
+id, and a timestamp:
+
+```json
+{
+  "v": 1,
+  "kind": "agent.turn",
+  "profile": "pr-reviewer",
+  "text": "Good morning! I'm here too.",
+  "sessionId": "…",
+  "platform": "tui",
+  "atMs": 1750000000000
+}
+```
+
+`profile` is the agent identity — Hermes3D names each character after the
+backend profile it represents, so the two line up without a lookup table. A
+frame naming a profile the office does not show is ignored.
+
+## What you see in the office
+
+Two or more agents replying inside the same ~25 second window count as a
+conversation. When that happens:
+
+- Everyone involved drops what they were doing and walks over, faster than a
+  normal stroll, to a circle laid out on free floor near the middle of the
+  group.
+- On arrival they stand facing the centre and the speaking turn rotates around
+  the circle, so the chatter bubbles alternate instead of everyone talking at
+  once. A soft murmur plays while any huddle is active (browsers need one click
+  on the page before audio is allowed).
+- The huddle holds for at least 45 seconds so nobody dissolves it while a
+  distant participant is still walking, and it keeps extending while the
+  conversation continues. It breaks up once the talking stops.
+
+An agent is only ever in one huddle. If a wider conversation forms, the smaller
+one it absorbed is retired rather than left to compete for the same agents.
+
+A standup meeting outranks a huddle: while one is gathering or running, agents
+go to the meeting room instead.
+
+## Configuration
+
+Defaults suit a backend on the same machine, which is the only topology the
+plugin targets — it always publishes locally and never across a network. To
+change them, add to `~/.hermes/config.yaml`:
+
+```yaml
+plugins:
+  entries:
+    hermes3d-office-bridge:
+      settings:
+        host: 127.0.0.1
+        port: 9119
+        channel: hermes3d
+```
+
+`channel` must match the channel the Hermes3D server subscribes to. Change it
+only if something else is already using `hermes3d` on your event bus.
+
+## Troubleshooting
+
+| Symptom | Cause | Fix |
+| --- | --- | --- |
+| Nothing happens when you chat | Plugin not loaded | Restart the backend after installing; check `hermes plugins list` |
+| Works for one agent, not the others | Installed in the default home only | Re-run `install.sh`, which covers every profile |
+| Warning about the session token at install | Token not pinned | Add `HERMES_DASHBOARD_SESSION_TOKEN` to `~/.hermes/.env` and restart |
+| One agent replies but no circle forms | A conversation needs two speakers | Ask a question the whole group answers |
+| Agents gather but the office is silent | Browser audio is locked until you interact | Click once anywhere on the page |

--- a/plugins/hermes3d-office-bridge/__init__.py
+++ b/plugins/hermes3d-office-bridge/__init__.py
@@ -1,0 +1,157 @@
+"""Publish finished agent turns so a Hermes3D office can visualise them.
+
+Hermes3D renders each backend profile as a character at a desk. To show who is
+talking — and to gather the speakers into a conversation circle — the office
+needs to know when an agent replied and what it said. Message events on the
+JSON-RPC gateway are delivered only to the client that submitted the prompt, so
+an office watching from the outside sees nothing when you chat somewhere else.
+
+This plugin closes that gap from inside the backend. It observes every finished
+turn through ``post_llm_call`` and republishes a small frame on the dashboard's
+event bus, which fans out to any subscriber. Chat wherever you like — the
+desktop app, the TUI, the CLI — and the office animates it.
+
+Install it into each profile you want on screen; plugins are scoped to a
+``HERMES_HOME``, so a profile without it stays silent. See ``install.sh``.
+
+Observation only: the hook never mutates the turn, never blocks it, and
+swallows its own failures.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any, Optional
+from urllib.parse import quote
+
+from .publisher import OfficePublisher
+
+_log = logging.getLogger(__name__)
+
+FRAME_VERSION = 1
+
+DEFAULT_HOST = "127.0.0.1"
+DEFAULT_PORT = 9119
+DEFAULT_CHANNEL = "hermes3d"
+
+# The office shows a short preview, not a transcript. Truncating keeps a long
+# answer from dominating the event bus.
+MAX_TEXT_CHARS = 2_000
+
+_publisher: Optional[OfficePublisher] = None
+
+
+def build_turn_frame(
+    *,
+    profile: str,
+    text: str,
+    session_id: str = "",
+    platform: str = "",
+    at_ms: Optional[int] = None,
+) -> dict:
+    """Build the wire frame for one finished turn.
+
+    ``profile`` is the agent identity: Hermes3D names each character after the
+    backend profile it represents, so the two line up without a lookup table.
+    """
+    body = (text or "").strip()
+    if len(body) > MAX_TEXT_CHARS:
+        body = body[:MAX_TEXT_CHARS].rstrip() + "…"
+    return {
+        "v": FRAME_VERSION,
+        "kind": "agent.turn",
+        "profile": profile or "",
+        "text": body,
+        "sessionId": session_id or "",
+        "platform": platform or "",
+        "atMs": int(at_ms if at_ms is not None else time.time() * 1000),
+    }
+
+
+def build_publish_url(*, host: str, port: int, channel: str, token: str) -> str:
+    """URL for the dashboard publisher endpoint.
+
+    ``/api/pub`` accepts ``?token=`` only on an ungated (loopback) bind, which
+    is the topology this plugin targets — it always publishes to the local
+    backend, never across a network.
+    """
+    return (
+        f"ws://{host}:{int(port)}/api/pub"
+        f"?channel={quote(channel, safe='')}&token={quote(token, safe='')}"
+    )
+
+
+def _resolve_token() -> str:
+    """The dashboard session token, which is a secret and so lives in the env.
+
+    Pin it in ``~/.hermes/.env`` as ``HERMES_DASHBOARD_SESSION_TOKEN`` — an
+    unpinned backend mints a random one per start, which no subscriber can know.
+    """
+    import os
+
+    return (os.environ.get("HERMES_DASHBOARD_SESSION_TOKEN") or "").strip()
+
+
+def _resolve_profile() -> str:
+    """Which profile produced this turn.
+
+    One ``hermes serve`` backend runs every profile, so the answer is per-turn
+    rather than per-process; ``get_active_profile_name()`` reflects the profile
+    scope in force while the hook runs.
+    """
+    try:
+        from hermes_cli.profiles import get_active_profile_name
+
+        return str(get_active_profile_name() or "")
+    except Exception as exc:
+        _log.debug("hermes3d-office-bridge: profile lookup failed: %s", exc)
+        return ""
+
+
+def _handle_post_llm_call(**kwargs: Any) -> None:
+    if _publisher is None:
+        return
+    try:
+        text = str(kwargs.get("assistant_response") or "").strip()
+        if not text:
+            return
+        frame = build_turn_frame(
+            profile=_resolve_profile(),
+            text=text,
+            session_id=str(kwargs.get("session_id") or ""),
+            platform=str(kwargs.get("platform") or ""),
+        )
+        _publisher.publish(frame)
+    except Exception as exc:
+        # An office that cannot draw is never a reason to disturb a turn.
+        _log.debug("hermes3d-office-bridge: publish skipped: %s", exc)
+
+
+def register(ctx: Any) -> None:
+    global _publisher
+
+    token = _resolve_token()
+    if not token:
+        _log.warning(
+            "hermes3d-office-bridge: HERMES_DASHBOARD_SESSION_TOKEN is unset; "
+            "turns will not be published. Pin it in ~/.hermes/.env."
+        )
+        return
+
+    def setting(key: str, fallback: Any) -> Any:
+        try:
+            value = ctx.get_config(key, fallback)
+        except Exception:
+            return fallback
+        return fallback if value in (None, "") else value
+
+    _publisher = OfficePublisher(
+        build_publish_url(
+            host=str(setting("host", DEFAULT_HOST)),
+            port=int(setting("port", DEFAULT_PORT)),
+            channel=str(setting("channel", DEFAULT_CHANNEL)),
+            token=token,
+        )
+    )
+    ctx.register_hook("post_llm_call", _handle_post_llm_call)

--- a/plugins/hermes3d-office-bridge/install.sh
+++ b/plugins/hermes3d-office-bridge/install.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+#
+# Install the Hermes3D office bridge into every Hermes profile.
+#
+# Plugins are scoped to a HERMES_HOME, and each Hermes profile has its own, so
+# a plugin installed only in the default home stays silent for every other
+# agent. This copies the plugin into the default home plus each profile and
+# enables it in all of them. Re-running is safe.
+#
+# Usage:  ./install.sh            install and enable everywhere
+#         ./install.sh --uninstall  remove it everywhere
+
+set -euo pipefail
+
+PLUGIN_NAME="hermes3d-office-bridge"
+SOURCE_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HERMES_ROOT="${HERMES_ROOT:-$HOME/.hermes}"
+UNINSTALL=0
+[[ "${1:-}" == "--uninstall" ]] && UNINSTALL=1
+
+find_hermes() {
+  if command -v hermes >/dev/null 2>&1; then
+    command -v hermes
+    return 0
+  fi
+  if [[ -x "$HERMES_ROOT/hermes-agent/hermes" ]]; then
+    echo "$HERMES_ROOT/hermes-agent/hermes"
+    return 0
+  fi
+  return 1
+}
+
+if ! HERMES_BIN="$(find_hermes)"; then
+  echo "error: could not find the 'hermes' command." >&2
+  echo "       Add it to PATH, or set HERMES_ROOT to your Hermes install." >&2
+  exit 1
+fi
+
+if [[ ! -d "$HERMES_ROOT" ]]; then
+  echo "error: no Hermes home at $HERMES_ROOT" >&2
+  exit 1
+fi
+
+# Every target: the default home, then one per profile. A profile flag of ""
+# means the default profile.
+targets=("$HERMES_ROOT|")
+if [[ -d "$HERMES_ROOT/profiles" ]]; then
+  for profile_dir in "$HERMES_ROOT"/profiles/*/; do
+    [[ -d "$profile_dir" ]] || continue
+    targets+=("${profile_dir%/}|$(basename "$profile_dir")")
+  done
+fi
+
+for target in "${targets[@]}"; do
+  home="${target%%|*}"
+  profile="${target##*|}"
+  label="${profile:-default}"
+  dest="$home/plugins/$PLUGIN_NAME"
+
+  if (( UNINSTALL )); then
+    if [[ -n "$profile" ]]; then
+      "$HERMES_BIN" -p "$profile" plugins disable "$PLUGIN_NAME" >/dev/null 2>&1 || true
+    else
+      "$HERMES_BIN" plugins disable "$PLUGIN_NAME" >/dev/null 2>&1 || true
+    fi
+    rm -rf "$dest"
+    echo "  removed from $label"
+    continue
+  fi
+
+  mkdir -p "$home/plugins"
+  rm -rf "$dest"
+  cp -R "$SOURCE_DIR" "$dest"
+  rm -f "$dest/install.sh"
+
+  if [[ -n "$profile" ]]; then
+    "$HERMES_BIN" -p "$profile" plugins enable "$PLUGIN_NAME" >/dev/null 2>&1 || true
+  else
+    "$HERMES_BIN" plugins enable "$PLUGIN_NAME" >/dev/null 2>&1 || true
+  fi
+  echo "  installed for $label"
+done
+
+if (( UNINSTALL )); then
+  echo
+  echo "Done. Restart the backend to unload it."
+  exit 0
+fi
+
+echo
+if ! grep -qs 'HERMES_DASHBOARD_SESSION_TOKEN' "$HERMES_ROOT/.env"; then
+  echo "WARNING: HERMES_DASHBOARD_SESSION_TOKEN is not pinned in $HERMES_ROOT/.env."
+  echo "         Without it the backend mints a random token each start and the"
+  echo "         office cannot subscribe. Pin one with:"
+  echo
+  echo "           echo \"HERMES_DASHBOARD_SESSION_TOKEN=\$(openssl rand -hex 32)\" >> $HERMES_ROOT/.env"
+  echo
+fi
+echo "Done. Restart the backend so the plugin loads."

--- a/plugins/hermes3d-office-bridge/plugin.yaml
+++ b/plugins/hermes3d-office-bridge/plugin.yaml
@@ -1,0 +1,11 @@
+name: hermes3d-office-bridge
+version: 1.0.0
+description: "Publish each agent turn onto the Hermes dashboard event bus so Hermes3D can visualise conversations. Observation only — never alters a turn."
+author: Hermes3D
+kind: standalone
+platforms:
+  - linux
+  - macos
+  - windows
+hooks:
+  - post_llm_call

--- a/plugins/hermes3d-office-bridge/publisher.py
+++ b/plugins/hermes3d-office-bridge/publisher.py
@@ -1,0 +1,144 @@
+"""Best-effort publisher onto the Hermes dashboard event bus.
+
+The dashboard rebroadcasts whatever arrives on ``/api/pub`` to every
+``/api/events`` subscriber on the same channel, so shipping one frame per
+finished turn is all Hermes3D needs to animate a conversation.
+
+Everything here is deliberately failure-tolerant. An agent turn must never
+slow down, block on, or fail because of the office: sends happen on a daemon
+thread, a full queue drops the frame, a dead socket reconnects with backoff,
+and a missing ``websockets`` install makes the publisher inert rather than
+raising into the hook.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import queue
+import threading
+import time
+from typing import Any, Optional, Tuple
+
+try:
+    from websockets.sync.client import connect as ws_connect
+except ImportError:  # pragma: no cover - websockets ships with hermes-agent
+    ws_connect = None  # type: ignore[assignment]
+
+_log = logging.getLogger(__name__)
+
+_QUEUE_MAX = 128
+_CONNECT_TIMEOUT_S = 2.0
+
+# Retry gaps after a failed connect. The office is a nicety, so a backend that
+# is down or gated should cost one short attempt every so often, not a storm.
+_BACKOFF_S: Tuple[float, ...] = (1.0, 2.0, 5.0, 15.0, 30.0)
+
+# A turn that has been sitting in the queue longer than this is dropped rather
+# than published. Stale speech would make idle characters huddle for no reason.
+_MAX_FRAME_AGE_S = 20.0
+
+_STOP = object()
+
+
+class OfficePublisher:
+    """Ship JSON frames to ``/api/pub`` without ever blocking the caller."""
+
+    def __init__(self, url: str) -> None:
+        self._url = url
+        self._queue: "queue.Queue[Any]" = queue.Queue(maxsize=_QUEUE_MAX)
+        self._socket: Optional[Any] = None
+        self._worker: Optional[threading.Thread] = None
+        self._lock = threading.Lock()
+        self._failures = 0
+        self._next_attempt_at = 0.0
+        self._inert = ws_connect is None
+        if self._inert:
+            _log.debug("hermes3d-office-bridge: websockets missing; publisher inert")
+
+    def publish(self, frame: dict) -> bool:
+        """Queue one frame. Returns False when it was dropped."""
+        if self._inert:
+            return False
+        try:
+            line = json.dumps(frame, ensure_ascii=False)
+        except (TypeError, ValueError) as exc:
+            _log.debug("hermes3d-office-bridge: unserialisable frame: %s", exc)
+            return False
+
+        self._ensure_worker()
+        try:
+            self._queue.put_nowait((time.monotonic(), line))
+            return True
+        except queue.Full:
+            return False
+
+    def _ensure_worker(self) -> None:
+        with self._lock:
+            if self._worker is not None and self._worker.is_alive():
+                return
+            self._worker = threading.Thread(
+                target=self._drain,
+                name="hermes3d-office-bridge",
+                daemon=True,
+            )
+            self._worker.start()
+
+    def _connect(self) -> bool:
+        """Open the socket, honouring the backoff gate. Never raises."""
+        if self._socket is not None:
+            return True
+        if time.monotonic() < self._next_attempt_at:
+            return False
+        try:
+            self._socket = ws_connect(  # type: ignore[misc]
+                self._url,
+                open_timeout=_CONNECT_TIMEOUT_S,
+                max_size=None,
+            )
+        except Exception as exc:
+            self._socket = None
+            gap = _BACKOFF_S[min(self._failures, len(_BACKOFF_S) - 1)]
+            self._failures += 1
+            self._next_attempt_at = time.monotonic() + gap
+            _log.debug("hermes3d-office-bridge: connect failed (%s); retry in %ss", exc, gap)
+            return False
+
+        self._failures = 0
+        self._next_attempt_at = 0.0
+        return True
+
+    def _drain(self) -> None:
+        while True:
+            item = self._queue.get()
+            if item is _STOP:
+                self._close_socket()
+                return
+            if not isinstance(item, tuple):
+                continue
+            queued_at, line = item
+            if time.monotonic() - queued_at > _MAX_FRAME_AGE_S:
+                continue
+            if not self._connect():
+                continue
+            try:
+                self._socket.send(line)  # type: ignore[union-attr]
+            except Exception as exc:
+                _log.debug("hermes3d-office-bridge: send failed: %s", exc)
+                self._close_socket()
+
+    def _close_socket(self) -> None:
+        socket, self._socket = self._socket, None
+        if socket is None:
+            return
+        try:
+            socket.close()
+        except Exception:
+            pass
+
+    def close(self) -> None:
+        self._inert = True
+        try:
+            self._queue.put_nowait(_STOP)
+        except queue.Full:
+            pass

--- a/server/hermes-agent/bridge.js
+++ b/server/hermes-agent/bridge.js
@@ -18,6 +18,7 @@ const { EventEmitter } = require("node:events");
 const { randomUUID } = require("node:crypto");
 
 const { HermesAgentJsonRpcClient, redactUrl } = require("./jsonrpc-client");
+const { createOfficeSpeechSubscriber } = require("./office-speech");
 
 /** Mirrors the numeric WebSocket readyState constants the proxy compares against. */
 const CONNECTING = 0;
@@ -242,6 +243,8 @@ function createHermesAgentUpstream(options) {
    */
   let agentRoster = [fallbackAgent()];
   let defaultAgentId = AGENT_ID;
+  /** Optional feed of turns driven from other clients; see ./office-speech.js. */
+  let officeSpeech = null;
   /** runId -> { sessionKey, runtimeId, buffer, aborted } */
   const activeRuns = new Map();
   /** sessionKey -> runId, so session-scoped events find their run. */
@@ -477,8 +480,42 @@ function createHermesAgentUpstream(options) {
     }
   };
 
+  /**
+   * Relay a turn published by the office bridge plugin.
+   *
+   * The plugin names the profile that spoke, and Hermes3D names each agent
+   * after its profile, so the two line up directly. A turn from a profile this
+   * connection does not know about is dropped rather than guessed at.
+   */
+  const handlePublishedTurn = (turn) => {
+    const agent = agentRoster.find((a) => a.id === turn.profile);
+    if (!agent) {
+      log(`[office-speech] no agent for profile "${turn.profile}"; turn ignored`);
+      return;
+    }
+    emitEvent("office.speech", {
+      agentId: agent.id,
+      name: agent.name,
+      text: turn.text,
+      atMs: turn.atMs,
+      sessionId: turn.sessionId,
+    });
+  };
+
+  const startOfficeSpeech = () => {
+    if (officeSpeech) return;
+    officeSpeech = createOfficeSpeechSubscriber({
+      url,
+      token,
+      onTurn: handlePublishedTurn,
+      log,
+    });
+  };
+
   const handleConnect = async (id) => {
     await loadAgentRoster();
+    // Only worth subscribing once the roster exists to map turns onto.
+    startOfficeSpeech();
     const agents = agentRoster.map((a) => ({
       agentId: a.id,
       name: a.name,
@@ -866,15 +903,22 @@ function createHermesAgentUpstream(options) {
     });
   };
 
+  const stopOfficeSpeech = () => {
+    officeSpeech?.close();
+    officeSpeech = null;
+  };
+
   upstream.close = (code, reason) => {
     closed = true;
     upstream.readyState = CLOSED;
+    stopOfficeSpeech();
     client.close(code, reason);
   };
 
   upstream.terminate = () => {
     closed = true;
     upstream.readyState = CLOSED;
+    stopOfficeSpeech();
     client.terminate();
   };
 
@@ -887,6 +931,7 @@ function createHermesAgentUpstream(options) {
   client.on("close", (code, reason) => {
     closed = true;
     upstream.readyState = CLOSED;
+    stopOfficeSpeech();
     upstream.emit("close", code, Buffer.from(String(reason ?? "")));
   });
 

--- a/server/hermes-agent/office-speech.js
+++ b/server/hermes-agent/office-speech.js
@@ -1,0 +1,200 @@
+/**
+ * Subscriber for agent turns published by the office bridge plugin.
+ *
+ * A hermes-agent backend delivers message events only to the client that
+ * submitted the prompt, so an office watching from the outside never sees the
+ * chatter when you talk to your agents somewhere else — the desktop app, the
+ * TUI, the CLI. The companion plugin in `plugins/hermes3d-office-bridge`
+ * republishes each finished turn on the backend's event bus; this reads that
+ * bus and hands the turns to the bridge.
+ *
+ * The subscription is entirely optional. A backend without the plugin simply
+ * never publishes, so the office behaves exactly as it did before. Connection
+ * failures retry quietly rather than disturbing the gateway session.
+ */
+
+const { WebSocket } = require("ws");
+
+/** Where the dashboard fans published frames out to subscribers. */
+const HERMES_AGENT_EVENTS_PATH = "/api/events";
+
+/** Must match the plugin's default and the backend's channel-name rules. */
+const DEFAULT_CHANNEL = "hermes3d";
+
+const RECONNECT_BACKOFF_MS = [1_000, 2_000, 5_000, 15_000, 30_000];
+
+/** Frame shape the plugin emits; anything else on the channel is ignored. */
+const FRAME_KIND = "agent.turn";
+
+/**
+ * A turn older than this is dropped. Reconnecting can deliver a backlog, and
+ * replaying stale speech would huddle idle characters for no reason.
+ */
+const MAX_TURN_AGE_MS = 20_000;
+
+/** Same loopback-Host fallback the JSON-RPC client uses; see its rationale. */
+const LOOPBACK_HOST_HEADER = "localhost";
+
+const buildEventsUrl = (baseUrl, token, channel) => {
+  const raw = typeof baseUrl === "string" ? baseUrl.trim() : "";
+  if (!raw) throw new Error("hermes-agent URL is empty.");
+
+  const parsed = new URL(raw);
+  if (parsed.protocol === "https:") parsed.protocol = "wss:";
+  else if (parsed.protocol === "http:") parsed.protocol = "ws:";
+  else if (parsed.protocol !== "ws:" && parsed.protocol !== "wss:") {
+    throw new Error(`Unsupported scheme "${parsed.protocol}" for a hermes-agent URL.`);
+  }
+
+  parsed.pathname = HERMES_AGENT_EVENTS_PATH;
+  parsed.searchParams.set("channel", channel || DEFAULT_CHANNEL);
+  if (typeof token === "string" && token.trim()) {
+    parsed.searchParams.set("token", token.trim());
+  }
+  return parsed.toString();
+};
+
+const redactUrl = (url) => String(url).replace(/([?&]token=)[^&]*/gi, "$1***");
+
+/**
+ * Validate one published frame.
+ *
+ * Returns null for anything that is not a well-formed, recent turn: the
+ * channel is shared, so unrelated or malformed traffic must not reach the
+ * office.
+ */
+const parseTurnFrame = (raw, nowMs = Date.now()) => {
+  let frame;
+  try {
+    frame = JSON.parse(typeof raw === "string" ? raw : String(raw));
+  } catch {
+    return null;
+  }
+  if (!frame || typeof frame !== "object") return null;
+  if (frame.kind !== FRAME_KIND) return null;
+
+  const profile = typeof frame.profile === "string" ? frame.profile.trim() : "";
+  const text = typeof frame.text === "string" ? frame.text.trim() : "";
+  if (!profile || !text) return null;
+
+  const atMs = Number.isFinite(frame.atMs) ? Number(frame.atMs) : nowMs;
+  if (nowMs - atMs > MAX_TURN_AGE_MS) return null;
+
+  return {
+    profile,
+    text,
+    sessionId: typeof frame.sessionId === "string" ? frame.sessionId : "",
+    atMs,
+  };
+};
+
+/**
+ * Subscribe to published turns.
+ *
+ * `onTurn` is called with `{ profile, text, sessionId, atMs }`. Returns a
+ * handle with `close()`.
+ */
+function createOfficeSpeechSubscriber(options) {
+  const {
+    url,
+    token,
+    channel = DEFAULT_CHANNEL,
+    onTurn,
+    hostHeader = "",
+    loopbackHostFallback = true,
+    log = () => {},
+  } = options || {};
+
+  let eventsUrl;
+  try {
+    eventsUrl = buildEventsUrl(url, token, channel);
+  } catch (err) {
+    log(`[office-speech] disabled: ${err.message}`);
+    return { close() {} };
+  }
+
+  let socket = null;
+  let closed = false;
+  let failures = 0;
+  let timer = null;
+  let triedLoopbackHost = false;
+
+  const scheduleReconnect = () => {
+    if (closed || timer) return;
+    const gap = RECONNECT_BACKOFF_MS[Math.min(failures, RECONNECT_BACKOFF_MS.length - 1)];
+    failures += 1;
+    timer = setTimeout(() => {
+      timer = null;
+      open(triedLoopbackHost ? LOOPBACK_HOST_HEADER : hostHeader);
+    }, gap);
+    if (typeof timer.unref === "function") timer.unref();
+  };
+
+  function open(host) {
+    if (closed) return;
+    const wsOptions = {};
+    if (host) wsOptions.headers = { Host: host };
+
+    const ws = new WebSocket(eventsUrl, wsOptions);
+    socket = ws;
+
+    ws.on("open", () => {
+      failures = 0;
+      log(`[office-speech] subscribed to ${redactUrl(eventsUrl)}`);
+    });
+
+    ws.on("message", (raw) => {
+      const asText = Buffer.isBuffer(raw) ? raw.toString() : raw;
+      const turn = parseTurnFrame(asText);
+      if (!turn) {
+        log("[office-speech] frame rejected by parser");
+        return;
+      }
+      try {
+        onTurn?.(turn);
+      } catch (err) {
+        log(`[office-speech] handler failed: ${err.message}`);
+      }
+    });
+
+    ws.on("close", (code) => {
+      if (closed) return;
+      // A loopback-bound backend refuses a foreign Host; retry once the way
+      // the JSON-RPC client does before falling back to plain reconnects.
+      if (code === 4403 && loopbackHostFallback && !host && !triedLoopbackHost) {
+        triedLoopbackHost = true;
+        open(LOOPBACK_HOST_HEADER);
+        return;
+      }
+      scheduleReconnect();
+    });
+
+    ws.on("error", () => {
+      // `close` always follows, which is where reconnects are scheduled.
+    });
+  }
+
+  open(hostHeader);
+
+  return {
+    close() {
+      closed = true;
+      if (timer) clearTimeout(timer);
+      timer = null;
+      try {
+        socket?.close();
+      } catch {
+        // Already gone.
+      }
+    },
+  };
+}
+
+module.exports = {
+  DEFAULT_CHANNEL,
+  HERMES_AGENT_EVENTS_PATH,
+  MAX_TURN_AGE_MS,
+  buildEventsUrl,
+  createOfficeSpeechSubscriber,
+  parseTurnFrame,
+};

--- a/src/features/office/screens/OfficeScreen.tsx
+++ b/src/features/office/screens/OfficeScreen.tsx
@@ -187,6 +187,7 @@ import {
   type OfficePhoneCallRequest,
   type OfficeTextMessageRequest,
 } from "@/lib/office/eventTriggers";
+import { toOfficeSpeechFeedEvent } from "@/lib/office/officeSpeech";
 import { buildOfficeSkillTriggerHoldMaps } from "@/lib/office/places";
 import type { MockPhoneCallScenario } from "@/lib/office/call/types";
 import type { MockTextMessageScenario } from "@/lib/office/text/types";
@@ -2658,6 +2659,18 @@ export function OfficeScreen({
           phoneCallByAgentId: officeTriggerStateRef.current.phoneCallByAgentId,
         })
       ) {
+        return;
+      }
+      if (event.event === "office.speech") {
+        // A turn driven from another client (desktop app, TUI, CLI). It has no
+        // run of its own, so it bypasses the chat/run machinery and lands
+        // straight in the feed, which is what the 3D scene watches for speech.
+        const speech = toOfficeSpeechFeedEvent(event.payload, {
+          normalizeText: (value) => normalizeOfficeFeedText(value, 240),
+        });
+        if (speech) {
+          setFeedEvents((previous) => [speech, ...previous].slice(0, 6));
+        }
         return;
       }
       taskBoardEventHandlerRef.current(event);

--- a/src/features/retro-office/RetroOffice3D.tsx
+++ b/src/features/retro-office/RetroOffice3D.tsx
@@ -149,6 +149,7 @@ import {
   CONVERSATION_WINDOW_MS,
   conversationTalkTurn,
   deriveConversationGroups,
+  reconcileConversationGroups,
   type ConversationGroup,
   type ConversationSpeechSample,
 } from "@/features/retro-office/core/conversations";
@@ -2922,16 +2923,36 @@ export function RetroOffice3D({
     return names;
   }, [agents]);
 
+  // Every unseen reply in the feed counts, not just the newest one. Agents
+  // answering the same group message land in one render, and reading only the
+  // head would keep all but the last speaker out of the conversation.
+  const conversationSeenRepliesRef = useRef<Set<string> | null>(null);
   useEffect(() => {
-    const latest = feedEvents[0];
-    if (!latest || latest.kind !== "reply") return;
-    const text = latest.text.trim();
-    if (!text) return;
-    conversationSamplesRef.current.set(latest.id, {
-      agentId: latest.id,
-      text,
-      atMs: Date.now(),
-    });
+    const firstPass = conversationSeenRepliesRef.current === null;
+    const seen = conversationSeenRepliesRef.current ?? new Set<string>();
+    conversationSeenRepliesRef.current = seen;
+    const now = Date.now();
+    for (const event of feedEvents) {
+      if (event.kind !== "reply") continue;
+      const text = event.text.trim();
+      if (!text) continue;
+      const key = `${event.id}:${event.ts}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      // Replies already on screen at mount are history, not a live conversation.
+      if (firstPass) continue;
+      conversationSamplesRef.current.set(event.id, {
+        agentId: event.id,
+        text,
+        atMs: now,
+      });
+    }
+    // The feed keeps a handful of entries; bound the memo to match.
+    if (seen.size > 64) {
+      conversationSeenRepliesRef.current = new Set(
+        feedEvents.map((event) => `${event.id}:${event.ts}`),
+      );
+    }
   }, [feedEvents]);
 
   useEffect(() => {
@@ -2960,25 +2981,7 @@ export function RetroOffice3D({
       });
       const known = conversationKnownGroupsRef.current;
       if (suppressSceneSpeechBubbles) known.clear();
-      for (const group of derived) {
-        const entry = known.get(group.id);
-        if (entry) {
-          entry.group = group;
-          continue;
-        }
-        // A grown conversation supersedes the smaller huddle it absorbed.
-        for (const [otherId, other] of known) {
-          if (
-            otherId !== group.id &&
-            other.group.participantIds.every((id) =>
-              group.participantIds.includes(id),
-            )
-          ) {
-            known.delete(otherId);
-          }
-        }
-        known.set(group.id, { group, formedAtMs: now });
-      }
+      reconcileConversationGroups({ derived, known, nowMs: now });
       // A huddle lives until its speech window lapses, but never less than the
       // minimum lifetime — otherwise a one-shot mention dissolves the circle
       // while distant participants are still walking over. The movement tick

--- a/src/features/retro-office/core/constants.ts
+++ b/src/features/retro-office/core/constants.ts
@@ -43,8 +43,8 @@ export const WORLD_H = CANVAS_H * SCALE;
 export const PING_PONG_SESSION_MS = 60_000;
 export const PING_PONG_APPROACH_SPEED = WALK_SPEED * 1.8;
 // Conversations are timeboxed by the speech window, so distant participants
-// hurry over; at plain WALK_SPEED an agent crossing the office would arrive
-// after the chat already ended.
-export const CONVERSATION_APPROACH_SPEED = WALK_SPEED * 2.2;
+// hurry over. The floor is 1800 units across: at 2.2x an agent on the far side
+// was still walking a minute after the group chat it was answering.
+export const CONVERSATION_APPROACH_SPEED = WALK_SPEED * 4.5;
 export const PING_PONG_BALL_RADIUS = 0.055;
 export const PING_PONG_TABLE_SURFACE_Y = 0.465;

--- a/src/features/retro-office/core/conversations.ts
+++ b/src/features/retro-office/core/conversations.ts
@@ -181,6 +181,67 @@ export const deriveConversationGroups = (options: {
     .sort((a, b) => a.id.localeCompare(b.id));
 };
 
+export interface KnownConversationGroup {
+  group: ConversationGroup;
+  formedAtMs: number;
+}
+
+/**
+ * Fold freshly derived groups into the huddles already on the floor.
+ *
+ * Membership churns as speech samples age in and out of the window, and the
+ * naive "add whatever was derived" rule let two huddles claim the same agent —
+ * which hands that agent two circles and leaves it walking between them
+ * forever. Three cases, in order:
+ *
+ * - Same membership: the huddle continues, keep its formation time and slots.
+ * - Subset of a live huddle: a speaker's sample simply aged out. Still the same
+ *   conversation, so it counts as activity rather than re-seating the circle.
+ * - Anything else: the derived group is the fresher truth and retires every
+ *   huddle it overlaps, so no agent is ever in two groups.
+ */
+export const reconcileConversationGroups = (options: {
+  derived: ConversationGroup[];
+  known: Map<string, KnownConversationGroup>;
+  nowMs: number;
+}): Map<string, KnownConversationGroup> => {
+  const { derived, known, nowMs } = options;
+  for (const group of derived) {
+    const entry = known.get(group.id);
+    if (entry) {
+      entry.group = group;
+      continue;
+    }
+    const containing = [...known.values()].find((other) =>
+      group.participantIds.every((id) =>
+        other.group.participantIds.includes(id),
+      ),
+    );
+    if (containing) {
+      containing.group = {
+        ...containing.group,
+        lastActivityMs: Math.max(
+          containing.group.lastActivityMs,
+          group.lastActivityMs,
+        ),
+      };
+      continue;
+    }
+    for (const [otherId, other] of known) {
+      if (
+        otherId !== group.id &&
+        other.group.participantIds.some((id) =>
+          group.participantIds.includes(id),
+        )
+      ) {
+        known.delete(otherId);
+      }
+    }
+    known.set(group.id, { group, formedAtMs: nowMs });
+  }
+  return known;
+};
+
 // Rings of candidate centres, nearest first; the outer rings let a huddle
 // escape a whole blocked furniture cluster rather than just a single desk.
 const CENTER_CANDIDATE_OFFSETS: [number, number][] = [

--- a/src/features/retro-office/objects/agents.tsx
+++ b/src/features/retro-office/objects/agents.tsx
@@ -509,10 +509,18 @@ export const AgentModel = memo(function AgentModel({
         agent.state === "standing" &&
         (agent.frame + blinkSeed * 11) % 320 < 42);
     const bumpTalking = (agent.bumpTalkUntil ?? 0) > Date.now();
+    // Standing in a huddle, everyone holds the same reply, and the bubbles are
+    // close enough to overlap into an unreadable stack. The speaking turn
+    // already rotates around the circle, so let it own the bubble too.
+    const waitingForTurnInHuddle =
+      agent.conversationGroupId !== undefined &&
+      agent.state === "standing" &&
+      !bumpTalking;
 
     if (speechBubbleRef.current) {
       const bubbleVisible =
         !suppressSpeechBubble &&
+        !waitingForTurnInHuddle &&
         (showSpeech || bumpTalking || ambientBubbleVisible);
       speechBubbleRef.current.visible = bubbleVisible;
       if (bubbleVisible) {

--- a/src/lib/office/officeSpeech.ts
+++ b/src/lib/office/officeSpeech.ts
@@ -1,0 +1,73 @@
+/**
+ * Office feed entries for turns driven from outside Hermes3D.
+ *
+ * A hermes-agent backend sends message events only to the client that started
+ * the prompt, so chatting in the desktop app or the TUI leaves the office
+ * blind. The companion plugin (`plugins/hermes3d-office-bridge`) republishes
+ * each finished turn, the server bridge forwards it as an `office.speech`
+ * gateway event, and this turns that event into the same kind of feed entry a
+ * locally driven reply produces.
+ *
+ * Feeding the normal reply path is what makes the rest work for free: the 3D
+ * scene already derives conversation huddles from reply activity, so agents
+ * answering the same group message gather into a circle without any
+ * conversation-specific plumbing here.
+ */
+
+export interface OfficeSpeechFeedEvent {
+  id: string;
+  name: string;
+  text: string;
+  ts: number;
+  kind: "reply";
+}
+
+/**
+ * A turn older than this is ignored. Reconnecting can replay a short backlog,
+ * and stale speech would gather idle characters for a conversation that has
+ * already finished.
+ */
+export const OFFICE_SPEECH_MAX_AGE_MS = 20_000;
+
+interface ParseOptions {
+  nowMs?: number;
+  normalizeText?: (value: string) => string;
+}
+
+const asString = (value: unknown): string =>
+  typeof value === "string" ? value.trim() : "";
+
+/**
+ * Validate an `office.speech` payload.
+ *
+ * Returns null for anything unusable — a missing agent, empty text, or a turn
+ * that arrived too late to be worth animating.
+ */
+export const toOfficeSpeechFeedEvent = (
+  payload: unknown,
+  options: ParseOptions = {},
+): OfficeSpeechFeedEvent | null => {
+  const { nowMs = Date.now(), normalizeText = (value: string) => value.trim() } =
+    options;
+
+  if (!payload || typeof payload !== "object") return null;
+  const record = payload as Record<string, unknown>;
+
+  const id = asString(record.agentId);
+  if (!id) return null;
+
+  const text = normalizeText(asString(record.text));
+  if (!text) return null;
+
+  const rawTs = record.atMs;
+  const ts = typeof rawTs === "number" && Number.isFinite(rawTs) ? rawTs : nowMs;
+  if (nowMs - ts > OFFICE_SPEECH_MAX_AGE_MS) return null;
+
+  return {
+    id,
+    name: asString(record.name) || "Agent",
+    text,
+    ts,
+    kind: "reply",
+  };
+};

--- a/tests/unit/officeConversations.test.ts
+++ b/tests/unit/officeConversations.test.ts
@@ -6,6 +6,11 @@ import {
   CONVERSATION_MIN_RADIUS,
   conversationTalkTurn,
   deriveConversationGroups,
+  reconcileConversationGroups,
+} from "../../src/features/retro-office/core/conversations";
+import type {
+  ConversationGroup,
+  KnownConversationGroup,
 } from "../../src/features/retro-office/core/conversations";
 import { planChatterBlip } from "../../src/features/retro-office/systems/conversationChatterAudio";
 import { formatAgentSubtitleText } from "../../src/features/retro-office/objects/agents";
@@ -233,5 +238,76 @@ describe("formatAgentSubtitleText", () => {
   it("collapses whitespace and handles empties", () => {
     expect(formatAgentSubtitleText("   ")).toBe("");
     expect(formatAgentSubtitleText("qa\n  lead")).toBe("qa lead");
+  });
+});
+
+describe("reconcileConversationGroups", () => {
+  const group = (ids: string[], lastActivityMs = NOW): ConversationGroup => ({
+    id: [...ids].sort().join("+"),
+    participantIds: [...ids].sort(),
+    lastActivityMs,
+  });
+  const known = (
+    entries: [ConversationGroup, number][],
+  ): Map<string, KnownConversationGroup> =>
+    new Map(
+      entries.map(([entry, formedAtMs]) => [entry.id, { group: entry, formedAtMs }]),
+    );
+
+  it("keeps a huddle's formation time when its membership repeats", () => {
+    const state = known([[group(["allan", "owen"], NOW - 9_000), NOW - 30_000]]);
+    reconcileConversationGroups({
+      derived: [group(["allan", "owen"])],
+      known: state,
+      nowMs: NOW,
+    });
+    expect([...state.keys()]).toEqual(["allan+owen"]);
+    expect(state.get("allan+owen")?.formedAtMs).toBe(NOW - 30_000);
+    expect(state.get("allan+owen")?.group.lastActivityMs).toBe(NOW);
+  });
+
+  it("treats a shrunken group as activity on the huddle already standing", () => {
+    const state = known([
+      [group(["allan", "owen", "rev"], NOW - 9_000), NOW - 30_000],
+    ]);
+    reconcileConversationGroups({
+      derived: [group(["allan", "owen"])],
+      known: state,
+      nowMs: NOW,
+    });
+    // Re-seating the circle here would restart the walk for everyone.
+    expect([...state.keys()]).toEqual(["allan+owen+rev"]);
+    expect(state.get("allan+owen+rev")?.formedAtMs).toBe(NOW - 30_000);
+    expect(state.get("allan+owen+rev")?.group.lastActivityMs).toBe(NOW);
+  });
+
+  it("retires the smaller huddle a grown conversation absorbed", () => {
+    const state = known([[group(["allan", "owen"]), NOW - 5_000]]);
+    reconcileConversationGroups({
+      derived: [group(["allan", "owen", "rev"])],
+      known: state,
+      nowMs: NOW,
+    });
+    expect([...state.keys()]).toEqual(["allan+owen+rev"]);
+  });
+
+  it("never leaves an agent in two huddles at once", () => {
+    const state = known([[group(["allan", "owen"]), NOW - 5_000]]);
+    reconcileConversationGroups({
+      derived: [group(["owen", "samuel"])],
+      known: state,
+      nowMs: NOW,
+    });
+    expect([...state.keys()]).toEqual(["owen+samuel"]);
+  });
+
+  it("leaves an unrelated huddle running", () => {
+    const state = known([[group(["allan", "owen"]), NOW - 5_000]]);
+    reconcileConversationGroups({
+      derived: [group(["rev", "samuel"])],
+      known: state,
+      nowMs: NOW,
+    });
+    expect([...state.keys()].sort()).toEqual(["allan+owen", "rev+samuel"]);
   });
 });

--- a/tests/unit/officeSpeech.test.ts
+++ b/tests/unit/officeSpeech.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  OFFICE_SPEECH_MAX_AGE_MS,
+  toOfficeSpeechFeedEvent,
+} from "@/lib/office/officeSpeech";
+
+const NOW = 1_700_000_000_000;
+
+const payload = (overrides: Record<string, unknown> = {}) => ({
+  agentId: "pr-fixer",
+  name: "Pr Fixer",
+  text: "Good morning!",
+  atMs: NOW,
+  sessionId: "20260820_104030_9942e6",
+  ...overrides,
+});
+
+describe("toOfficeSpeechFeedEvent", () => {
+  it("turns a published turn into a reply feed entry", () => {
+    expect(toOfficeSpeechFeedEvent(payload(), { nowMs: NOW })).toEqual({
+      id: "pr-fixer",
+      name: "Pr Fixer",
+      text: "Good morning!",
+      ts: NOW,
+      kind: "reply",
+    });
+  });
+
+  it("keys the entry on the agent id so the scene attributes the speech", () => {
+    const event = toOfficeSpeechFeedEvent(payload({ agentId: "pr-reviewer" }), {
+      nowMs: NOW,
+    });
+    expect(event?.id).toBe("pr-reviewer");
+  });
+
+  it("applies the caller's text normaliser", () => {
+    const event = toOfficeSpeechFeedEvent(payload({ text: "a   b" }), {
+      nowMs: NOW,
+      normalizeText: (value) => value.replace(/\s+/g, " ").toUpperCase(),
+    });
+    expect(event?.text).toBe("A B");
+  });
+
+  it("falls back to a generic name when the payload omits one", () => {
+    const event = toOfficeSpeechFeedEvent(payload({ name: "" }), { nowMs: NOW });
+    expect(event?.name).toBe("Agent");
+  });
+
+  it("defaults the timestamp when the payload has none", () => {
+    const event = toOfficeSpeechFeedEvent(payload({ atMs: undefined }), {
+      nowMs: NOW,
+    });
+    expect(event?.ts).toBe(NOW);
+  });
+
+  it.each([
+    ["a non-object payload", "nope"],
+    ["a null payload", null],
+    ["a missing agent id", payload({ agentId: "" })],
+    ["text that is only whitespace", payload({ text: "   " })],
+  ])("rejects %s", (_label, input) => {
+    expect(toOfficeSpeechFeedEvent(input, { nowMs: NOW })).toBeNull();
+  });
+
+  it("drops a stale turn so a reconnect backlog cannot huddle idle agents", () => {
+    const stale = payload({ atMs: NOW - OFFICE_SPEECH_MAX_AGE_MS - 1 });
+    expect(toOfficeSpeechFeedEvent(stale, { nowMs: NOW })).toBeNull();
+  });
+
+  it("keeps a turn that is old but still inside the window", () => {
+    const recent = payload({ atMs: NOW - OFFICE_SPEECH_MAX_AGE_MS + 1_000 });
+    expect(toOfficeSpeechFeedEvent(recent, { nowMs: NOW })).not.toBeNull();
+  });
+});

--- a/tests/unit/officeSpeechSubscriber.test.ts
+++ b/tests/unit/officeSpeechSubscriber.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from "vitest";
+
+const { MAX_TURN_AGE_MS, buildEventsUrl, parseTurnFrame } = await import(
+  "../../server/hermes-agent/office-speech"
+);
+
+const NOW = 1_700_000_000_000;
+
+const frame = (overrides: Record<string, unknown> = {}) =>
+  JSON.stringify({
+    v: 1,
+    kind: "agent.turn",
+    profile: "pr-fixer",
+    text: "Good morning!",
+    sessionId: "20260820_104030_9942e6",
+    atMs: NOW,
+    ...overrides,
+  });
+
+describe("buildEventsUrl", () => {
+  it("points a bare origin at the subscriber endpoint", () => {
+    const url = new URL(buildEventsUrl("ws://localhost:9119", "secret", "hermes3d"));
+    expect(url.pathname).toBe("/api/events");
+    expect(url.searchParams.get("channel")).toBe("hermes3d");
+    expect(url.searchParams.get("token")).toBe("secret");
+  });
+
+  it("upgrades http and https to their WebSocket schemes", () => {
+    expect(buildEventsUrl("http://localhost:9119", "t", "c")).toMatch(/^ws:/);
+    expect(buildEventsUrl("https://box.ts.net:10000", "t", "c")).toMatch(/^wss:/);
+  });
+
+  it("replaces a gateway path rather than appending to it", () => {
+    const url = new URL(buildEventsUrl("ws://localhost:9119/api/ws", "t", "c"));
+    expect(url.pathname).toBe("/api/events");
+  });
+
+  it("omits the token when none is configured", () => {
+    const url = new URL(buildEventsUrl("ws://localhost:9119", "", "c"));
+    expect(url.searchParams.has("token")).toBe(false);
+  });
+
+  it.each([
+    ["an empty url", ""],
+    ["an unsupported scheme", "ftp://localhost:9119"],
+  ])("rejects %s", (_label, input) => {
+    expect(() => buildEventsUrl(input, "t", "c")).toThrow();
+  });
+});
+
+describe("parseTurnFrame", () => {
+  it("accepts a well-formed turn", () => {
+    expect(parseTurnFrame(frame(), NOW)).toEqual({
+      profile: "pr-fixer",
+      text: "Good morning!",
+      sessionId: "20260820_104030_9942e6",
+      atMs: NOW,
+    });
+  });
+
+  it.each([
+    ["malformed json", "{not json"],
+    ["another publisher's frame", JSON.stringify({ kind: "something.else" })],
+    ["a turn with no profile", frame({ profile: "" })],
+    ["a turn with no text", frame({ text: "  " })],
+  ])("ignores %s", (_label, input) => {
+    expect(parseTurnFrame(input, NOW)).toBeNull();
+  });
+
+  it("drops a stale turn from a reconnect backlog", () => {
+    expect(parseTurnFrame(frame({ atMs: NOW - MAX_TURN_AGE_MS - 1 }), NOW)).toBeNull();
+  });
+
+  it("treats a turn with no timestamp as current", () => {
+    expect(parseTurnFrame(frame({ atMs: undefined }), NOW)?.atMs).toBe(NOW);
+  });
+});


### PR DESCRIPTION
## Summary

Hermes3D is a visualiser, not a chat client. When you talk to your agents in the desktop app, the TUI, or the CLI, the office had no way to know it happened — message events on the JSON-RPC gateway reach only the client that submitted the prompt, so an office watching from outside sees session activity but never the text.

This closes the gap with an **optional, user-installable plugin** rather than by pulling chat into Hermes3D:

- `plugins/hermes3d-office-bridge` observes finished turns via `post_llm_call` and republishes them on the backend's event bus. Observation only — no tool, no prompt-token cost, and it cannot delay or alter a turn. Plugins are scoped per `HERMES_HOME`, so `install.sh` covers the default home and every profile.
- The Studio bridge subscribes to that bus and relays turns as `office.speech`, which lands in the office feed and drives the huddle logic that already exists.
- [`docs/office-conversation-bridge.md`](docs/office-conversation-bridge.md) documents install, the data flow, what you see, config, and troubleshooting.

Three bugs the live runs surfaced, all fixed here:

- The office sampled only the **newest** feed reply, so agents answering the same group message within one render were dropped and no group ever formed.
- Group bookkeeping could leave an agent in **two overlapping huddles**, handing it two circles and leaving it walking between them forever. Reconciliation is now an explicit rule extracted into `reconcileConversationGroups` and unit tested.
- At 2.2x walk speed an agent on the far side of the 1800-unit floor was still walking a minute after the chat it was answering.

Also gates huddle speech bubbles on the speaking turn — standing in a circle everyone holds the same reply, and the bubbles overlapped into an unreadable stack.

## Test plan

- [x] `npm run typecheck` clean.
- [x] `npm run lint` — no new errors (the 6 in `RetroOffice3D.tsx` are pre-existing).
- [x] `npm run test -- --run` — 29 new tests; the 3 failures are pre-existing and identical on the base commit.
- [x] Live end-to-end against a real `hermes serve` backend: publishing three agent turns onto the event bus forms one group of three, and all three walk over and stand in the circle facing each other, with the bubble rotating between them.

Made with [Cursor](https://cursor.com)