### PR TITLE
Make huddle chatter sound like conversation instead of a ticking clock

### DIFF
--- a/src/features/retro-office/systems/conversationChatterAudio.ts
+++ b/src/features/retro-office/systems/conversationChatterAudio.ts
@@ -1,35 +1,82 @@
 /**
- * Soft synthesized murmur played while agents huddle in a conversation.
+ * Soft synthesized chatter played while agents huddle in a conversation.
  *
- * No audio assets: each "utterance" is one or two short filtered triangle
- * blips with randomized pitch, so a circle of talking agents sounds like
- * distant chatter. Browsers keep an AudioContext suspended until a user
- * gesture, so the scene calls `unlock()` from a pointer handler; until then
- * scheduling runs silently and simply produces no sound.
+ * No audio assets: speech is faked with short filtered triangle blips. A
+ * single evenly-spaced blip sounds like a ticking clock, so blips are grouped
+ * into word-like utterances — a burst of syllables around a per-utterance base
+ * pitch, ending on a falling (or occasionally rising, questioning) note — and
+ * consecutive utterances alternate between a lower and a higher voice so the
+ * murmur reads as back-and-forth conversation. Browsers keep an AudioContext
+ * suspended until a user gesture, so the scene calls `unlock()` from a pointer
+ * handler; until then scheduling runs silently and simply produces no sound.
  */
 
