### PR TITLE
Improve adaptive mobile rendering performance

### DIFF
--- a/src/features/retro-office/RetroOffice3D.tsx
+++ b/src/features/retro-office/RetroOffice3D.tsx
@@ -240,6 +240,7 @@ import {
   getGraphicsQualityConfig,
   isSoftwareWebGLRenderer,
   resolveInitialGraphicsQuality,
+  resolveRenderDpr,
   loadStoredGraphicsQuality,
   saveGraphicsQuality,
   type GraphicsQuality,
@@ -831,7 +832,7 @@ function AdaptiveDprController({ maxDpr: maxDprCap = 1.5 }: { maxDpr?: number })
   const avgDeltaRef = useRef(1 / 60);
 
   useEffect(() => {
-    const initialDpr = Math.min(window.devicePixelRatio || 1, maxDprCap);
+    const initialDpr = resolveRenderDpr(window.devicePixelRatio, maxDprCap);
     currentDprRef.current = initialDpr;
     setDpr(initialDpr);
     const handleVisibilityChange = () => {
@@ -840,7 +841,7 @@ function AdaptiveDprController({ maxDpr: maxDprCap = 1.5 }: { maxDpr?: number })
         setDpr(0.85);
         return;
       }
-      const restoredDpr = Math.min(window.devicePixelRatio || 1, maxDprCap);
+      const restoredDpr = resolveRenderDpr(window.devicePixelRatio, maxDprCap);
       currentDprRef.current = restoredDpr;
       setDpr(restoredDpr);
     };
@@ -857,7 +858,7 @@ function AdaptiveDprController({ maxDpr: maxDprCap = 1.5 }: { maxDpr?: number })
     if (frameCounterRef.current < 45) return;
     frameCounterRef.current = 0;
 
-    const maxDpr = Math.min(window.devicePixelRatio || 1, maxDprCap);
+    const maxDpr = resolveRenderDpr(window.devicePixelRatio, maxDprCap);
     const minDpr = 0.85;
     let nextDpr = currentDprRef.current;
     if (avgDeltaRef.current > 1 / 42) {
@@ -5774,7 +5775,7 @@ export function RetroOffice3D({
         {!immersiveOverlayActive ? (
           <SceneErrorBoundary>
           <Canvas
-            key={canvasResetKey}
+            key={`${canvasResetKey}-${graphicsQuality}`}
             dpr={[0.85, graphicsQualityConfig.maxDpr]}
             camera={{
               position: CAM_POS,
@@ -5782,9 +5783,9 @@ export function RetroOffice3D({
               near: 0.3,
               far: 320,
             }}
-            shadows={{ type: THREE.PCFShadowMap }}
+            shadows={graphicsQualityConfig.shadows ? { type: THREE.PCFShadowMap } : false}
             gl={{
-              antialias: true,
+              antialias: graphicsQualityConfig.antialias,
               powerPreference: "high-performance",
               toneMapping: THREE.ACESFilmicToneMapping,
               toneMappingExposure: 1.0,

--- a/src/features/retro-office/core/graphicsQuality.ts
+++ b/src/features/retro-office/core/graphicsQuality.ts
@@ -28,6 +28,12 @@ export const GRAPHICS_QUALITY_OPTIONS: Array<{
 ];
 
 export type GraphicsQualityConfig = {
+  /** Whether dynamic shadows are rendered. */
+  shadows: boolean;
+  /** Whether the default framebuffer uses MSAA. */
+  antialias: boolean;
+  /** Whether decorative particles are mounted. */
+  decorativeMotion: boolean;
   /** Shadow map resolution for the key light. */
   shadowMapSize: number;
   /** Upper bound for the adaptive device pixel ratio controller. */
@@ -48,8 +54,11 @@ export type GraphicsQualityConfig = {
 
 const QUALITY_CONFIGS: Record<GraphicsQuality, GraphicsQualityConfig> = {
   low: {
-    shadowMapSize: 1024,
-    maxDpr: 1.25,
+    shadows: false,
+    antialias: false,
+    decorativeMotion: false,
+    shadowMapSize: 512,
+    maxDpr: 1,
     postProcessing: false,
     ambientOcclusion: false,
     aoQuality: "performance",
@@ -58,6 +67,9 @@ const QUALITY_CONFIGS: Record<GraphicsQuality, GraphicsQualityConfig> = {
     followDepthOfField: false,
   },
   balanced: {
+    shadows: true,
+    antialias: true,
+    decorativeMotion: true,
     shadowMapSize: 2048,
     maxDpr: 1.5,
     postProcessing: true,
@@ -68,6 +80,9 @@ const QUALITY_CONFIGS: Record<GraphicsQuality, GraphicsQualityConfig> = {
     followDepthOfField: false,
   },
   ultra: {
+    shadows: true,
+    antialias: true,
+    decorativeMotion: true,
     shadowMapSize: 4096,
     maxDpr: 2,
     postProcessing: true,
@@ -156,8 +171,53 @@ export const detectSoftwareWebGL = (): boolean => {
  * The quality the office should boot with: the user's stored choice, or a
  * hardware-appropriate default.
  */
+export type GraphicsCapabilities = {
+  viewportWidth: number;
+  coarsePointer: boolean;
+  deviceMemory?: number;
+  reducedMotion: boolean;
+  softwareRenderer: boolean;
+};
+
+export const resolveAutomaticGraphicsQuality = (
+  capabilities: GraphicsCapabilities,
+): GraphicsQuality => {
+  if (capabilities.softwareRenderer || capabilities.reducedMotion) return "low";
+  const constrainedMemory =
+    typeof capabilities.deviceMemory === "number" && capabilities.deviceMemory <= 4;
+  if (
+    capabilities.viewportWidth <= 768 &&
+    (capabilities.coarsePointer || constrainedMemory)
+  ) {
+    return "low";
+  }
+  return "balanced";
+};
+
+export const readGraphicsCapabilities = (): GraphicsCapabilities => ({
+  viewportWidth: typeof window === "undefined" ? 1024 : window.innerWidth,
+  coarsePointer:
+    typeof window !== "undefined" && window.matchMedia("(pointer: coarse)").matches,
+  deviceMemory:
+    typeof navigator === "undefined"
+      ? undefined
+      : (navigator as Navigator & { deviceMemory?: number }).deviceMemory,
+  reducedMotion:
+    typeof window !== "undefined" &&
+    window.matchMedia("(prefers-reduced-motion: reduce)").matches,
+  softwareRenderer: detectSoftwareWebGL(),
+});
+
 export const resolveInitialGraphicsQuality = (): GraphicsQuality =>
-  loadStoredGraphicsQuality() ?? (detectSoftwareWebGL() ? "low" : "balanced");
+  loadStoredGraphicsQuality() ?? resolveAutomaticGraphicsQuality(readGraphicsCapabilities());
+
+export const resolveRenderDpr = (
+  devicePixelRatio: number,
+  maxDpr: number,
+): number => Math.max(0.75, Math.min(devicePixelRatio || 1, maxDpr));
+
+export const shouldRunAnimationFrame = (visibilityState: DocumentVisibilityState): boolean =>
+  visibilityState === "visible";
 
 export const saveGraphicsQuality = (quality: GraphicsQuality) => {
   if (typeof window === "undefined") return;

--- a/src/features/retro-office/systems/atmosphere.tsx
+++ b/src/features/retro-office/systems/atmosphere.tsx
@@ -278,7 +278,7 @@ export function SceneAtmosphere({
         position={SUN_BASE_POSITION.toArray()}
         intensity={3.3}
         color="#ffedd2"
-        castShadow
+        castShadow={config.shadows}
         shadow-mapSize={[config.shadowMapSize, config.shadowMapSize]}
         shadow-bias={-0.00015}
         shadow-normalBias={0.025}
@@ -330,12 +330,14 @@ export function SceneAtmosphere({
       ))}
 
       {/* Drifting dust motes over the office interior. */}
-      <DustMotes
-        centerX={groundCenterX}
-        centerZ={groundCenterZ}
-        extentX={groundWidth * 0.9}
-        extentZ={groundHeight * 0.9}
-      />
+      {config.decorativeMotion ? (
+        <DustMotes
+          centerX={groundCenterX}
+          centerZ={groundCenterZ}
+          extentX={groundWidth * 0.9}
+          extentZ={groundHeight * 0.9}
+        />
+      ) : null}
 
       <DaylightDrift sunRef={sunRef} />
     </>

--- a/src/features/retro-office/systems/sceneRuntime.tsx
+++ b/src/features/retro-office/systems/sceneRuntime.tsx
@@ -3,6 +3,7 @@
 import { useFrame, useThree } from "@react-three/fiber";
 import { useEffect, useMemo, useRef, type RefObject } from "react";
 import * as THREE from "three";
+import { shouldRunAnimationFrame } from "@/features/retro-office/core/graphicsQuality";
 import {
   PING_PONG_BALL_RADIUS,
   PING_PONG_TABLE_SURFACE_Y,
@@ -183,7 +184,9 @@ export function PingPongBall({
 }
 
 export function GameLoop({ tick }: { tick: () => void }) {
-  useFrame(() => tick());
+  useFrame(() => {
+    if (shouldRunAnimationFrame(document.visibilityState)) tick();
+  });
   return null;
 }
 

--- a/tests/unit/graphicsQuality.test.ts
+++ b/tests/unit/graphicsQuality.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import {
+  GRAPHICS_QUALITY_STORAGE_KEY,
+  loadStoredGraphicsQuality,
+  resolveAutomaticGraphicsQuality,
+  resolveRenderDpr,
+  shouldRunAnimationFrame,
+} from "@/features/retro-office/core/graphicsQuality";
+
+describe("graphics quality selection", () => {
+  it("keeps unconstrained desktop hardware balanced", () => {
+    expect(resolveAutomaticGraphicsQuality({
+      viewportWidth: 1440, coarsePointer: false, deviceMemory: 8,
+      reducedMotion: false, softwareRenderer: false,
+    })).toBe("balanced");
+  });
+
+  it("starts constrained mobile and reduced-motion devices low", () => {
+    expect(resolveAutomaticGraphicsQuality({
+      viewportWidth: 412, coarsePointer: true, deviceMemory: 4,
+      reducedMotion: false, softwareRenderer: false,
+    })).toBe("low");
+    expect(resolveAutomaticGraphicsQuality({
+      viewportWidth: 1440, coarsePointer: false, deviceMemory: 8,
+      reducedMotion: true, softwareRenderer: false,
+    })).toBe("low");
+  });
+
+  it("preserves an explicit user override", () => {
+    window.localStorage.setItem(GRAPHICS_QUALITY_STORAGE_KEY, "ultra");
+    expect(loadStoredGraphicsQuality()).toBe("ultra");
+    window.localStorage.removeItem(GRAPHICS_QUALITY_STORAGE_KEY);
+  });
+
+  it("caps DPR and rejects unusably small values", () => {
+    expect(resolveRenderDpr(3, 1)).toBe(1);
+    expect(resolveRenderDpr(0.5, 2)).toBe(0.75);
+  });
+
+  it("pauses scene simulation while the document is hidden", () => {
+    expect(shouldRunAnimationFrame("visible")).toBe(true);
+    expect(shouldRunAnimationFrame("hidden")).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary
- choose the existing Low renderer tier automatically for constrained mobile/coarse-pointer devices, reduced-motion users, and software WebGL while preserving explicit user overrides
- reduce Low-tier GPU work by capping DPR at 1, disabling framebuffer MSAA, dynamic shadows, and decorative particles
- pause the scene simulation tick while the document is hidden
- keep Balanced and Ultra desktop defaults visually unchanged

## Problem and profiling
A real phone can render the office, but the current default is not responsive enough. Profiling first showed the existing renderer already had quality presets and adaptive DPR, so this patch extends those mechanisms rather than adding a separate mobile renderer or UA sniffing.

The reproducible comparison used clean production builds from the same `main` revision and route, Chromium's 412×915 mobile profile at DPR 3, and SwiftShader. It is a constrained software-renderer proxy, not a real-phone benchmark. Results are one matched checkpoint and should be treated as directional rather than statistically conclusive.

| Metric | `main` | this branch | change |
|---|---:|---:|---:|
| drawing buffer | 515×1143 (588,645 px) | 412×915 (376,980 px) | -36.0% pixels |
| sampled FPS | 1.83 | 2.46 | +34.0% |
| median sampled frame interval | 33.4 ms | 16.7 ms | -50.0% |
| used JS heap after capture | 66.9 MB | 48.4 MB | -27.6% |
| production network transfer | 5.10 MB | 5.10 MB | unchanged |

Long-task results were noisy and did not improve reliably, so this PR makes no long-task claim. The profile was not capable of trustworthy GPU/draw-call/triangle or thermal measurements. Real-device validation remains required.

## Root causes addressed
- mobile/coarse-pointer hardware previously defaulted to Balanced unless it exposed a software renderer
- Low still rendered at DPR 1.25 with MSAA, a 1024 shadow map, and per-frame dust animation
- the scene simulation tick did not explicitly guard hidden documents

## Behavior and compatibility
- no UA sniffing; selection uses viewport width, coarse-pointer media query, `deviceMemory` when available, reduced-motion preference, and the existing WebGL renderer probe
- a stored Low/Balanced/Ultra choice always wins over automatic selection
- Balanced and Ultra retain their prior DPR, shadows, post-processing, and decorative motion
- changing quality remounts the canvas so immutable WebGL context options apply correctly
- no gateway/API changes and no bundled asset changes

## Testing
- [x] `npm run test -- --run` — 180 files, 1,190 tests passed
- [x] `npm run typecheck`
- [x] `npm run lint` — 0 errors; 9 pre-existing warnings
- [x] `npm run build`
- [x] focused quality tests — automatic desktop/mobile/reduced-motion selection, stored override, DPR bounds, hidden pause
- [x] sanitized 412×915 production mobile smoke on baseline and branch
- [x] screenshot output dimensions matched (1236×2745 at DPR 3); visual delta was bounded to quality reduction (normalized RMSE 0.074)

## Risks and rollback
Low intentionally trades soft shadows, MSAA, and dust motes for responsiveness. Users can select Balanced or Ultra in the existing graphics setting. Reverting commit `9a43734` fully restores prior behavior.

## Remaining validation
- real-phone median/p95 frame time, long tasks, thermal behavior, and interaction smoke
- maintainer visual review of the Low-tier tradeoff on representative phones
- desktop screenshot smoke on physical GPU (desktop configuration is unchanged)

## AI-assisted
- [x] AI-assisted implementation and test execution; measurements and limitations are reported directly from the sanitized harness output
