### PR TITLE
Show the built-in hermes kanban board instead of demanding a skill

### DIFF
--- a/docs/hermes-agent-tailscale.md
+++ b/docs/hermes-agent-tailscale.md
@@ -199,6 +199,12 @@ HERMES3D_GATEWAY_TOKEN=<your-token>
 
 You should land in the office with one character per `hermes-agent` profile.
 
+The kanban desk works out of the box: it shows the backend's built-in
+`hermes kanban` board over the same connection and token — nothing to
+install. Moving a card writes the matching status back to Hermes (dragging
+toward **Working** queues the task as `ready`; the dispatcher is the only
+thing allowed to mark it `running`).
+
 ---
 
 ## Troubleshooting

--- a/server/hermes-agent/bridge.js
+++ b/server/hermes-agent/bridge.js
@@ -19,6 +19,13 @@ const { randomUUID } = require("node:crypto");
 
 const { HermesAgentJsonRpcClient, redactUrl } = require("./jsonrpc-client");
 const { createOfficeSpeechSubscriber } = require("./office-speech");
+const {
+  KANBAN_TASK_ID_PREFIX,
+  toHermes3dKanbanTaskRecord,
+  toHermes3dKanbanTasks,
+  toKanbanPatchBody,
+  kanbanRequest,
+} = require("./kanban");
 
 /** Mirrors the numeric WebSocket readyState constants the proxy compares against. */
 const CONNECTING = 0;
