### PR TITLE
Link published images to the repository with OCI labels

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,6 +21,12 @@ WORKDIR /app
 ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1
 
+# Links images to the repository on GHCR, so packages created by a push
+# automatically grant this repo's workflows access and show up on the repo page.
+LABEL org.opencontainers.image.source="https://github.com/iamlukethedev/Hermes3D"
+LABEL org.opencontainers.image.description="Hermes3D — a 3D workspace for AI agents."
+LABEL org.opencontainers.image.licenses="MIT"
+
 # Copy built app + custom server + production node_modules only.
 COPY --from=builder /app/.next ./.next
 COPY --from=builder /app/public ./public


### PR DESCRIPTION
## Summary

Adds the standard OCI image labels to the runner stage. The `org.opencontainers.image.source` label links images pushed to GHCR back to this repository, so a freshly created package automatically grants this repo's workflows access — the missing link that caused every `Docker Publish` run to fail with `permission_denied: write_package` after the rebrand-era package lost its repo association.

## Test plan

- [x] Labels only touch the final stage; no build behaviour change.

Made with [Cursor](https://cursor.com)