### PR TITLE
Make conversation huddles readable and keep them off the furniture

### DIFF
--- a/src/features/retro-office/RetroOffice3D.tsx
+++ b/src/features/retro-office/RetroOffice3D.tsx
@@ -127,7 +127,7 @@ import {
   getMeetingSeatLocations,
   getQaLabStations,
   GYM_DEFAULT_TARGET,
-  isNavPointFree,
+  isNavAreaFree,
   MEETING_OVERFLOW_LOCATIONS,
   QA_LAB_DEFAULT_TARGET,
   resolveDeskIndexForItem,
@@ -153,6 +153,11 @@ import {
   type ConversationGroup,
   type ConversationSpeechSample,
 } from "@/features/retro-office/core/conversations";
+import {
+  enqueueSpeechTurns,
+  speechTurnDurationMs,
+  type SpeechTurn,
+} from "@/features/retro-office/core/speechTurns";
 import { ConversationChatterAudio } from "@/features/retro-office/systems/conversationChatterAudio";
 import {
   loadFurniture,
@@ -259,7 +264,7 @@ import type { OfficeCleaningCue } from "@/lib/office/janitorReset";
 type OfficeDeskMonitorMap = Record<string, OfficeDeskMonitor>;
 type RenderAgentUiSnapshot = Pick<
   RenderAgent,
-  "state" | "status" | "conversationGroupId"
+  "state" | "status" | "conversationGroupId" | "conversationSeatIndex"
 >;
 type FeedEvent = {
   id: string;
@@ -1037,7 +1042,10 @@ function useAgentTick(
         const grid = getNavGrid();
         const slots = computeConversationSlots({
           participants,
-          isFree: (x, y) => isNavPointFree(grid, x, y),
+          // Members stand here for the life of the huddle, so the whole body
+          // has to clear the furniture — a point-only check seated them with
+          // half a torso inside a desk.
+          isFree: (x, y) => isNavAreaFree(grid, x, y),
         });
         for (const [agentId, slot] of slots) {
           conversationSlotByAgentIdRef.current.set(agentId, {
@@ -2872,8 +2880,36 @@ export function RetroOffice3D({
   } | null>(null);
   const [deskActionUid, setDeskActionUid] = useState<string | null>(null);
   const [deskAssignPickerOpen, setDeskAssignPickerOpen] = useState(false);
-  // New Idea 3: speech bubble agent IDs.
+  // New Idea 3: speech bubble agent IDs. Holds at most the one agent currently
+  // granted the floor — see the speech-turn queue below.
   const [speechAgentIds, setSpeechAgentIds] = useState<Set<string>>(new Set());
+  const speechQueueRef = useRef<SpeechTurn[]>([]);
+  const speechSeenRepliesRef = useRef<Set<string>>(new Set());
+  const speechTurnTimerRef = useRef<number | null>(null);
+  // Hand the floor to the next waiting reply, and keep handing it on until the
+  // queue drains. Re-entrant by design: the timer calls straight back in.
+  const pumpSpeechTurns = useCallback(() => {
+    if (speechTurnTimerRef.current !== null) return;
+    const next = speechQueueRef.current.shift();
+    if (!next) {
+      setSpeechAgentIds((previous) => (previous.size === 0 ? previous : new Set()));
+      return;
+    }
+    setSpeechAgentIds(new Set([next.agentId]));
+    speechTurnTimerRef.current = window.setTimeout(() => {
+      speechTurnTimerRef.current = null;
+      pumpSpeechTurns();
+    }, next.durationMs);
+  }, []);
+  useEffect(
+    () => () => {
+      if (speechTurnTimerRef.current !== null) {
+        window.clearTimeout(speechTurnTimerRef.current);
+        speechTurnTimerRef.current = null;
+      }
+    },
+    [],
+  );
   const statusFeedEvents = useMemo(
     () => feedEvents.filter((event) => event.kind !== "reply"),
     [feedEvents],
@@ -2890,6 +2926,37 @@ export function RetroOffice3D({
     }
     return { speechTextByAgentId: texts, speechImageUrlByAgentId: images };
   }, [feedEvents]);
+  // Live typing outranks a queued reply, but only one stream may hold the
+  // floor. Whoever started first keeps it until they stop, so the bubble does
+  // not hop between agents mid-sentence.
+  const streamingSinceRef = useRef<Map<string, number>>(new Map());
+  const streamingSpeakerId = useMemo(() => {
+    const since = streamingSinceRef.current;
+    const now = Date.now();
+    const streaming = new Set(
+      Object.entries(streamingTextByAgentId)
+        .filter(([, text]) => Boolean(text?.trim()))
+        .map(([agentId]) => agentId),
+    );
+    for (const agentId of streaming) {
+      if (!since.has(agentId)) since.set(agentId, now);
+    }
+    for (const agentId of [...since.keys()]) {
+      if (!streaming.has(agentId)) since.delete(agentId);
+    }
+    let speakerId: string | null = null;
+    let earliest = Number.POSITIVE_INFINITY;
+    for (const agentId of streaming) {
+      const startedAt = since.get(agentId) ?? now;
+      if (startedAt < earliest) {
+        earliest = startedAt;
+        speakerId = agentId;
+      }
+    }
+    return speakerId;
+  }, [streamingTextByAgentId]);
+  const activeSpeechAgentId =
+    streamingSpeakerId ?? [...speechAgentIds][0] ?? null;
   const standupSpeechTextByAgentId = useMemo(() => {
     if (!standupMeeting || standupMeeting.phase !== "in_progress") return {};
     const currentCard =
@@ -3339,6 +3406,7 @@ export function RetroOffice3D({
           state: agent.state,
           status: agent.status,
           conversationGroupId: agent.conversationGroupId,
+          conversationSeatIndex: agent.conversationSeatIndex,
         };
       }
       // Keep the previous object when nothing changed so idle frames do not
@@ -3354,7 +3422,8 @@ export function RetroOffice3D({
               !after ||
               before.state !== after.state ||
               before.status !== after.status ||
-              before.conversationGroupId !== after.conversationGroupId
+              before.conversationGroupId !== after.conversationGroupId ||
+              before.conversationSeatIndex !== after.conversationSeatIndex
             ) {
               identical = false;
               break;
@@ -5576,31 +5645,38 @@ export function RetroOffice3D({
     return () => window.removeEventListener("pointerdown", dismiss);
   }, [deskActionUid]);
 
-  // New Idea 3: show speech bubble based on reply length.
+  // Replies take the floor one at a time. A group message answered by four
+  // agents arrives as four replies in the same second, and showing them at once
+  // stacks four full-size bubbles into an unreadable pile.
   useEffect(() => {
-    if (feedEvents.length === 0) return;
-    const latest = feedEvents[0];
-    if (!latest) return;
-    if (latest.kind !== "reply") return;
-    const speechBubbleDurationMs = Math.min(
-      12_000,
-      Math.max(5_500, 2_500 + latest.text.trim().length * 42),
-    );
-    const addTimer = window.setTimeout(() => {
-      setSpeechAgentIds((prev) => new Set([...prev, latest.id]));
-    }, 0);
-    const timer = window.setTimeout(() => {
-      setSpeechAgentIds((prev) => {
-        const next = new Set(prev);
-        next.delete(latest.id);
-        return next;
+    const seen = speechSeenRepliesRef.current;
+    const arrivals: SpeechTurn[] = [];
+    // Oldest first: the queue is a waiting line, and feedEvents is newest-first.
+    for (const event of [...feedEvents].reverse()) {
+      if (event.kind !== "reply") continue;
+      const text = event.text.trim();
+      if (!text) continue;
+      const key = `${event.id}:${event.ts}`;
+      if (seen.has(key)) continue;
+      seen.add(key);
+      arrivals.push({
+        agentId: event.id,
+        key,
+        durationMs: speechTurnDurationMs(text.length),
       });
-    }, speechBubbleDurationMs);
-    return () => {
-      window.clearTimeout(addTimer);
-      window.clearTimeout(timer);
-    };
-  }, [feedEvents]);
+    }
+    if (seen.size > 64) {
+      speechSeenRepliesRef.current = new Set(
+        feedEvents.map((event) => `${event.id}:${event.ts}`),
+      );
+    }
+    if (arrivals.length === 0) return;
+    speechQueueRef.current = enqueueSpeechTurns(
+      speechQueueRef.current,
+      arrivals,
+    );
+    pumpSpeechTurns();
+  }, [feedEvents, pumpSpeechTurns]);
 
   // E3 Idea 1: emoji mood reactions on feed events.
   useEffect(() => {
@@ -6252,8 +6328,7 @@ export function RetroOffice3D({
                       ? false
                       : standupMeeting?.phase === "in_progress"
                         ? Boolean(standupSpeechTextByAgentId[agent.id])
-                        : speechAgentIds.has(agent.id) ||
-                          Boolean(streamingTextByAgentId[agent.id])
+                        : agent.id === activeSpeechAgentId
                   }
                   speechText={
                     isJanitor
@@ -6267,6 +6342,11 @@ export function RetroOffice3D({
                   suppressSpeechBubble={
                     suppressSceneSpeechBubbles &&
                     standupMeeting?.currentSpeakerAgentId !== agent.id
+                  }
+                  huddleSeatIndex={
+                    renderAgentUiById[agent.id]?.conversationGroupId
+                      ? (renderAgentUiById[agent.id]?.conversationSeatIndex ?? 0)
+                      : null
                   }
                 />
               );

--- a/src/features/retro-office/core/conversations.ts
+++ b/src/features/retro-office/core/conversations.ts
@@ -1,4 +1,8 @@
-import { CANVAS_H, CANVAS_W } from "@/features/retro-office/core/constants";
+import {
+  AGENT_RADIUS,
+  CANVAS_H,
+  CANVAS_W,
+} from "@/features/retro-office/core/constants";
 
 /**
  * Agent-to-agent conversation detection and huddle placement.
@@ -51,11 +55,30 @@ export const CONVERSATION_EN_ROUTE_GRACE_MS = 12_000;
 /** Hard ceiling on a huddle's life from formation, extensions included. */
 export const CONVERSATION_MAX_LIFETIME_MS = 150_000;
 
-/** Arc distance between neighbours on the circle, in canvas units. */
-export const CONVERSATION_SLOT_SPACING = 34;
+/**
+ * Centre-to-centre gap between neighbours on the circle, in canvas units.
+ *
+ * Derived from the body size rather than picked by eye: anything below
+ * `AGENT_RADIUS * 2` puts two agents inside each other. The extra margin is
+ * breathing room so a circle reads as a group of people rather than a huddle of
+ * touching boxes.
+ */
+export const CONVERSATION_SLOT_SPACING = AGENT_RADIUS * 2 + 8;
 
 /** Minimum huddle radius so two agents don't stand nose-to-nose. */
 export const CONVERSATION_MIN_RADIUS = 26;
+
+/**
+ * Radius that seats `count` agents without overlapping.
+ *
+ * Neighbours sit on a chord of `2r·sin(π/n)`, so the radius has to grow with
+ * the group; a fixed radius silently overlapped every huddle of four or more.
+ */
+export const conversationRadius = (count: number): number =>
+  Math.max(
+    CONVERSATION_MIN_RADIUS,
+    CONVERSATION_SLOT_SPACING / (2 * Math.sin(Math.PI / Math.max(2, count))),
+  );
 
 /** How long one agent "speaks" before the turn passes around the circle. */
 export const CONVERSATION_TALK_TURN_MS = 1_600;
@@ -311,41 +334,51 @@ export const computeConversationSlots = (options: {
     margin,
     canvasHeight - margin,
   );
-  const radius = Math.max(
-    CONVERSATION_MIN_RADIUS,
-    (CONVERSATION_SLOT_SPACING * count) / (2 * Math.PI),
-  );
+  const radius = conversationRadius(count);
 
-  const slotPointsAt = (cx: number, cy: number) =>
+  const slotPointsAt = (cx: number, cy: number, phase: number) =>
     Array.from({ length: count }, (_, index) => {
-      const angle = -Math.PI / 2 + (index * 2 * Math.PI) / count;
+      const angle = -Math.PI / 2 + phase + (index * 2 * Math.PI) / count;
       return {
         x: cx + radius * Math.cos(angle),
         y: cy + radius * Math.sin(angle),
       };
     });
 
+  // Rotating by a full seat spacing maps the circle onto itself, so the useful
+  // phases live inside one seat. Spinning matters most for a pair, where the
+  // circle is a line segment that translation alone cannot fit between desks.
+  const seatArc = (2 * Math.PI) / count;
+  const phases = [0, seatArc / 3, (2 * seatArc) / 3];
+
   // Prefer the first fully free candidate; otherwise take the one with the
   // most walkable slots so a crowded floor still yields a usable circle.
   let centerX = centroidX;
   let centerY = centroidY;
+  let centerPhase = 0;
   let bestFreeCount = -1;
-  for (const [offsetX, offsetY] of CENTER_CANDIDATE_OFFSETS) {
+  search: for (const [offsetX, offsetY] of CENTER_CANDIDATE_OFFSETS) {
     const cx = clamp(centroidX + offsetX, margin, canvasWidth - margin);
     const cy = clamp(centroidY + offsetY, margin, canvasHeight - margin);
-    const points = slotPointsAt(cx, cy);
-    const freeCount =
-      (isFree(cx, cy) ? 1 : 0) +
-      points.reduce((sum, point) => sum + (isFree(point.x, point.y) ? 1 : 0), 0);
-    if (freeCount > bestFreeCount) {
-      bestFreeCount = freeCount;
-      centerX = cx;
-      centerY = cy;
+    const centerFree = isFree(cx, cy) ? 1 : 0;
+    for (const phase of phases) {
+      const freeCount =
+        centerFree +
+        slotPointsAt(cx, cy, phase).reduce(
+          (sum, point) => sum + (isFree(point.x, point.y) ? 1 : 0),
+          0,
+        );
+      if (freeCount > bestFreeCount) {
+        bestFreeCount = freeCount;
+        centerX = cx;
+        centerY = cy;
+        centerPhase = phase;
+      }
+      if (freeCount === count + 1) break search;
     }
-    if (freeCount === count + 1) break;
   }
 
-  const points = slotPointsAt(centerX, centerY);
+  const points = slotPointsAt(centerX, centerY, centerPhase);
   // Hand out slots in bearing order so nobody walks through the circle.
   const ordered = [...participants].sort((a, b) => {
     const bearingA = Math.atan2(a.y - centerY, a.x - centerX);

--- a/src/features/retro-office/core/navigation.ts
+++ b/src/features/retro-office/core/navigation.ts
@@ -1,4 +1,8 @@
-import { CANVAS_H, CANVAS_W } from "@/features/retro-office/core/constants";
+import {
+  AGENT_RADIUS,
+  CANVAS_H,
+  CANVAS_W,
+} from "@/features/retro-office/core/constants";
 import {
   getItemBounds,
   ITEM_FOOTPRINT,
@@ -123,6 +127,41 @@ export const isNavPointFree = (grid: NavGrid, x: number, y: number): boolean => 
     return false;
   }
   return grid[row * GRID_COLS + column] === 0;
+};
+
+/**
+ * True when a body of `radius` centred on (x, y) clears every blocked cell.
+ *
+ * A cell is 25 units and an agent is 40 across, so a point-only check reports
+ * "free" for a spot where the agent's body still sinks into the desk in the
+ * neighbouring cell. Use this for anywhere an agent comes to a stop and stays
+ * visible — walking through a pinch point can tolerate the looser test, but a
+ * character standing half inside a desk cannot.
+ */
+export const isNavAreaFree = (
+  grid: NavGrid,
+  x: number,
+  y: number,
+  radius: number = AGENT_RADIUS,
+): boolean => {
+  const firstColumn = Math.floor((x - radius) / GRID_CELL);
+  const lastColumn = Math.floor((x + radius) / GRID_CELL);
+  const firstRow = Math.floor((y - radius) / GRID_CELL);
+  const lastRow = Math.floor((y + radius) / GRID_CELL);
+  if (
+    firstColumn < 0 ||
+    firstRow < 0 ||
+    lastColumn >= GRID_COLS ||
+    lastRow >= GRID_ROWS
+  ) {
+    return false;
+  }
+  for (let row = firstRow; row <= lastRow; row += 1) {
+    for (let column = firstColumn; column <= lastColumn; column += 1) {
+      if (grid[row * GRID_COLS + column] !== 0) return false;
+    }
+  }
+  return true;
 };
 
 export function astar(

--- a/src/features/retro-office/core/speechTurns.ts
+++ b/src/features/retro-office/core/speechTurns.ts
@@ -1,0 +1,63 @@
+/**
+ * One speaking turn at a time for scene speech bubbles.
+ *
+ * A group chat answered by four agents used to raise four full-size bubbles in
+ * the same second. They overlap into an unreadable stack, and the office reads
+ * as noise rather than a conversation. Replies are therefore queued and granted
+ * the floor one at a time, the way people actually take turns.
+ *
+ * Pure so the ordering and timing rules are testable without a scene.
+ */
+
+/** Shortest a bubble stays up — below this it flashes past unread. */
+export const SPEECH_TURN_MIN_MS = 3_400;
+
+/** Longest a single reply may hold the floor while others are waiting. */
+export const SPEECH_TURN_MAX_MS = 9_000;
+
+/**
+ * How many replies may wait for the floor.
+ *
+ * A burst larger than this would keep the office narrating a conversation long
+ * after it ended, so the oldest waiting replies are dropped: by the time their
+ * turn arrived they would no longer be news.
+ */
+export const SPEECH_QUEUE_MAX = 4;
+
+export interface SpeechTurn {
+  agentId: string;
+  /** Identifies one reply, so the same event is never queued twice. */
+  key: string;
+  durationMs: number;
+}
+
+/** Reading time for a reply of this length, bounded at both ends. */
+export const speechTurnDurationMs = (textLength: number): number =>
+  Math.min(
+    SPEECH_TURN_MAX_MS,
+    Math.max(SPEECH_TURN_MIN_MS, 1_800 + textLength * 34),
+  );
+
+/**
+ * Add replies to the waiting line.
+ *
+ * An agent holds at most one place in the queue: when it speaks again before
+ * its earlier reply reached the floor, the newer text replaces the older one
+ * rather than making the same character say two things in a row.
+ */
+export const enqueueSpeechTurns = (
+  queue: SpeechTurn[],
+  incoming: SpeechTurn[],
+  max: number = SPEECH_QUEUE_MAX,
+): SpeechTurn[] => {
+  const next = [...queue];
+  for (const turn of incoming) {
+    if (next.some((queued) => queued.key === turn.key)) continue;
+    const supersedes = next.findIndex(
+      (queued) => queued.agentId === turn.agentId,
+    );
+    if (supersedes >= 0) next.splice(supersedes, 1);
+    next.push(turn);
+  }
+  return next.length > max ? next.slice(next.length - max) : next;
+};

--- a/src/features/retro-office/objects/agents.tsx
+++ b/src/features/retro-office/objects/agents.tsx
@@ -88,6 +88,7 @@ export const AgentModel = memo(function AgentModel({
   showSpeech = false,
   speechText = null,
   suppressSpeechBubble = false,
+  huddleSeatIndex = null,
 }: AgentModelProps) {
   const groupRef = useRef<THREE.Group>(null);
   const leftArmRef = useRef<THREE.Group>(null);
@@ -509,13 +510,15 @@ export const AgentModel = memo(function AgentModel({
         agent.state === "standing" &&
         (agent.frame + blinkSeed * 11) % 320 < 42);
     const bumpTalking = (agent.bumpTalkUntil ?? 0) > Date.now();
-    // Standing in a huddle, everyone holds the same reply, and the bubbles are
-    // close enough to overlap into an unreadable stack. The speaking turn
-    // already rotates around the circle, so let it own the bubble too.
+    // In a huddle the bubbles are close enough to overlap into an unreadable
+    // stack, so the rotating talk pulse owns the ambient "..." bubble. The
+    // scene grants one real speaking turn at a time, and that speaker is never
+    // competing with another bubble — it always shows.
     const waitingForTurnInHuddle =
       agent.conversationGroupId !== undefined &&
       agent.state === "standing" &&
-      !bumpTalking;
+      !bumpTalking &&
+      !showSpeech;
 
     if (speechBubbleRef.current) {
       const bubbleVisible =
@@ -707,8 +710,16 @@ export const AgentModel = memo(function AgentModel({
     : "transparent";
   const speechBubbleBorderInset = activeSpeechBubble ? 0.03 : 0;
   const nameplateText = name ? formatAgentNameplateText(name) : "";
+  // A huddle packs four plates into roughly one plate's worth of screen space.
+  // Drop the role line there and step each seat's plate to its own height so
+  // the names read as a list instead of a pile.
+  const inHuddle = huddleSeatIndex !== null;
   const subtitleText =
-    typeof subtitle === "string" ? formatAgentSubtitleText(subtitle) : "";
+    !inHuddle && typeof subtitle === "string"
+      ? formatAgentSubtitleText(subtitle)
+      : "";
+  const nameplateHeight =
+    1.05 + (inHuddle ? ((huddleSeatIndex ?? 0) % 4) * 0.17 : 0);
   const nameplateFontSize =
     nameplateText.length > 9 ? 0.118 : nameplateText.length > 7 ? 0.13 : 0.144;
 
@@ -1156,7 +1167,7 @@ export const AgentModel = memo(function AgentModel({
         />
       </mesh>
       {!activeSpeechBubble && nameplateText ? (
-        <Billboard position={[0, 1.05, 0]}>
+        <Billboard position={[0, nameplateHeight, 0]}>
           <mesh position={[0, 0, -0.001]}>
             <planeGeometry args={[0.82, subtitleText ? 0.34 : 0.24]} />
             <meshBasicMaterial color="#080c14" transparent opacity={0.9} />

--- a/src/features/retro-office/objects/types.ts
+++ b/src/features/retro-office/objects/types.ts
@@ -43,4 +43,6 @@ export type AgentModelProps = {
   showSpeech?: boolean;
   speechText?: string | null;
   suppressSpeechBubble?: boolean;
+  /** Seat on the conversation circle, or null when not in a huddle. */
+  huddleSeatIndex?: number | null;
 };

--- a/tests/unit/navigation.areaClearance.test.ts
+++ b/tests/unit/navigation.areaClearance.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+
+import { AGENT_RADIUS } from "@/features/retro-office/core/constants";
+import { getItemBounds } from "@/features/retro-office/core/geometry";
+import {
+  buildNavGrid,
+  isNavAreaFree,
+  isNavPointFree,
+} from "@/features/retro-office/core/navigation";
+import type { FurnitureItem } from "@/features/retro-office/core/types";
+
+// desk_cubicle is one of the types that blocks navigation, so it produces the
+// blocked cells this clearance check exists for.
+const desk: FurnitureItem = {
+  _uid: "test_desk",
+  type: "desk_cubicle",
+  x: 400,
+  y: 400,
+};
+
+const bounds = getItemBounds(desk);
+const deskCenterY = bounds.y + bounds.h / 2;
+
+/** Distance to the right of the desk where a predicate first reports free. */
+const firstFreeOffset = (predicate: (x: number, y: number) => boolean) => {
+  for (let offset = 0; offset <= 600; offset += 1) {
+    if (predicate(bounds.x + offset, deskCenterY)) return offset;
+  }
+  return Number.POSITIVE_INFINITY;
+};
+
+describe("isNavAreaFree", () => {
+  const grid = buildNavGrid([desk]);
+
+  it("rejects the band where a body still overlaps the furniture", () => {
+    // The point check clears the desk the moment the centre leaves the blocked
+    // cell, which parks an agent with half a torso inside it. Demanding room
+    // for the whole body has to push the first acceptable spot further out.
+    const pointOffset = firstFreeOffset((x, y) => isNavPointFree(grid, x, y));
+    const areaOffset = firstFreeOffset((x, y) => isNavAreaFree(grid, x, y));
+    expect(Number.isFinite(pointOffset)).toBe(true);
+    expect(Number.isFinite(areaOffset)).toBe(true);
+    expect(areaOffset).toBeGreaterThan(pointOffset);
+  });
+
+  it("agrees with the point check out on open floor", () => {
+    expect(isNavPointFree(grid, 900, 900)).toBe(true);
+    expect(isNavAreaFree(grid, 900, 900)).toBe(true);
+  });
+
+  it("treats a larger body as needing more room", () => {
+    const justClear = bounds.x + firstFreeOffset((x, y) => isNavAreaFree(grid, x, y));
+    expect(isNavAreaFree(grid, justClear, deskCenterY, AGENT_RADIUS)).toBe(true);
+    expect(isNavAreaFree(grid, justClear, deskCenterY, AGENT_RADIUS * 4)).toBe(
+      false,
+    );
+  });
+
+  it("rejects points outside the grid", () => {
+    expect(isNavAreaFree(grid, -50, 400)).toBe(false);
+    expect(isNavAreaFree(grid, 400, -50)).toBe(false);
+  });
+});

--- a/tests/unit/officeConversations.test.ts
+++ b/tests/unit/officeConversations.test.ts
@@ -12,6 +12,7 @@ import type {
   ConversationGroup,
   KnownConversationGroup,
 } from "../../src/features/retro-office/core/conversations";
+import { AGENT_RADIUS } from "../../src/features/retro-office/core/constants";
 import { planChatterBlip } from "../../src/features/retro-office/systems/conversationChatterAudio";
 import { formatAgentSubtitleText } from "../../src/features/retro-office/objects/agents";
 
@@ -169,11 +170,53 @@ describe("computeConversationSlots", () => {
     }
   });
 
+  it("rotates a pair into a corridor that no translation of the circle fits", () => {
+    // A horizontal aisle: only a narrow band of y is walkable. A pair defaults
+    // to a vertical line, so every candidate centre puts one slot in the wall
+    // until the circle is allowed to spin flat into the aisle.
+    // Narrower than the circle's diameter, so no vertical placement fits.
+    const aisle = (_x: number, y: number) => y > 290 && y < 330;
+    const slots = computeConversationSlots({
+      participants: [
+        { id: "allan", x: 300, y: 310 },
+        { id: "owen", x: 360, y: 310 },
+      ],
+      isFree: aisle,
+    });
+    expect(slots.size).toBe(2);
+    for (const slot of slots.values()) {
+      expect(aisle(slot.x, slot.y)).toBe(true);
+    }
+  });
+
   it("returns nothing for fewer than two participants", () => {
     expect(
       computeConversationSlots({ participants: [{ id: "a", x: 0, y: 0 }] })
         .size,
     ).toBe(0);
+  });
+
+  it("keeps neighbours at least a body apart at every group size", () => {
+    // A fixed radius seated four agents 37 units apart — inside each other,
+    // since a body is 40 across. The circle has to grow with the group.
+    for (let count = 2; count <= 8; count += 1) {
+      const participants = Array.from({ length: count }, (_, index) => ({
+        id: `agent-${index}`,
+        x: 600 + index * 30,
+        y: 600,
+      }));
+      const points = [...computeConversationSlots({ participants }).values()];
+      expect(points).toHaveLength(count);
+      for (let i = 0; i < points.length; i += 1) {
+        for (let j = i + 1; j < points.length; j += 1) {
+          const gap = Math.hypot(
+            points[i].x - points[j].x,
+            points[i].y - points[j].y,
+          );
+          expect(gap).toBeGreaterThanOrEqual(AGENT_RADIUS * 2);
+        }
+      }
+    }
   });
 });
 

--- a/tests/unit/officeSpeechTurns.test.ts
+++ b/tests/unit/officeSpeechTurns.test.ts
@@ -1,0 +1,68 @@
+// @vitest-environment node
+import { describe, expect, it } from "vitest";
+
+import {
+  enqueueSpeechTurns,
+  SPEECH_QUEUE_MAX,
+  SPEECH_TURN_MAX_MS,
+  SPEECH_TURN_MIN_MS,
+  speechTurnDurationMs,
+  type SpeechTurn,
+} from "../../src/features/retro-office/core/speechTurns";
+
+const turn = (agentId: string, key: string): SpeechTurn => ({
+  agentId,
+  key,
+  durationMs: SPEECH_TURN_MIN_MS,
+});
+
+describe("speechTurnDurationMs", () => {
+  it("stays long enough to read and short enough to pass the floor on", () => {
+    for (const length of [0, 1, 40, 180, 2_000]) {
+      const duration = speechTurnDurationMs(length);
+      expect(duration).toBeGreaterThanOrEqual(SPEECH_TURN_MIN_MS);
+      expect(duration).toBeLessThanOrEqual(SPEECH_TURN_MAX_MS);
+    }
+  });
+
+  it("gives a longer reply more time than a shorter one", () => {
+    expect(speechTurnDurationMs(150)).toBeGreaterThan(speechTurnDurationMs(20));
+  });
+});
+
+describe("enqueueSpeechTurns", () => {
+  it("queues a burst in arrival order rather than showing it at once", () => {
+    const queue = enqueueSpeechTurns(
+      [],
+      [turn("a", "a:1"), turn("b", "b:1"), turn("c", "c:1")],
+    );
+    expect(queue.map((entry) => entry.agentId)).toEqual(["a", "b", "c"]);
+  });
+
+  it("ignores a reply it has already queued", () => {
+    const first = enqueueSpeechTurns([], [turn("a", "a:1")]);
+    const second = enqueueSpeechTurns(first, [turn("a", "a:1")]);
+    expect(second).toHaveLength(1);
+  });
+
+  it("replaces an agent's waiting reply instead of making it speak twice", () => {
+    const queue = enqueueSpeechTurns(
+      [turn("a", "a:1"), turn("b", "b:1")],
+      [turn("a", "a:2")],
+    );
+    expect(queue.map((entry) => entry.key)).toEqual(["b:1", "a:2"]);
+  });
+
+  it("drops the oldest waiting replies once the line is full", () => {
+    const incoming = Array.from({ length: SPEECH_QUEUE_MAX + 3 }, (_, index) =>
+      turn(`agent-${index}`, `agent-${index}:1`),
+    );
+    const queue = enqueueSpeechTurns([], incoming);
+    expect(queue).toHaveLength(SPEECH_QUEUE_MAX);
+    // The survivors are the freshest: a reply that waited out the whole burst
+    // is no longer news by the time its turn would arrive.
+    expect(queue.map((entry) => entry.agentId)).toEqual(
+      incoming.slice(-SPEECH_QUEUE_MAX).map((entry) => entry.agentId),
+    );
+  });
+});


### PR DESCRIPTION
## Summary

When a group message went out and every agent replied, all four bubbles rendered at once into an unreadable stack, and the huddle circle was loose enough that members overlapped each other and came to rest inside desks.

- **One speaker at a time.** Replies go into a queue (`core/speechTurns.ts`) and are granted a turn sized to the length of the line, so bubbles cycle instead of piling up. Live streaming still takes precedence over queued replies.
- **Circle sized from the body.** `conversationRadius(count)` derives the radius from `AGENT_RADIUS`, so neighbours keep a full body of clearance at any group size. The old fixed radius seated four agents 37 units apart — inside each other, since a body is 40 across.
- **Clearance-aware placement.** `isNavAreaFree` checks the agent's whole footprint instead of a single point, so a slot can no longer land where half a torso sits in the neighbouring desk cell.
- **The circle can rotate, not just translate.** A pair is a line segment; in a narrow aisle no translation of a vertical segment fits, but a rotated one does.
- **Decluttered nameplates.** Inside a huddle the role line is dropped and each seat's plate steps to its own height, so four names read as a list instead of one block.

## Test plan

- [x] `npx vitest run` — 1169 passing. The 3 failures in `agentChatPanel-controls` and `agentFleetHydration` are pre-existing on `main` (verified by stashing this branch's changes).
- [x] New unit tests: `officeSpeechTurns.test.ts` (queue ordering, supersede, cap), `navigation.areaClearance.test.ts` (area vs point clearance), plus huddle spacing and circle-rotation cases in `officeConversations.test.ts`. The rotation test was confirmed to fail without the rotation change.
- [x] Driven live against a real `hermes serve` backend: published four agent turns to the event bus and watched the office. All four agents reach the circle in ~7s, one bubble shows at a time and rotates between speakers, and the settled circle sits on open floor.
- [x] `npx tsc --noEmit` and `eslint` clean on the changed files.

### Note on verifying this locally

Headless Chromium software-renders this scene at 2-6 fps, which starves the walk loop and makes agents look stuck mid-approach. Launch headed with `--use-angle=metal` and the background-throttling flags disabled to get a realistic ~50 fps before judging arrival behaviour.

Made with [Cursor](https://cursor.com)