### PR TITLE
Stop the office token from breaking the Hermes desktop app

### DIFF
--- a/docs/hermes-agent-tailscale.md
+++ b/docs/hermes-agent-tailscale.md
@@ -36,17 +36,26 @@ zero-login setup below possible.
 ### 1. Pin a session token
 
 This is the shared secret between the two machines. Generate one and store it
-in `~/.hermes/.env` — Hermes loads that file at startup, so every later
-`hermes serve` picks it up with no extra flags:
+in `~/.hermes/.env` under a **dedicated name**, then hand it to the backend on
+its command line in [step 2](#2-start-the-backend-on-loopback):
 
 ```bash
-echo "HERMES_DASHBOARD_SESSION_TOKEN=$(openssl rand -hex 32)" >> ~/.hermes/.env
-grep HERMES_DASHBOARD_SESSION_TOKEN ~/.hermes/.env   # copy this for Machine B
+echo "HERMES3D_OFFICE_TOKEN=$(openssl rand -hex 32)" >> ~/.hermes/.env
+grep HERMES3D_OFFICE_TOKEN ~/.hermes/.env   # copy this for Machine B
 ```
 
 Pinning the token matters. Leave it unset and `hermes serve` invents a fresh
 random one on every start, so Studio's saved token stops matching after each
 restart.
+
+> **Do not pin `HERMES_DASHBOARD_SESSION_TOKEN` itself.** That is the variable
+> the backend reads, so pinning it looks like the obvious shortcut — but Hermes
+> loads `~/.hermes/.env` with `override=True`, which forces the value on *every*
+> backend started on this machine. The Hermes desktop app mints a fresh token
+> per launch for the backend it spawns; the pin overrides it, the app's own
+> gateway then rejects the app, and it dies at boot with "the WebSocket
+> (/api/ws) rejected the session token". A dedicated name avoids the collision:
+> only the command below opts into it.
 
 If you use profiles, `.env` is per-profile — write it to the `HERMES_HOME` of
 the profile you intend to serve.
@@ -54,7 +63,17 @@ the profile you intend to serve.
 ### 2. Start the backend on loopback
 
 ```bash
-hermes serve --host 127.0.0.1 --port 9120 --skip-build
+HERMES_DASHBOARD_SESSION_TOKEN="$HERMES3D_OFFICE_TOKEN" \
+  hermes serve --host 127.0.0.1 --port 9120 --skip-build
+```
+
+An inline assignment is not overridden by `.env`, because the pinned name there
+is different. Read the value straight out of the file if your shell has not
+exported it:
+
+```bash
+HERMES_DASHBOARD_SESSION_TOKEN="$(grep '^HERMES3D_OFFICE_TOKEN=' ~/.hermes/.env | cut -d= -f2)" \
+  hermes serve --host 127.0.0.1 --port 9120 --skip-build
 ```
 
 Notes:
@@ -68,14 +87,6 @@ Notes:
   browser UI, so the build is wasted work here.
 - `hermes serve --status` lists running servers. `hermes serve --stop` stops
   **all** Hermes web servers on the machine, not just this one.
-
-If you would rather not keep the token in `.env`, pass it inline instead —
-either form works:
-
-```bash
-HERMES_DASHBOARD_SESSION_TOKEN=<your-token> \
-  hermes serve --host 127.0.0.1 --port 9120 --skip-build
-```
 
 ### 3. Publish it on the tailnet
 
@@ -103,8 +114,8 @@ cause is that `hermes serve` was stopped.
 
 Without this, closing the terminal or rebooting takes the office offline.
 
-Neither unit below carries the token: Hermes reads it from `~/.hermes/.env` on
-its own, so the secret stays out of your service definitions.
+Both units read the token out of `~/.hermes/.env` at launch, so the secret
+stays out of your service definitions and out of `ps`.
 
 **macOS (launchd).** Save as
 `~/Library/LaunchAgents/dev.hermes3d.serve.plist`, substituting the output of
@@ -119,11 +130,9 @@ its own, so the secret stays out of your service definitions.
   <key>Label</key><string>dev.hermes3d.serve</string>
   <key>ProgramArguments</key>
   <array>
-    <string>/opt/homebrew/bin/hermes</string>
-    <string>serve</string>
-    <string>--host</string><string>127.0.0.1</string>
-    <string>--port</string><string>9120</string>
-    <string>--skip-build</string>
+    <string>/bin/sh</string>
+    <string>-c</string>
+    <string>HERMES_DASHBOARD_SESSION_TOKEN="$(grep '^HERMES3D_OFFICE_TOKEN=' "$HOME/.hermes/.env" | cut -d= -f2)" exec /opt/homebrew/bin/hermes serve --host 127.0.0.1 --port 9120 --skip-build</string>
   </array>
   <key>RunAtLoad</key><true/>
   <key>KeepAlive</key><true/>
@@ -145,7 +154,7 @@ Description=Hermes backend for Hermes3D
 After=network-online.target
 
 [Service]
-ExecStart=%h/.local/bin/hermes serve --host 127.0.0.1 --port 9120 --skip-build
+ExecStart=/bin/sh -c 'HERMES_DASHBOARD_SESSION_TOKEN="$(grep "^HERMES3D_OFFICE_TOKEN=" %h/.hermes/.env | cut -d= -f2)" exec %h/.local/bin/hermes serve --host 127.0.0.1 --port 9120 --skip-build'
 Restart=always
 
 [Install]
@@ -197,7 +206,8 @@ You should land in the office with one character per `hermes-agent` profile.
 | Symptom | Cause | Fix |
 |---|---|---|
 | `wrong version number` / `EPROTO` | `wss://` against a plaintext port | Use the port you passed to `--https`, not the `hermes serve` port |
-| Gateway closes, HTTP `403` | Token mismatch | Studio's token must equal `HERMES_DASHBOARD_SESSION_TOKEN`. If it worked until a restart, the token was never pinned — see [step 1](#1-pin-a-session-token) |
+| Gateway closes, HTTP `403` | Token mismatch | Studio's token must equal the one the backend started with. If it worked until a restart, the token was never pinned — see [step 1](#1-pin-a-session-token) |
+| The Hermes **desktop app** stops starting | `HERMES_DASHBOARD_SESSION_TOKEN` pinned in `~/.hermes/.env` overrides the token the app minted for its own backend | Rename that line to `HERMES3D_OFFICE_TOKEN` — see [step 1](#1-pin-a-session-token) |
 | Gateway closes, HTTP `401` | Pointed at a gated server | You are hitting `hermes dashboard` (public bind) rather than the loopback `hermes serve`. Gated servers reject `?token=` entirely |
 | Port open, empty response | Backend stopped | `hermes serve --status` on Machine A; see [step 4](#4-keep-it-running) |
 | `400 Invalid Host header` | Tailscale forwards the tailnet hostname to a loopback-bound server | Handled automatically — Studio retries with `Host: localhost`. Seeing it means you are on an older build |

--- a/docs/office-conversation-bridge.md
+++ b/docs/office-conversation-bridge.md
@@ -20,18 +20,27 @@ silently does nothing.
 - The `hermes-agent` backend, connected to Hermes3D through the **Hermes Agent
   (direct)** backend type. See
   [`hermes-agent-tailscale.md`](hermes-agent-tailscale.md) for that setup.
-- A pinned `HERMES_DASHBOARD_SESSION_TOKEN`. An unpinned backend mints a random
-  token every start, which nothing else can know. The installer warns you if it
-  is missing; pin one with:
+- A pinned `HERMES3D_OFFICE_TOKEN`. An unpinned backend mints a random token
+  every start, which nothing else can know. The installer warns you if it is
+  missing; pin one with:
 
 ```bash
-echo "HERMES_DASHBOARD_SESSION_TOKEN=$(openssl rand -hex 32)" >> ~/.hermes/.env
+echo "HERMES3D_OFFICE_TOKEN=$(openssl rand -hex 32)" >> ~/.hermes/.env
 ```
 
   `~/.hermes/.env` is the only place you need it, even if you run profiles.
   Profiles each have their own `.env`, but this token identifies the one local
-  dashboard they all publish to, so the plugin falls back to the default home
+  backend they all publish to, so the plugin falls back to the default home
   rather than making you copy the same secret into every profile.
+
+> **Do not pin `HERMES_DASHBOARD_SESSION_TOKEN` in `~/.hermes/.env`.** Hermes
+> loads that file with `override=True`, so the pinned value is forced on *every*
+> backend the machine starts. The Hermes desktop app mints a fresh token per
+> launch and hands it to the backend it spawns; a pin overrides it, and the app
+> then fails to start with "the WebSocket (/api/ws) rejected the session token".
+> Pin `HERMES3D_OFFICE_TOKEN` instead and pass it to the office backend on the
+> command line, as [`hermes-agent-tailscale.md`](hermes-agent-tailscale.md)
+> shows. The desktop app keeps minting its own and both run side by side.
 
 ## Install
 
@@ -153,7 +162,8 @@ only if something else is already using `hermes3d` on your event bus.
 | --- | --- | --- |
 | Nothing happens when you chat | Plugin not loaded | Restart the backend after installing; check `hermes plugins list` |
 | Works for one agent, not the others | Installed in the default home only | Re-run `install.sh`, which covers every profile |
-| Warning about the session token at install | Token not pinned | Add `HERMES_DASHBOARD_SESSION_TOKEN` to `~/.hermes/.env` and restart |
-| Still silent with everything enabled | A stale `HERMES_DASHBOARD_SESSION_TOKEN` exported in the shell that started the backend overrides the pinned one | `unset` it, or start the backend from a clean shell |
+| Warning about the session token at install | Token not pinned | Add `HERMES3D_OFFICE_TOKEN` to `~/.hermes/.env` and restart |
+| The desktop app will not start: "the WebSocket (/api/ws) rejected the session token" | `HERMES_DASHBOARD_SESSION_TOKEN` is pinned in `~/.hermes/.env` and overrides the token the app minted for its own backend | Rename that line to `HERMES3D_OFFICE_TOKEN` and pass it to the office backend on its command line |
+| Still silent with everything enabled | A stale `HERMES3D_OFFICE_TOKEN` exported in the shell that started the backend overrides the pinned one | `unset` it, or start the backend from a clean shell |
 | One agent replies but no circle forms | A conversation needs two speakers | Ask a question the whole group answers |
 | Agents gather but the office is silent | Browser audio is locked until you interact | Click once anywhere on the page |

--- a/plugins/hermes3d-office-bridge/__init__.py
+++ b/plugins/hermes3d-office-bridge/__init__.py
@@ -83,13 +83,13 @@ def build_publish_url(*, host: str, port: int, channel: str, token: str) -> str:
     )
 
 
-def _default_home_token() -> str:
-    """Read the token out of the default home's ``.env``.
+def _default_home_token(key: str) -> str:
+    """Read ``key`` out of the default home's ``.env``.
 
     Profiles each get their own ``HERMES_HOME`` and their own ``.env``, so a
     profile-scoped process never sees a token pinned in the default home. That
     matters here because this token is not profile-level config: it identifies
-    the one local dashboard every profile on the machine publishes to. Asking
+    the one office backend every profile on the machine publishes to. Asking
     users to copy the same secret into five ``.env`` files would be worse.
     """
     from pathlib import Path
@@ -103,8 +103,8 @@ def _default_home_token() -> str:
 
     try:
         for line in (root / ".env").read_text(encoding="utf-8").splitlines():
-            key, sep, value = line.partition("=")
-            if sep and key.strip() == "HERMES_DASHBOARD_SESSION_TOKEN":
+            name, sep, value = line.partition("=")
+            if sep and name.strip() == key:
                 return value.strip().strip("'\"")
     except OSError:
         pass
@@ -112,16 +112,32 @@ def _default_home_token() -> str:
 
 
 def _resolve_token() -> str:
-    """The dashboard session token, which is a secret and so lives in the env.
+    """The office backend's session token, which is a secret and lives in env.
 
-    Pin it in ``~/.hermes/.env`` as ``HERMES_DASHBOARD_SESSION_TOKEN`` — an
-    unpinned backend mints a random one per start, which no subscriber can know.
+    Pin it in ``~/.hermes/.env`` as ``HERMES3D_OFFICE_TOKEN`` — an unpinned
+    backend mints a random one per start, which no subscriber can know.
+
+    The office backend's own token variable, ``HERMES_DASHBOARD_SESSION_TOKEN``,
+    deliberately is NOT the key to pin. ``.env`` loads with ``override=True``, so
+    pinning that name hands the same fixed token to *every* backend on the
+    machine — including the one the desktop app spawns, which mints a fresh
+    token per launch and then cannot authenticate against its own gateway. Under
+    a dedicated name the office backend still receives it (passed inline on the
+    command line) while every other backend keeps minting its own.
     """
     import os
 
-    return (
-        os.environ.get("HERMES_DASHBOARD_SESSION_TOKEN") or ""
-    ).strip() or _default_home_token()
+    token = (os.environ.get("HERMES3D_OFFICE_TOKEN") or "").strip()
+    if token:
+        return token
+    token = _default_home_token("HERMES3D_OFFICE_TOKEN")
+    if token:
+        return token
+    # Back-compat for setups written against the earlier guide, which pinned the
+    # dashboard token. Only the pinned file counts: this process's own
+    # ``HERMES_DASHBOARD_SESSION_TOKEN`` authenticates whichever backend it
+    # happens to be, which is rarely the office backend it publishes to.
+    return _default_home_token("HERMES_DASHBOARD_SESSION_TOKEN")
 
 
 def _resolve_profile() -> str:
@@ -165,8 +181,8 @@ def register(ctx: Any) -> None:
     token = _resolve_token()
     if not token:
         _log.warning(
-            "hermes3d-office-bridge: HERMES_DASHBOARD_SESSION_TOKEN is unset; "
-            "turns will not be published. Pin it in ~/.hermes/.env."
+            "hermes3d-office-bridge: HERMES3D_OFFICE_TOKEN is unset; turns will "
+            "not be published. Pin it in ~/.hermes/.env."
         )
         return
 

--- a/plugins/hermes3d-office-bridge/install.sh
+++ b/plugins/hermes3d-office-bridge/install.sh
@@ -88,12 +88,21 @@ if (( UNINSTALL )); then
 fi
 
 echo
-if ! grep -qs 'HERMES_DASHBOARD_SESSION_TOKEN' "$HERMES_ROOT/.env"; then
-  echo "WARNING: HERMES_DASHBOARD_SESSION_TOKEN is not pinned in $HERMES_ROOT/.env."
-  echo "         Without it the backend mints a random token each start and the"
-  echo "         office cannot subscribe. Pin one with:"
+if grep -qs '^[[:space:]]*HERMES_DASHBOARD_SESSION_TOKEN=' "$HERMES_ROOT/.env"; then
+  echo "WARNING: HERMES_DASHBOARD_SESSION_TOKEN is pinned in $HERMES_ROOT/.env."
+  echo "         That file loads with override=True, so the pin also lands in the"
+  echo "         backend the desktop app spawns — which mints its own token per"
+  echo "         launch and will then fail to start. Rename the line to"
+  echo "         HERMES3D_OFFICE_TOKEN and pass it to the office backend instead:"
   echo
-  echo "           echo \"HERMES_DASHBOARD_SESSION_TOKEN=\$(openssl rand -hex 32)\" >> $HERMES_ROOT/.env"
+  echo "           HERMES_DASHBOARD_SESSION_TOKEN=\"\$HERMES3D_OFFICE_TOKEN\" hermes serve ..."
+  echo
+elif ! grep -qs '^[[:space:]]*HERMES3D_OFFICE_TOKEN=' "$HERMES_ROOT/.env"; then
+  echo "WARNING: HERMES3D_OFFICE_TOKEN is not pinned in $HERMES_ROOT/.env."
+  echo "         Without it the office backend mints a random token each start and"
+  echo "         the plugin cannot publish to it. Pin one with:"
+  echo
+  echo "           echo \"HERMES3D_OFFICE_TOKEN=\$(openssl rand -hex 32)\" >> $HERMES_ROOT/.env"
   echo
 fi
 echo "Done. Restart the backend so the plugin loads."


### PR DESCRIPTION
## Summary

Following our own bridge guide made the Hermes desktop app unlaunchable:

```
Local Hermes backend is HTTP-reachable but the WebSocket (/api/ws)
rejected the session token: WebSocket connection failed.
```

The guide said to pin `HERMES_DASHBOARD_SESSION_TOKEN` in `~/.hermes/.env` so the office backend keeps a stable token. Hermes loads that file with `override=True`, so the pin lands on **every** backend the machine starts — including the one the desktop app spawns. The app mints a fresh token per launch, passes it to its child, then probes `/api/ws` with it; the pin overrode the child's token, the probe failed, and the app died at boot.

The fix is a dedicated name. `HERMES3D_OFFICE_TOKEN` is pinned in `.env` and passed to the office backend inline on its command line, which `.env` cannot override because the pinned name differs. Every other backend keeps minting its own.

- The resolver does **not** fall back to the process's own `HERMES_DASHBOARD_SESSION_TOKEN` — that authenticates whichever backend the plugin is running inside, rarely the one it publishes to, so reading it would send a wrong token and fail silently. Existing setups are covered by reading the pinned file.
- The installer warned when the dashboard token was *absent*, pushing users into the trap. It now warns when it is *present* and shows the rename.
- Both docs get the warning, and the launchd/systemd units read the token out of `.env` at launch so it stays out of service definitions and `ps`.

## Test plan

- [x] A backend spawned the way the desktop app spawns its own accepts the token it minted (the exact `/api/ws` probe that was failing).
- [x] A profile-scoped one-shot turn still publishes to the office backend end to end.
- [x] Token precedence: office token wins; the desktop backend's token is never used.
- [x] `npm run test -- --run` — same 3 pre-existing failures as clean `main`.

Made with [Cursor](https://cursor.com)