@@ -524,7 +531,10 @@ function createHermesAgentUpstream(options) {
     return resOk(id, {
       type: "hello-ok",
       protocol: 3,
-      adapterType: "hermes",
+      // The client trusts this over the configured type once connected, so
+      // report what the backend actually is — hermes-agent capabilities
+      // (native kanban, profile fleet) hang off this detection.
+      adapterType: "hermes-agent",
       features: {
         methods: [
           "agents.list",
@@ -549,6 +559,7 @@ function createHermesAgentUpstream(options) {
           "skills.status",
           "models.list",
           "tasks.list",
+          "tasks.update",
           "cron.list",
         ],
         events: ["chat", "agent", "presence", "heartbeat", "cron"],
@@ -867,8 +878,60 @@ function createHermesAgentUpstream(options) {
         return resOk(id, { ok: true });
       }
 
-      case "tasks.list":
-        return resOk(id, { tasks: [] });
+      // Kanban is built into hermes-agent — the board rides the same origin
+      // and session token as the JSON-RPC gateway, so the office task board
+      // reflects the real `hermes kanban` board with nothing to install.
+      case "tasks.list": {
+        try {
+          const includeArchived = p.includeArchived === false ? "false" : "true";
+          const board = await kanbanRequest({
+            wsUrl: url,
+            token,
+            useLoopbackHost: client.usedLoopbackHost,
+            method: "GET",
+            path: `/board?include_archived=${includeArchived}`,
+          });
+          return resOk(id, { tasks: toHermes3dKanbanTasks(board) });
+        } catch (err) {
+          // A hidden/disabled kanban plugin or older backend is not an error
+          // state for the office — the board just has no hermes tasks.
+          log(`[hermes-agent] kanban board unavailable: ${errorMessage(err)}`);
+          return resOk(id, { tasks: [] });
+        }
+      }
+
+      case "tasks.update": {
+        const rawId = asString(p.id);
+        if (!rawId.startsWith(KANBAN_TASK_ID_PREFIX)) {
+          return resErr(
+            id,
+            "hermes_agent.tasks_update_unsupported",
+            "Only Hermes kanban tasks can be updated on this backend.",
+          );
+        }
+        const taskId = rawId.slice(KANBAN_TASK_ID_PREFIX.length);
+        try {
+          const result = await kanbanRequest({
+            wsUrl: url,
+            token,
+            useLoopbackHost: client.usedLoopbackHost,
+            method: "PATCH",
+            path: `/tasks/${encodeURIComponent(taskId)}`,
+            body: toKanbanPatchBody(p),
+          });
+          const record = toHermes3dKanbanTaskRecord(result?.task);
+          if (!record) {
+            return resErr(
+              id,
+              "hermes_agent.tasks_update_failed",
+              "hermes-agent did not return the updated task.",
+            );
+          }
+          return resOk(id, record);
+        } catch (err) {
+          return resErr(id, "hermes_agent.tasks_update_failed", errorMessage(err));
+        }
+      }
 
       default:
         log(`[hermes-agent] unhandled method: ${method}`);

--- a/server/hermes-agent/kanban.js
+++ b/server/hermes-agent/kanban.js
@@ -1,0 +1,221 @@
+/**
+ * Hermes kanban board access for the hermes-agent bridge.
+ *
+ * Kanban ships inside hermes-agent itself — every `hermes serve` backend
+ * exposes the board over HTTP on the same origin as the JSON-RPC gateway,
+ * authenticated with the same session token. This module maps the office task
+ * board onto that API so the kanban desk works without installing anything.
+ *
+ * Status vocabularies differ on purpose. The office has five columns; hermes
+ * has nine states with dispatcher semantics. Reads collapse hermes states into
+ * office columns; writes pick the human-legal hermes transition. `running` is
+ * claim-only upstream (the dispatcher owns it), so dragging a card toward
+ * "working" queues it as `ready` and the dispatcher takes it from there.
+ */
+
+const http = require("node:http");
+const https = require("node:https");
+
+/** Office card ids carry this prefix so mutations can be routed back here. */
+const KANBAN_TASK_ID_PREFIX = "kanban:";
+
+/** hermes status -> office column. */
+const READ_STATUS = {
+  triage: "inbox",
+  todo: "inbox",
+  scheduled: "scheduled",
+  ready: "scheduled",
+  running: "working",
+  blocked: "needs_attention",
+  review: "needs_attention",
+  done: "done",
+  archived: "done",
+};
+
+/** Office column -> hermes status a human is allowed to set. */
+const WRITE_STATUS = {
+  inbox: "todo",
+  scheduled: "ready",
+  working: "ready",
+  needs_attention: "blocked",
+  done: "done",
+};
+
+const asTrimmed = (value) =>
+  typeof value === "string" && value.trim() ? value.trim() : "";
+
+/** Kanban stores epoch seconds; the office wants ISO strings. */
+const toIsoTime = (seconds) => {
+  const numeric = Number(seconds);
+  if (!Number.isFinite(numeric) || numeric <= 0) return null;
+  return new Date(numeric * 1000).toISOString();
+};
+
+const NOTE_MAX_CHARS = 280;
+
+const toNote = (label, value) => {
+  const text = asTrimmed(value);
+  if (!text) return null;
+  const clipped =
+    text.length > NOTE_MAX_CHARS ? `${text.slice(0, NOTE_MAX_CHARS - 1)}…` : text;
+  return label ? `${label}: ${clipped}` : clipped;
+};
+
+/** One hermes kanban task -> the office `GatewayTaskRecord` shape. */
+const toHermes3dKanbanTaskRecord = (task) => {
+  if (!task || typeof task !== "object") return null;
+  const taskId = asTrimmed(task.id);
+  const title = asTrimmed(task.title);
+  if (!taskId || !title) return null;
+
+  const status = READ_STATUS[asTrimmed(task.status)] ?? "inbox";
+  const createdAt = toIsoTime(task.created_at) ?? new Date(0).toISOString();
+  const updatedAt =
+    toIsoTime(task.completed_at) ?? toIsoTime(task.started_at) ?? createdAt;
+  const notes = [
+    toNote("", task.latest_summary),
+    toNote("Result", task.result),
+    toNote("Blocked", task.last_failure_error),
+  ].filter(Boolean);
+
+  return {
+    id: `${KANBAN_TASK_ID_PREFIX}${taskId}`,
+    title,
+    description: typeof task.body === "string" ? task.body : "",
+    status,
+    source: "hermes_event",
+    sourceEventId: null,
+    assignedAgentId: asTrimmed(task.assignee) || null,
+    createdAt,
+    updatedAt,
+    playbookJobId: null,
+    runId: asTrimmed(task.current_run_id) || null,
+    channel: "kanban",
+    externalThreadId: asTrimmed(task.session_id) || null,
+    lastActivityAt: toIsoTime(task.last_heartbeat_at) ?? updatedAt,
+    notes,
+    archived: asTrimmed(task.status) === "archived",
+  };
+};
+
+/** The whole `GET /board` response -> a flat office task list. */
+const toHermes3dKanbanTasks = (board) => {
+  const columns = Array.isArray(board?.columns) ? board.columns : [];
+  const records = [];
+  for (const column of columns) {
+    const tasks = Array.isArray(column?.tasks) ? column.tasks : [];
+    for (const task of tasks) {
+      const record = toHermes3dKanbanTaskRecord(task);
+      if (record) records.push(record);
+    }
+  }
+  return records;
+};
+
+/**
+ * An office task patch -> the kanban `PATCH /tasks/{id}` body.
+ *
+ * Archiving wins over any simultaneous status change: the office models
+ * archive as a flag while hermes models it as a status.
+ */
+const toKanbanPatchBody = (patch) => {
+  const body = {};
+  const title = asTrimmed(patch?.title);
+  if (title) body.title = title;
+  if (typeof patch?.description === "string") body.body = patch.description;
+  if (patch?.assignedAgentId !== undefined) {
+    body.assignee = asTrimmed(patch.assignedAgentId) || "";
+  }
+  const status = WRITE_STATUS[asTrimmed(patch?.status)];
+  if (status) body.status = status;
+  if (patch?.archived === true) body.status = "archived";
+  return body;
+};
+
+/** ws(s):// gateway URL -> the http(s) origin serving the kanban plugin API. */
+const kanbanOriginFromWsUrl = (wsUrl) => {
+  const parsed = new URL(String(wsUrl));
+  const protocol =
+    parsed.protocol === "wss:" || parsed.protocol === "https:" ? "https:" : "http:";
+  return { protocol, hostname: parsed.hostname, port: parsed.port };
+};
+
+const REQUEST_TIMEOUT_MS = 10_000;
+
+/**
+ * Minimal JSON client for `/api/plugins/kanban/*`.
+ *
+ * Uses node's http module rather than fetch because the Tailscale Serve
+ * topology sometimes requires overriding the Host header to a loopback name —
+ * the same fallback the WebSocket client negotiates — and fetch forbids that.
+ */
+const kanbanRequest = ({ wsUrl, token, useLoopbackHost, method, path, body }) =>
+  new Promise((resolve, reject) => {
+    let origin;
+    try {
+      origin = kanbanOriginFromWsUrl(wsUrl);
+    } catch (err) {
+      reject(err);
+      return;
+    }
+    const transport = origin.protocol === "https:" ? https : http;
+    const payload = body === undefined ? null : JSON.stringify(body);
+    const request = transport.request(
+      {
+        protocol: origin.protocol,
+        hostname: origin.hostname,
+        port: origin.port || undefined,
+        method,
+        path: `/api/plugins/kanban${path}`,
+        headers: {
+          Accept: "application/json",
+          "X-Hermes-Session-Token": String(token ?? ""),
+          ...(payload
+            ? {
+                "Content-Type": "application/json",
+                "Content-Length": Buffer.byteLength(payload),
+              }
+            : {}),
+          ...(useLoopbackHost ? { Host: "127.0.0.1" } : {}),
+        },
+      },
+      (response) => {
+        const chunks = [];
+        response.on("data", (chunk) => chunks.push(chunk));
+        response.on("end", () => {
+          const text = Buffer.concat(chunks).toString("utf8");
+          const statusCode = response.statusCode ?? 0;
+          if (statusCode < 200 || statusCode >= 300) {
+            let detail = text.slice(0, 300);
+            try {
+              detail = JSON.parse(text)?.detail ?? detail;
+            } catch {}
+            reject(
+              new Error(`kanban API responded with HTTP ${statusCode}: ${detail}`),
+            );
+            return;
+          }
+          try {
+            resolve(text ? JSON.parse(text) : {});
+          } catch {
+            reject(new Error("kanban API returned invalid JSON."));
+          }
+        });
+      },
+    );
+    request.setTimeout(REQUEST_TIMEOUT_MS, () => {
+      request.destroy(new Error("kanban API request timed out."));
+    });
+    request.on("error", reject);
+    if (payload) request.write(payload);
+    request.end();
+  });
+
+module.exports = {
+  KANBAN_TASK_ID_PREFIX,
+  toHermes3dKanbanTaskRecord,
+  toHermes3dKanbanTasks,
+  toKanbanPatchBody,
+  kanbanOriginFromWsUrl,
+  kanbanRequest,
+};

--- a/src/features/office/screens/OfficeScreen.tsx
+++ b/src/features/office/screens/OfficeScreen.tsx
@@ -4260,6 +4260,11 @@ export function OfficeScreen({
     () => (taskManagerSkill ? deriveSkillReadinessState(taskManagerSkill) === "ready" : false),
     [taskManagerSkill],
   );
+  // Kanban is built into hermes-agent (`hermes kanban` + the dashboard board
+  // API the bridge proxies as tasks.list), so the desk must not demand the
+  // task-manager skill there — that skill is the legacy backend's task store.
+  const kanbanDeskEnabled =
+    taskManagerReady || activeAdapterType === "hermes-agent";
   const soundhermesReady = useMemo(
     () => (soundhermesSkill ? deriveSkillReadinessState(soundhermesSkill) === "ready" : false),
     [soundhermesSkill]
@@ -4476,7 +4481,7 @@ export function OfficeScreen({
           monitorAgentId={monitorAgentId}
           monitorByAgentId={monitorByAgentId}
           githubSkill={githubSkill}
-          taskManagerEnabled={taskManagerReady}
+          taskManagerEnabled={kanbanDeskEnabled}
           soundhermesEnabled={soundhermesReady}
           officeTitle={officeTitle}
           officeTitleLoaded={officeTitleLoaded}

--- a/src/features/office/tasks/useTaskBoardController.ts
+++ b/src/features/office/tasks/useTaskBoardController.ts
@@ -43,9 +43,12 @@ import {
 } from "@/lib/studio/settings";
 import type { StudioSettingsCoordinator } from "@/lib/studio/coordinator";
 import {
+  isKanbanManagedTaskId,
   isUnsupportedTaskGatewayError,
   listGatewayTasks,
+  updateGatewayTask,
   type GatewayTaskRecord,
+  type GatewayTaskUpdateInput,
 } from "@/lib/tasks/gateway";
 import {
   archiveSharedTaskRecord,
@@ -964,6 +967,19 @@ export const useTaskBoardController = ({
     void refreshRemoteTasks();
   }, [refreshRemoteTasks]);
 
+  // Backend-managed boards (hermes kanban) change from outside this client —
+  // workers claim tasks, the dispatcher completes them — so keep polling while
+  // the gateway actually serves tasks.
+  useEffect(() => {
+    if (gatewayTasksSupported !== "supported" || status !== "connected") return;
+    const intervalId = window.setInterval(() => {
+      void refreshRemoteTasks();
+    }, 12_000);
+    return () => {
+      window.clearInterval(intervalId);
+    };
+  }, [gatewayTasksSupported, refreshRemoteTasks, status]);
+
   useEffect(() => {
     if (!hydratedRef.current) return;
     const playbookCards = buildPlaybookCards(cronJobs, stateRef.current.cards);
@@ -1067,12 +1083,56 @@ export const useTaskBoardController = ({
     [applySharedTaskRecord],
   );
 
+  // Kanban cards live on the hermes backend; writing them to the shared file
+  // store would create a divergent local copy that the next board refresh
+  // fights. Round-trip the patch through the gateway and apply its truth.
+  const persistKanbanCardPatch = useCallback(
+    async (
+      cardId: string,
+      patch: GatewayTaskUpdateInput,
+      revertCard: TaskBoardCard,
+    ) => {
+      try {
+        const updated = await updateGatewayTask(client, cardId, patch);
+        applyGatewayTaskRecord(updated);
+      } catch (error) {
+        dispatch({ type: "upsert", card: revertCard });
+        setGatewayTasksError(
+          error instanceof Error
+            ? error.message
+            : "Failed to update the Hermes kanban task.",
+        );
+      }
+    },
+    [applyGatewayTaskRecord, client],
+  );
+
   const updateCard = useCallback(
     async (cardId: string, patch: Partial<TaskBoardCard>) => {
       const existing =
         stateRef.current.cards.find((card) => card.id === cardId) ?? null;
       dispatch({ type: "update", cardId, patch });
       if (!existing || existing.isInferred) return;
+      if (isKanbanManagedTaskId(cardId)) {
+        await persistKanbanCardPatch(
+          cardId,
+          {
+            ...(patch.title !== undefined ? { title: patch.title } : {}),
+            ...(patch.description !== undefined
+              ? { description: patch.description }
+              : {}),
+            ...(patch.status !== undefined ? { status: patch.status } : {}),
+            ...(patch.assignedAgentId !== undefined
+              ? { assignedAgentId: patch.assignedAgentId }
+              : {}),
+            ...(patch.isArchived !== undefined
+              ? { archived: patch.isArchived }
+              : {}),
+          },
+          existing,
+        );
+        return;
+      }
       try {
         const updated = await upsertSharedTaskRecord({
           ...existing,
@@ -1092,7 +1152,7 @@ export const useTaskBoardController = ({
         );
       }
     },
-    [applySharedTaskRecord],
+    [applySharedTaskRecord, persistKanbanCardPatch],
   );
 
   const moveCard = useCallback(
@@ -1101,6 +1161,10 @@ export const useTaskBoardController = ({
         stateRef.current.cards.find((card) => card.id === cardId) ?? null;
       dispatch({ type: "move", cardId, status: nextStatus });
       if (!existing || existing.isInferred) return;
+      if (isKanbanManagedTaskId(cardId)) {
+        await persistKanbanCardPatch(cardId, { status: nextStatus }, existing);
+        return;
+      }
       try {
         const updated = await upsertSharedTaskRecord({
           ...existing,
@@ -1120,7 +1184,7 @@ export const useTaskBoardController = ({
         );
       }
     },
-    [applySharedTaskRecord],
+    [applySharedTaskRecord, persistKanbanCardPatch],
   );
 
   const removeCard = useCallback(
@@ -1140,6 +1204,10 @@ export const useTaskBoardController = ({
         return;
       }
       dispatch({ type: "update", cardId, patch: { isArchived: true } });
+      if (isKanbanManagedTaskId(cardId)) {
+        await persistKanbanCardPatch(cardId, { archived: true }, existing);
+        return;
+      }
       try {
         const archived = await archiveSharedTaskRecord(cardId);
         applySharedTaskRecord(archived);
@@ -1152,7 +1220,7 @@ export const useTaskBoardController = ({
         );
       }
     },
-    [applySharedTaskRecord],
+    [applySharedTaskRecord, persistKanbanCardPatch],
   );
 
   const lastDedupeSnapshotRef = useRef<string | null>(null);

--- a/src/lib/gateway/GatewayClient.ts
+++ b/src/lib/gateway/GatewayClient.ts
@@ -958,6 +958,7 @@ export const useGatewayConnection = (
       const nextDetectedAdapterType =
         hello?.adapterType === "demo" ||
         hello?.adapterType === "hermes" ||
+        hello?.adapterType === "hermes-agent" ||
         hello?.adapterType === "custom"
           ? hello.adapterType
           : "hermes";

--- a/src/lib/gateway/protocol/GatewayBrowserClient.ts
+++ b/src/lib/gateway/protocol/GatewayBrowserClient.ts
@@ -363,7 +363,7 @@ export type GatewayResponseFrame = {
 export type GatewayHelloOk = {
   type: "hello-ok";
   protocol: number;
-  adapterType?: "hermes" | "demo" | "custom";
+  adapterType?: "hermes" | "hermes-agent" | "demo" | "custom";
   features?: { methods?: string[]; events?: string[] };
   snapshot?: unknown;
   auth?: {

--- a/src/lib/tasks/gateway.ts
+++ b/src/lib/tasks/gateway.ts
@@ -57,6 +57,17 @@ const trimOrUndefined = (value: string | null | undefined) => {
   return trimmed || undefined;
 };
 
+/**
+ * Cards fed from a backend-managed board (hermes-agent's built-in kanban)
+ * carry this id prefix. Their mutations must round-trip through the gateway
+ * instead of the local shared store, or the next board refresh would fight a
+ * divergent local copy.
+ */
+export const KANBAN_TASK_ID_PREFIX = "kanban:";
+
+export const isKanbanManagedTaskId = (id: string): boolean =>
+  id.startsWith(KANBAN_TASK_ID_PREFIX);
+
 export const isUnsupportedTaskGatewayError = (error: unknown): boolean => {
   if (!(error instanceof GatewayResponseError)) return false;
   const code = error.code.trim().toUpperCase();

--- a/tests/unit/hermesAgentKanban.test.ts
+++ b/tests/unit/hermesAgentKanban.test.ts
@@ -1,0 +1,176 @@
+// @vitest-environment node
+import { describe, expect, it } from "vitest";
+
+import {
+  TASK_BOARD_STATUSES,
+  isTaskBoardStatus,
+} from "../../src/features/office/tasks/types";
+
+const {
+  KANBAN_TASK_ID_PREFIX,
+  toHermes3dKanbanTaskRecord,
+  toHermes3dKanbanTasks,
+  toKanbanPatchBody,
+  kanbanOriginFromWsUrl,
+} = await import("../../server/hermes-agent/kanban");
+
+const HERMES_STATUSES = [
+  "triage",
+  "todo",
+  "scheduled",
+  "ready",
+  "running",
+  "blocked",
+  "review",
+  "done",
+  "archived",
+] as const;
+
+const sampleTask = (overrides: Record<string, unknown> = {}) => ({
+  id: "t_4925f3b7",
+  title: "Ship the release",
+  body: "Cut the tag and publish.",
+  assignee: "pr-fixer",
+  status: "ready",
+  created_at: 1_787_223_224,
+  started_at: null,
+  completed_at: null,
+  last_heartbeat_at: null,
+  current_run_id: null,
+  session_id: null,
+  latest_summary: null,
+  result: null,
+  last_failure_error: null,
+  ...overrides,
+});
+
+const mustMap = (task: Record<string, unknown>) => {
+  const record = toHermes3dKanbanTaskRecord(task);
+  expect(record).not.toBeNull();
+  return record as NonNullable<typeof record>;
+};
+
+describe("toHermes3dKanbanTaskRecord", () => {
+  it("maps every hermes status onto a valid office column", () => {
+    for (const status of HERMES_STATUSES) {
+      const record = mustMap(sampleTask({ status }));
+      expect(isTaskBoardStatus(record.status)).toBe(true);
+    }
+  });
+
+  it("keeps dispatcher truth visible: running is the only working column", () => {
+    for (const status of HERMES_STATUSES) {
+      const record = mustMap(sampleTask({ status }));
+      expect(record.status === "working").toBe(status === "running");
+    }
+  });
+
+  it("prefixes the id and converts epoch seconds to ISO timestamps", () => {
+    const record = mustMap(sampleTask());
+    expect(record.id).toBe(`${KANBAN_TASK_ID_PREFIX}t_4925f3b7`);
+    expect(record.createdAt).toBe(new Date(1_787_223_224 * 1000).toISOString());
+    expect(record.channel).toBe("kanban");
+    expect(record.assignedAgentId).toBe("pr-fixer");
+    expect(record.archived).toBe(false);
+  });
+
+  it("marks archived tasks and surfaces summaries as notes", () => {
+    const record = mustMap(
+      sampleTask({
+        status: "archived",
+        latest_summary: "Merged and deployed.",
+        result: "All checks green.",
+      }),
+    );
+    expect(record.archived).toBe(true);
+    expect(record.notes).toEqual([
+      "Merged and deployed.",
+      "Result: All checks green.",
+    ]);
+  });
+
+  it("rejects rows without an id or title", () => {
+    expect(toHermes3dKanbanTaskRecord(sampleTask({ id: "" }))).toBeNull();
+    expect(toHermes3dKanbanTaskRecord(sampleTask({ title: "  " }))).toBeNull();
+    expect(toHermes3dKanbanTaskRecord(null)).toBeNull();
+  });
+});
+
+describe("toHermes3dKanbanTasks", () => {
+  it("flattens the board columns into one task list", () => {
+    const board = {
+      columns: [
+        { name: "todo", tasks: [sampleTask({ id: "t_1", status: "todo" })] },
+        { name: "running", tasks: [sampleTask({ id: "t_2", status: "running" })] },
+        { name: "done", tasks: [] },
+      ],
+    };
+    const tasks = toHermes3dKanbanTasks(board);
+    expect(tasks.map((task) => task.id)).toEqual([
+      `${KANBAN_TASK_ID_PREFIX}t_1`,
+      `${KANBAN_TASK_ID_PREFIX}t_2`,
+    ]);
+  });
+
+  it("returns an empty list for malformed payloads", () => {
+    expect(toHermes3dKanbanTasks(null)).toEqual([]);
+    expect(toHermes3dKanbanTasks({})).toEqual([]);
+    expect(toHermes3dKanbanTasks({ columns: [{ tasks: [{}] }] })).toEqual([]);
+  });
+});
+
+describe("toKanbanPatchBody", () => {
+  it("maps every office column to a status a human may set upstream", () => {
+    // PATCH rejects `running` — only the dispatcher claims into it. Dragging
+    // toward "working" must queue the task as `ready` instead.
+    for (const status of TASK_BOARD_STATUSES) {
+      const body = toKanbanPatchBody({ status });
+      expect(body.status).toBeDefined();
+      expect(body.status).not.toBe("running");
+    }
+    expect(toKanbanPatchBody({ status: "working" }).status).toBe("ready");
+    expect(toKanbanPatchBody({ status: "inbox" }).status).toBe("todo");
+    expect(toKanbanPatchBody({ status: "needs_attention" }).status).toBe(
+      "blocked",
+    );
+    expect(toKanbanPatchBody({ status: "done" }).status).toBe("done");
+  });
+
+  it("lets the archive flag win over a simultaneous status change", () => {
+    expect(toKanbanPatchBody({ status: "working", archived: true }).status).toBe(
+      "archived",
+    );
+  });
+
+  it("maps title, description, and assignee onto the kanban fields", () => {
+    expect(
+      toKanbanPatchBody({
+        title: "  New title ",
+        description: "Body text.",
+        assignedAgentId: "pr-reviewer",
+      }),
+    ).toEqual({
+      title: "New title",
+      body: "Body text.",
+      assignee: "pr-reviewer",
+    });
+    // Explicit unassignment sends the empty string the PATCH API expects.
+    expect(toKanbanPatchBody({ assignedAgentId: null }).assignee).toBe("");
+    expect(toKanbanPatchBody({})).toEqual({});
+  });
+});
+
+describe("kanbanOriginFromWsUrl", () => {
+  it("derives the http(s) origin from the gateway WebSocket URL", () => {
+    expect(kanbanOriginFromWsUrl("ws://127.0.0.1:9119/api/ws")).toEqual({
+      protocol: "http:",
+      hostname: "127.0.0.1",
+      port: "9119",
+    });
+    expect(kanbanOriginFromWsUrl("wss://box.ts.net:8443/api/ws")).toEqual({
+      protocol: "https:",
+      hostname: "box.ts.net",
+      port: "8443",
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Clicking the kanban desk on a hermes-agent connection showed "Kanban Skill Not Installed — install the TASK-MANAGER skill". That gate belongs to the legacy backend, where task tracking is a skill that writes a JSON file. Kanban is **built into hermes-agent** — every `hermes serve` exposes the board at `/api/plugins/kanban/*` on the same origin and session token the gateway already uses. The office now shows that board with nothing to install.

- **Read**: the bridge's `tasks.list` (previously hardcoded `{tasks: []}`) fetches `GET /board` and maps hermes tasks onto office cards — `kanban:` id prefix, epoch-seconds → ISO, and the nine hermes statuses collapsed onto the five office columns (`triage/todo → Inbox`, `scheduled/ready → Scheduled`, `running → Working`, `blocked/review → Needs attention`, `done/archived → Done`).
- **Write**: a new `tasks.update` bridge handler PATCHes the task upstream. Hermes rejects a direct move to `running` (the dispatcher owns claims), so dragging toward **Working** queues the task as `ready` — the dispatcher then actually runs it. Archive maps to the `archived` status.
- **No divergent copies**: the board controller routes mutations of `kanban:` cards through the gateway instead of the local shared task store, and polls the backend board every 12s so worker/dispatcher activity appears.
- **Honest adapter identity**: the bridge's hello now announces `adapterType: "hermes-agent"` and the client accepts it — detection previously downgraded every bridge connection to `"hermes"`, which is exactly why the skill gate fired. The desk gate keys off that identity; the legacy skill flow is untouched for legacy backends.
- Documented in `docs/hermes-agent-tailscale.md`.

## Test plan

- [x] New unit contracts (`hermesAgentKanban.test.ts`): every hermes status maps to a valid office column, only `running` renders as Working, the write map never emits `running`, archive wins over concurrent status changes, id/timestamp/notes mapping, origin derivation from ws/wss URLs.
- [x] Live end-to-end against a real `hermes serve`: created a task via the kanban HTTP API, clicked KANBAN BOARD headlessly — no install modal, the board opened with the task in Scheduled; sent `tasks.update` through the studio proxy and confirmed the task landed as `blocked` in the kanban SQLite DB; archived and deleted the probe task afterwards.
- [x] `npx vitest run` — 179 files, 1186/1186. Typecheck clean, lint 0 errors.

Made with [Cursor](https://cursor.com)