### PR TITLE
fix(docker): bump runtime to Node 22

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,17 @@
 # Hermes3D - 3D agent visualization for Hermes.
 # Multi-stage build: install prod deps -> build Next.js -> run with custom server.
+#
+# Node 22 is required: the runner ships next.config.ts without the `typescript`
+# devDependency, so Next auto-installs it at startup, which pulls in transitive
+# deps (e.g. camera-controls) that require Node >=22. On Node 20 that install
+# fails and the app crash-loops before ever binding to a port.
 
-FROM node:20-slim AS deps
+FROM node:22-slim AS deps
 WORKDIR /app
 COPY package.json package-lock.json ./
 RUN npm ci --ignore-scripts --omit=dev
 
-FROM node:20-slim AS builder
+FROM node:22-slim AS builder
 WORKDIR /app
 COPY package.json package-lock.json ./
 RUN npm ci --ignore-scripts
@@ -16,7 +21,7 @@ ENV NEXT_TELEMETRY_DISABLED=1
 ENV NEXT_PUBLIC_GATEWAY_URL=ws://127.0.0.1:18789
 RUN npm run build
 
-FROM node:20-slim AS runner
+FROM node:22-slim AS runner
 WORKDIR /app
 ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1


### PR DESCRIPTION
The production image ships next.config.ts without the typescript devDependency, so Next auto-installs it at container startup. That fresh install pulls in transitive deps (e.g. camera-controls) that require Node >=22, which fails on the Node 20 runtime and leaves the container crash-looping before it ever binds to a port.