### PR TITLE
Release 1.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "hermes3d",
-  "version": "0.1.4",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "hermes3d",
-      "version": "0.1.4",
+      "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
         "@noble/ed25519": "^3.0.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hermes3d",
-  "version": "0.1.4",
+  "version": "1.0.0",
   "private": true,
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
First public release. Bumps the package version to 1.0.0 ahead of tagging v1.0.0, which publishes ghcr.io/iamlukethedev/hermes3d:1.0.0 and :latest.

Made with [Cursor](https://cursor.com)