### PR TITLE
Make the office bridge plugin work under profiles and one-shot turns

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,7 @@ test-results
 
 # Agent/QA review screenshots (never commit).
 screenshots-*/
+
+# Bytecode from the bundled Python plugin.
+__pycache__/
+*.pyc

--- a/docs/office-conversation-bridge.md
+++ b/docs/office-conversation-bridge.md
@@ -28,6 +28,11 @@ silently does nothing.
 echo "HERMES_DASHBOARD_SESSION_TOKEN=$(openssl rand -hex 32)" >> ~/.hermes/.env
 ```
 
+  `~/.hermes/.env` is the only place you need it, even if you run profiles.
+  Profiles each have their own `.env`, but this token identifies the one local
+  dashboard they all publish to, so the plugin falls back to the default home
+  rather than making you copy the same secret into every profile.
+
 ## Install
 
 Run the installer from your Hermes3D checkout, on the machine that runs the
@@ -37,12 +42,23 @@ backend:
 ./plugins/hermes3d-office-bridge/install.sh
 ```
 
-Then restart the backend (`hermes serve …`) so the plugin loads.
+Then restart anything already running an agent so the plugin loads — the
+backend (`hermes serve …`) and, if it is open, the desktop app. A process that
+started before the install keeps the old plugin state until it restarts.
 
 Plugins are scoped to a `HERMES_HOME`, and every Hermes profile has its own, so
 a plugin installed only in the default home stays silent for every other agent.
 The installer copies the plugin into the default home **and each profile**, and
 enables it in all of them. Re-running it is safe.
+
+Check it landed:
+
+```bash
+hermes plugins list | grep hermes3d          # default home
+hermes -p <profile> plugins list | grep hermes3d
+```
+
+Both should report `enabled`.
 
 To remove it:
 
@@ -138,5 +154,6 @@ only if something else is already using `hermes3d` on your event bus.
 | Nothing happens when you chat | Plugin not loaded | Restart the backend after installing; check `hermes plugins list` |
 | Works for one agent, not the others | Installed in the default home only | Re-run `install.sh`, which covers every profile |
 | Warning about the session token at install | Token not pinned | Add `HERMES_DASHBOARD_SESSION_TOKEN` to `~/.hermes/.env` and restart |
+| Still silent with everything enabled | A stale `HERMES_DASHBOARD_SESSION_TOKEN` exported in the shell that started the backend overrides the pinned one | `unset` it, or start the backend from a clean shell |
 | One agent replies but no circle forms | A conversation needs two speakers | Ask a question the whole group answers |
 | Agents gather but the office is silent | Browser audio is locked until you interact | Click once anywhere on the page |

--- a/plugins/hermes3d-office-bridge/__init__.py
+++ b/plugins/hermes3d-office-bridge/__init__.py
@@ -20,6 +20,7 @@ swallows its own failures.
 
 from __future__ import annotations
 
+import atexit
 import logging
 import time
 from typing import Any, Optional
@@ -82,6 +83,34 @@ def build_publish_url(*, host: str, port: int, channel: str, token: str) -> str:
     )
 
 
+def _default_home_token() -> str:
+    """Read the token out of the default home's ``.env``.
+
+    Profiles each get their own ``HERMES_HOME`` and their own ``.env``, so a
+    profile-scoped process never sees a token pinned in the default home. That
+    matters here because this token is not profile-level config: it identifies
+    the one local dashboard every profile on the machine publishes to. Asking
+    users to copy the same secret into five ``.env`` files would be worse.
+    """
+    from pathlib import Path
+
+    try:
+        from hermes_constants import get_default_hermes_root
+
+        root = Path(get_default_hermes_root())
+    except Exception:
+        root = Path.home() / ".hermes"
+
+    try:
+        for line in (root / ".env").read_text(encoding="utf-8").splitlines():
+            key, sep, value = line.partition("=")
+            if sep and key.strip() == "HERMES_DASHBOARD_SESSION_TOKEN":
+                return value.strip().strip("'\"")
+    except OSError:
+        pass
+    return ""
+
+
 def _resolve_token() -> str:
     """The dashboard session token, which is a secret and so lives in the env.
 
@@ -90,7 +119,9 @@ def _resolve_token() -> str:
     """
     import os
 
-    return (os.environ.get("HERMES_DASHBOARD_SESSION_TOKEN") or "").strip()
+    return (
+        os.environ.get("HERMES_DASHBOARD_SESSION_TOKEN") or ""
+    ).strip() or _default_home_token()
 
 
 def _resolve_profile() -> str:
@@ -154,4 +185,8 @@ def register(ctx: Any) -> None:
             token=token,
         )
     )
+    # A one-shot CLI turn ends its process the moment the hook returns, well
+    # before a background send completes. Give the queue a bounded chance to
+    # drain so those turns reach the office too, not just long-lived backends.
+    atexit.register(_publisher.flush)
     ctx.register_hook("post_llm_call", _handle_post_llm_call)