-export interface ChatterBlipPlan {
-  delayMs: number;
+export type ChatterVoice = "low" | "high";
+
+export interface ChatterSyllablePlan {
   frequencyHz: number;
   durationMs: number;
-  gain: number;
-  syllables: 1 | 2;
+  /** Silence between this syllable and the next one. */
+  gapMs: number;
 }
 
-/** Randomized-but-bounded plan; extracted for tests. */
-export const planChatterBlip = (random: () => number = Math.random): ChatterBlipPlan => ({
-  delayMs: 260 + random() * 640,
-  frequencyHz: 165 + random() * 190,
-  durationMs: 70 + random() * 90,
-  gain: 0.024 + random() * 0.02,
-  syllables: random() < 0.4 ? 2 : 1,
-});
+export interface ChatterUtterancePlan {
+  syllables: ChatterSyllablePlan[];
+  gain: number;
+  /** Silence after the utterance before the next voice answers. */
+  pauseAfterMs: number;
+}
+
+/** Randomized-but-bounded utterance; extracted for tests. */
+export const planChatterUtterance = (
+  voice: ChatterVoice,
+  random: () => number = Math.random,
+): ChatterUtterancePlan => {
+  const baseHz = voice === "low" ? 125 + random() * 45 : 205 + random() * 65;
+  const syllableCount = 2 + Math.floor(random() * 4);
+  const questioning = random() < 0.3;
+
+  const syllables: ChatterSyllablePlan[] = [];
+  for (let index = 0; index < syllableCount; index += 1) {
+    const isLast = index === syllableCount - 1;
+    // Wander around the base like unstressed/stressed syllables; the final
+    // one falls for a statement or rises for a question.
+    const contour = isLast
+      ? questioning
+        ? 1.22
+        : 0.8
+      : 0.92 + random() * 0.18;
+    syllables.push({
+      frequencyHz: baseHz * contour,
+      durationMs: 60 + random() * 60,
+      gapMs: isLast ? 0 : 30 + random() * 60,
+    });
+  }
+
+  // Occasionally leave a longer lull so the murmur breathes.
+  const lullMs = random() < 0.18 ? 700 + random() * 900 : 0;
+  return {
+    syllables,
+    gain: 0.05 + random() * 0.03,
+    pauseAfterMs: 380 + random() * 620 + lullMs,
+  };
+};
+
+/** Total footprint of an utterance on the clock, excluding the pause. */
+export const chatterUtteranceDurationMs = (
+  plan: ChatterUtterancePlan,
+): number =>
+  plan.syllables.reduce(
+    (sum, syllable) => sum + syllable.durationMs + syllable.gapMs,
+    0,
+  );
 
 export class ConversationChatterAudio {
   private context: AudioContext | null = null;
   private timer: ReturnType<typeof setTimeout> | null = null;
   private activeConversationCount = 0;
   private disposed = false;
+  private voice: ChatterVoice = "low";
 
   setActiveConversationCount(count: number) {
     if (this.disposed) return;
@@ -85,37 +132,43 @@ export class ConversationChatterAudio {
       this.timer = null;
       return;
     }
-    const plan = planChatterBlip();
-    // More simultaneous conversations chatter a bit more often.
-    const delay = plan.delayMs / Math.sqrt(this.activeConversationCount);
-    this.timer = setTimeout(() => {
-      this.playBlip(plan);
-      this.scheduleNext();
-    }, delay);
+    // Mostly alternate voices so it sounds like an exchange; sometimes the
+    // same voice keeps going, like someone finishing a thought.
+    if (Math.random() < 0.72) {
+      this.voice = this.voice === "low" ? "high" : "low";
+    }
+    const plan = planChatterUtterance(this.voice);
+    this.playUtterance(plan);
+    // More simultaneous conversations pause less between utterances.
+    const pause = plan.pauseAfterMs / Math.sqrt(this.activeConversationCount);
+    this.timer = setTimeout(
+      () => this.scheduleNext(),
+      chatterUtteranceDurationMs(plan) + pause,
+    );
   }
 
-  private playBlip(plan: ChatterBlipPlan) {
+  private playUtterance(plan: ChatterUtterancePlan) {
     if (this.disposed || this.activeConversationCount === 0) return;
     const context = this.ensureContext();
     if (!context || context.state !== "running") return;
 
-    const startAt = context.currentTime + 0.01;
-    const playSyllable = (at: number, frequency: number) => {
+    let at = context.currentTime + 0.01;
+    for (const syllable of plan.syllables) {
       const oscillator = context.createOscillator();
       const gainNode = context.createGain();
       const filter = context.createBiquadFilter();
-      const duration = plan.durationMs / 1000;
+      const duration = syllable.durationMs / 1000;
 
       oscillator.type = "triangle";
-      oscillator.frequency.setValueAtTime(frequency, at);
+      oscillator.frequency.setValueAtTime(syllable.frequencyHz, at);
       oscillator.frequency.exponentialRampToValueAtTime(
-        Math.max(60, frequency * 0.78),
+        Math.max(60, syllable.frequencyHz * 0.82),
         at + duration,
       );
       filter.type = "lowpass";
-      filter.frequency.setValueAtTime(900, at);
+      filter.frequency.setValueAtTime(1000, at);
       gainNode.gain.setValueAtTime(0.0001, at);
-      gainNode.gain.exponentialRampToValueAtTime(plan.gain, at + duration * 0.25);
+      gainNode.gain.exponentialRampToValueAtTime(plan.gain, at + duration * 0.3);
       gainNode.gain.exponentialRampToValueAtTime(0.0001, at + duration);
 
       oscillator.connect(filter);
@@ -123,14 +176,8 @@ export class ConversationChatterAudio {
       gainNode.connect(context.destination);
       oscillator.start(at);
       oscillator.stop(at + duration + 0.02);
-    };
 
-    playSyllable(startAt, plan.frequencyHz);
-    if (plan.syllables === 2) {
-      playSyllable(
-        startAt + plan.durationMs / 1000 + 0.05,
-        plan.frequencyHz * 1.22,
-      );
+      at += duration + syllable.gapMs / 1000;
     }
   }
 }

--- a/tests/unit/officeConversations.test.ts
+++ b/tests/unit/officeConversations.test.ts
@@ -13,7 +13,10 @@ import type {
   KnownConversationGroup,
 } from "../../src/features/retro-office/core/conversations";
 import { AGENT_RADIUS } from "../../src/features/retro-office/core/constants";
-import { planChatterBlip } from "../../src/features/retro-office/systems/conversationChatterAudio";
+import {
+  chatterUtteranceDurationMs,
+  planChatterUtterance,
+} from "../../src/features/retro-office/systems/conversationChatterAudio";
 import { formatAgentSubtitleText } from "../../src/features/retro-office/objects/agents";
 
 const NAMES = {
@@ -239,18 +242,63 @@ describe("conversationTalkTurn", () => {
   });
 });
 
-describe("planChatterBlip", () => {
-  it("stays within audible-but-quiet bounds", () => {
-    for (const roll of [0, 0.25, 0.5, 0.75, 0.999]) {
-      const plan = planChatterBlip(() => roll);
-      expect(plan.delayMs).toBeGreaterThanOrEqual(260);
-      expect(plan.delayMs).toBeLessThanOrEqual(900);
-      expect(plan.frequencyHz).toBeGreaterThanOrEqual(165);
-      expect(plan.frequencyHz).toBeLessThanOrEqual(355);
-      expect(plan.durationMs).toBeGreaterThanOrEqual(70);
-      expect(plan.durationMs).toBeLessThanOrEqual(160);
-      expect(plan.gain).toBeLessThanOrEqual(0.044);
-      expect([1, 2]).toContain(plan.syllables);
+describe("planChatterUtterance", () => {
+  const rolls = [0, 0.25, 0.5, 0.75, 0.999];
+
+  it("stays within audible-but-quiet bounds for both voices", () => {
+    for (const voice of ["low", "high"] as const) {
+      for (const roll of rolls) {
+        const plan = planChatterUtterance(voice, () => roll);
+        expect(plan.syllables.length).toBeGreaterThanOrEqual(2);
+        expect(plan.syllables.length).toBeLessThanOrEqual(5);
+        for (const syllable of plan.syllables) {
+          expect(syllable.frequencyHz).toBeGreaterThanOrEqual(90);
+          expect(syllable.frequencyHz).toBeLessThanOrEqual(400);
+          expect(syllable.durationMs).toBeGreaterThanOrEqual(60);
+          expect(syllable.durationMs).toBeLessThanOrEqual(120);
+          expect(syllable.gapMs).toBeGreaterThanOrEqual(0);
+          expect(syllable.gapMs).toBeLessThanOrEqual(90);
+        }
+        expect(plan.gain).toBeGreaterThan(0);
+        expect(plan.gain).toBeLessThanOrEqual(0.08);
+        expect(plan.pauseAfterMs).toBeGreaterThanOrEqual(380);
+        expect(plan.pauseAfterMs).toBeLessThanOrEqual(2_600);
+      }
+    }
+  });
+
+  it("keeps an utterance short enough to stay conversational", () => {
+    for (const roll of rolls) {
+      const plan = planChatterUtterance("low", () => roll);
+      expect(chatterUtteranceDurationMs(plan)).toBeLessThanOrEqual(1_000);
+    }
+  });
+
+  it("separates the two voice registers under identical randomness", () => {
+    for (const roll of rolls) {
+      const low = planChatterUtterance("low", () => roll);
+      const high = planChatterUtterance("high", () => roll);
+      expect(high.syllables[0].frequencyHz).toBeGreaterThan(
+        low.syllables[0].frequencyHz,
+      );
+    }
+  });
+
+  it("ends on a note away from the base so it reads as speech", () => {
+    // With a mid roll the last syllable falls below the wander band; with a
+    // low roll (questioning) it rises above it.
+    const statement = planChatterUtterance("low", () => 0.5);
+    const statementLast = statement.syllables[statement.syllables.length - 1];
+    const statementBody = statement.syllables.slice(0, -1);
+    for (const syllable of statementBody) {
+      expect(statementLast.frequencyHz).toBeLessThan(syllable.frequencyHz);
+    }
+
+    const question = planChatterUtterance("low", () => 0.1);
+    const questionLast = question.syllables[question.syllables.length - 1];
+    const questionBody = question.syllables.slice(0, -1);
+    for (const syllable of questionBody) {
+      expect(questionLast.frequencyHz).toBeGreaterThan(syllable.frequencyHz);
     }
   });
 });


### PR DESCRIPTION
## Summary

The huddle murmur was one quiet blip every ~half second at a random pitch. Evenly spaced, unrelated notes read as a ticking clock rather than people talking, and the gain was low enough to miss entirely.

- Blips are now grouped into **word-like utterances**: 2-5 syllables wandering around a per-utterance base pitch, ending on a falling note — or occasionally a rising one, like a question.
- Consecutive utterances **alternate between a lower and a higher voice register** (with the same voice sometimes continuing, like someone finishing a thought), separated by natural pauses and occasional longer lulls, so the murmur reads as a back-and-forth exchange.
- Peak gain roughly doubles (0.024-0.044 → 0.05-0.08) while staying ambient; the low-pass keeps it soft.
- Still zero audio assets, still gated on the browser's user-gesture unlock, still starts/stops with conversation groups.

## Test plan

- [x] New unit contracts for the utterance planner: frequency/duration/gap/gain/pause bounds for both voices, utterances capped at 1s so they stay conversational, voice registers separated under identical randomness, and the speech contour (statement falls below the wander band, question rises above it).
- [x] End-to-end against a live `hermes serve` backend with `AudioContext.createOscillator` instrumented: 0 starts before the huddle, 41 syllable starts across 18s once all four agents gathered.
- [x] `npx vitest run` — 178 files, 1175/1175 passing. Typecheck and lint clean.

Made with [Cursor](https://cursor.com)