--- a/plugins/hermes3d-office-bridge/publisher.py
+++ b/plugins/hermes3d-office-bridge/publisher.py
@@ -30,6 +30,11 @@ _log = logging.getLogger(__name__)
 _QUEUE_MAX = 128
 _CONNECT_TIMEOUT_S = 2.0
 
+# Bound on how long process exit waits for queued frames. Long enough to cover
+# a loopback connect, short enough that a one-shot CLI still feels instant. A
+# backend that is simply not running refuses immediately and costs nothing.
+_FLUSH_TIMEOUT_S = 3.0
+
 # Retry gaps after a failed connect. The office is a nicety, so a backend that
 # is down or gated should cost one short attempt every so often, not a storm.
 _BACKOFF_S: Tuple[float, ...] = (1.0, 2.0, 5.0, 15.0, 30.0)
@@ -52,6 +57,8 @@ class OfficePublisher:
         self._lock = threading.Lock()
         self._failures = 0
         self._next_attempt_at = 0.0
+        # Frames queued but not yet handled, so `flush` knows when it is done.
+        self._pending = 0
         self._inert = ws_connect is None
         if self._inert:
             _log.debug("hermes3d-office-bridge: websockets missing; publisher inert")
@@ -69,9 +76,11 @@ class OfficePublisher:
         self._ensure_worker()
         try:
             self._queue.put_nowait((time.monotonic(), line))
-            return True
         except queue.Full:
             return False
+        with self._lock:
+            self._pending += 1
+        return True
 
     def _ensure_worker(self) -> None:
         with self._lock:
@@ -114,18 +123,39 @@ class OfficePublisher:
             if item is _STOP:
                 self._close_socket()
                 return
-            if not isinstance(item, tuple):
-                continue
-            queued_at, line = item
-            if time.monotonic() - queued_at > _MAX_FRAME_AGE_S:
-                continue
-            if not self._connect():
-                continue
             try:
-                self._socket.send(line)  # type: ignore[union-attr]
-            except Exception as exc:
-                _log.debug("hermes3d-office-bridge: send failed: %s", exc)
-                self._close_socket()
+                if not isinstance(item, tuple):
+                    continue
+                queued_at, line = item
+                if time.monotonic() - queued_at > _MAX_FRAME_AGE_S:
+                    continue
+                if not self._connect():
+                    continue
+                try:
+                    self._socket.send(line)  # type: ignore[union-attr]
+                except Exception as exc:
+                    _log.debug("hermes3d-office-bridge: send failed: %s", exc)
+                    self._close_socket()
+            finally:
+                with self._lock:
+                    self._pending -= 1
+
+    def flush(self, timeout: float = _FLUSH_TIMEOUT_S) -> None:
+        """Give queued frames a bounded chance to go out before the process ends.
+
+        The sender is a daemon thread, so a short-lived process — a one-shot
+        CLI turn, a slash worker — would otherwise exit while the frame is
+        still queued and the socket is not even open yet. Returns as soon as
+        the queue is handled, whether each frame was sent or dropped.
+        """
+        if self._inert:
+            return
+        deadline = time.monotonic() + timeout
+        while time.monotonic() < deadline:
+            with self._lock:
+                if self._pending <= 0:
+                    return
+            time.sleep(0.02)
 
     def _close_socket(self) -> None:
         socket, self._socket = self._socket, None


### PR DESCRIPTION
## Summary

Installing the plugin from #12 on a real machine surfaced two paths where a turn was observed but the frame never reached the office.

- **Profiles couldn't see the token.** Each profile gets its own `HERMES_HOME` and its own `.env`, so a profile-scoped turn never saw a `HERMES_DASHBOARD_SESSION_TOKEN` pinned in the default home, and the plugin disabled itself at register time. That token isn't profile-level config — it identifies the one local dashboard every profile publishes to — so it now falls back to the default home's `.env` rather than asking users to copy the same secret into every profile.
- **One-shot turns were lost.** The sender is a daemon thread, so `hermes -z` ended its process while the frame was still queued and the socket wasn't open yet. Outstanding frames are now tracked and flushed on exit, bounded so a CLI still feels instant. A backend that isn't running refuses immediately and costs nothing.

Docs gain the profile/token note, a post-install verification step, a reminder to restart the desktop app too, and a troubleshooting row for a stale exported token shadowing the pinned one (which cost me a while to spot).

Also ignores `__pycache__/` — the bundled Python plugin generates it.

## Test plan

- [x] `flush` is bounded and leaves no pending work: returns in 0.02s against a dead backend, drops unserialisable frames without leaking a pending count, and returns immediately when inert.
- [x] Live end to end against a real backend: `hermes -p pr-fixer -z` publishes `profile=pr-fixer platform=cli` onto the channel.
- [x] Three concurrent real profile turns reach the office and gather their characters into one circle.

Made with [Cursor](https://cursor.com)