### PR TITLE
Add 2D pixel office mode (Gather-style) with a 3D/2D renderer toggle

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -82,6 +82,7 @@ This keeps the upstream connection server-managed and makes local, remote, and t
 - `src/features/agents`: agents workspace UI and agent-runtime state handling.
 - `src/features/office`: office screens, panels, and builder UI.
 - `src/features/retro-office`: 3D scene, navigation, actors, and rendering helpers.
+- `src/features/pixel-office`: the 2D pixel office (Gather-style Phaser renderer). Consumes the same agent roster and animation state as the 3D scene; users switch renderers via the office settings ("Office renderer") persisted in localStorage.
 - `src/lib`: gateway adapters, Studio settings, office derivation logic, and shared utilities.
 - `server`: custom Studio server and WebSocket proxy.
 

--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Built and maintained by **LukeTheDev**. Follow on X: [@iamlukethedev](https://x.
 ## What you can do with Hermes3D
 
 - **Watch your AI agents work in real time** inside a shared 3D office.
+- **Switch to the 2D pixel office** — a Gather-style pixel-art view of the same live agents for low-power machines (Settings → Office renderer, or the `2D` button in the office toolbar).
 - **Run standups** with agents connected to GitHub and Jira.
 - **Review pull requests** from inside the office.
 - **Monitor QA pipelines** and logs without leaving the workspace.
@@ -237,7 +238,7 @@ Alternative with SSH:
 - Next.js App Router, React, and TypeScript for the main web application.
 - A custom Node server for the Studio-side WebSocket proxy.
 - Three.js, React Three Fiber, and Drei for the 3D office experience.
-- Phaser for office/viewer-builder workflows and related interactive surfaces.
+- Phaser for the 2D pixel office, office/viewer-builder workflows, and related interactive surfaces.
 - Vitest for unit tests and Playwright for end-to-end coverage.
 
 ## Configuration

--- a/src/features/agents/components/GatewayConnectScreen.tsx
+++ b/src/features/agents/components/GatewayConnectScreen.tsx
@@ -4,6 +4,10 @@ import type { GatewayStatus } from "@/lib/gateway/GatewayClient";
 import { isLocalGatewayUrl } from "@/lib/gateway/local-gateway";
 import { inspectUpstreamGatewayUrl } from "@/lib/gateway/upstreamUrlDiagnostics";
 import type { StudioGatewayAdapterType, StudioGatewaySettings } from "@/lib/studio/settings";
+import {
+  OFFICE_RENDER_MODE_OPTIONS,
+  type OfficeRenderMode,
+} from "@/features/office/renderMode";
 import { RunningAvatarLoader } from "@/features/agents/components/RunningAvatarLoader";
 
 type GatewayConnectScreenProps = {
@@ -19,6 +23,9 @@ type GatewayConnectScreenProps = {
   onAdapterTypeChange: (value: StudioGatewayAdapterType) => void;
   onUseLocalDefaults: () => void;
   onConnect: () => void;
+  /** When provided, shows the 3D/2D office renderer choice before connecting. */
+  renderMode?: OfficeRenderMode;
+  onRenderModeChange?: (mode: OfficeRenderMode) => void;
 };
 
 const resolveLocalGatewayPort = (gatewayUrl: string): number => {
@@ -43,6 +50,8 @@ export const GatewayConnectScreen = ({
   onAdapterTypeChange,
   onUseLocalDefaults,
   onConnect,
+  renderMode,
+  onRenderModeChange,
 }: GatewayConnectScreenProps) => {
   const [copyStatus, setCopyStatus] = useState<"idle" | "copied" | "failed">("idle");
   const [showToken, setShowToken] = useState(false);
@@ -262,6 +271,44 @@ export const GatewayConnectScreen = ({
           <p className="text-sm font-semibold text-foreground">{statusCopy}</p>
         </div>
       </div>
+
+      {renderMode && onRenderModeChange ? (
+        <div className="ui-card px-4 py-4 sm:px-6">
+          <p className="font-mono text-[10px] font-medium tracking-[0.06em] text-muted-foreground">
+            Office renderer
+          </p>
+          <p className="mt-2 text-sm text-foreground/90">
+            Pick before connecting — nothing heavy loads until you do.
+          </p>
+          <div className="mt-3 grid gap-2 sm:grid-cols-2">
+            {OFFICE_RENDER_MODE_OPTIONS.map((option) => {
+              const selected = renderMode === option.id;
+              return (
+                <button
+                  key={option.id}
+                  type="button"
+                  aria-pressed={selected}
+                  data-testid={`connect-render-mode-${option.id}`}
+                  className={`rounded-md border px-3 py-2.5 text-left transition-colors ${
+                    selected
+                      ? "border-amber-500/70 bg-amber-500/10"
+                      : "border-border bg-muted/30 hover:border-amber-500/35"
+                  }`}
+                  onClick={() => onRenderModeChange(option.id)}
+                >
+                  <span className="flex items-center gap-2 text-xs font-semibold text-foreground">
+                    {option.label}
+                    {selected ? <Check className="h-3.5 w-3.5 text-amber-400" /> : null}
+                  </span>
+                  <span className="mt-1 block text-xs leading-snug text-muted-foreground">
+                    {option.description}
+                  </span>
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      ) : null}
 
       <div className="ui-card px-4 py-5 sm:px-6">
         <div>

--- a/src/features/office/components/panels/SettingsPanel.tsx
+++ b/src/features/office/components/panels/SettingsPanel.tsx
@@ -7,6 +7,10 @@ import {
   GRAPHICS_QUALITY_OPTIONS,
   type GraphicsQuality,
 } from "@/features/retro-office/core/graphicsQuality";
+import {
+  OFFICE_RENDER_MODE_OPTIONS,
+  type OfficeRenderMode,
+} from "@/features/office/renderMode";
 
 type SettingsPanelProps = {
   gatewayStatus?: string;
@@ -45,6 +49,8 @@ type SettingsPanelProps = {
   onVoiceRepliesPreview: (voiceId: string | null, voiceName: string) => void;
   graphicsQuality?: GraphicsQuality;
   onGraphicsQualityChange?: (quality: GraphicsQuality) => void;
+  renderMode?: OfficeRenderMode;
+  onRenderModeChange?: (mode: OfficeRenderMode) => void;
 };
 
 export function SettingsPanel({
@@ -84,6 +90,8 @@ export function SettingsPanel({
   onVoiceRepliesPreview,
   graphicsQuality,
   onGraphicsQualityChange,
+  renderMode,
+  onRenderModeChange,
 }: SettingsPanelProps) {
   const normalizedGatewayUrl = gatewayUrl?.trim() ?? "";
   const normalizedGatewayToken = gatewayToken ?? "";
@@ -433,6 +441,41 @@ export function SettingsPanel({
           </button>
         </div>
       </div>
+      {renderMode && onRenderModeChange ? (
+        <div className="mt-3 rounded-lg border border-cyan-500/10 bg-black/20 px-4 py-3">
+          <div className="text-[11px] font-medium text-white">Office renderer</div>
+          <div className="mt-1 text-[10px] text-white/75">
+            Pick the immersive 3D office or the lightweight 2D pixel office.
+          </div>
+          <div className="mt-3 grid gap-2">
+            {OFFICE_RENDER_MODE_OPTIONS.map((option) => {
+              const selected = option.id === renderMode;
+              return (
+                <button
+                  key={option.id}
+                  type="button"
+                  onClick={() => onRenderModeChange(option.id)}
+                  className={`rounded-lg border px-3 py-2 text-left transition-colors ${
+                    selected
+                      ? "border-cyan-400/40 bg-cyan-500/12 text-white"
+                      : "border-cyan-500/10 bg-black/15 text-white/80 hover:border-cyan-400/20 hover:bg-cyan-500/6"
+                  }`}
+                >
+                  <div className="flex items-center justify-between gap-2">
+                    <span className="text-[11px] font-medium">{option.label}</span>
+                    {selected ? (
+                      <span className="rounded-full border border-cyan-400/35 bg-cyan-500/15 px-2 py-0.5 text-[9px] uppercase tracking-[0.14em] text-cyan-100">
+                        Active
+                      </span>
+                    ) : null}
+                  </div>
+                  <div className="mt-1 text-[10px] text-white/65">{option.description}</div>
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      ) : null}
       {graphicsQuality && onGraphicsQualityChange ? (
         <div className="mt-3 rounded-lg border border-cyan-500/10 bg-black/20 px-4 py-3">
           <div className="text-[11px] font-medium text-white">Graphics quality</div>

--- a/src/features/office/renderMode.ts
+++ b/src/features/office/renderMode.ts
@@ -1,0 +1,57 @@
+// Office renderer preference: immersive 3D scene vs. lightweight 2D pixel scene.
+// Persisted in localStorage so the choice survives reloads.
+
+import { detectSoftwareWebGL } from "@/features/retro-office/core/graphicsQuality";
+
+export type OfficeRenderMode = "3d" | "2d";
+
+export const OFFICE_RENDER_MODE_STORAGE_KEY = "hermes-office-render-mode-v1";
+
+export const OFFICE_RENDER_MODE_OPTIONS: Array<{
+  id: OfficeRenderMode;
+  label: string;
+  description: string;
+}> = [
+  {
+    id: "3d",
+    label: "3D immersive",
+    description: "Full Three.js office with shadows and post-processing.",
+  },
+  {
+    id: "2d",
+    label: "2D pixel",
+    description: "Gather-style pixel office. Great for low-power machines.",
+  },
+];
+
+export const isOfficeRenderMode = (value: unknown): value is OfficeRenderMode =>
+  value === "3d" || value === "2d";
+
+/** The explicit user choice, or null when the user never picked one. */
+export const loadStoredOfficeRenderMode = (): OfficeRenderMode | null => {
+  if (typeof window === "undefined") return null;
+  try {
+    const stored = window.localStorage.getItem(OFFICE_RENDER_MODE_STORAGE_KEY);
+    if (isOfficeRenderMode(stored)) return stored;
+  } catch {
+    // Storage unavailable (private mode, etc.) — fall through to default.
+  }
+  return null;
+};
+
+/**
+ * The mode the office should boot with: the user's stored choice, or a
+ * hardware-appropriate default. Machines that rasterize WebGL in software
+ * cannot drive the 3D pipeline smoothly, so they default to the pixel office.
+ */
+export const resolveInitialOfficeRenderMode = (): OfficeRenderMode =>
+  loadStoredOfficeRenderMode() ?? (detectSoftwareWebGL() ? "2d" : "3d");
+
+export const saveOfficeRenderMode = (mode: OfficeRenderMode) => {
+  if (typeof window === "undefined") return;
+  try {
+    window.localStorage.setItem(OFFICE_RENDER_MODE_STORAGE_KEY, mode);
+  } catch {
+    // Best effort only.
+  }
+};

--- a/src/features/office/screens/OfficeScreen.tsx
+++ b/src/features/office/screens/OfficeScreen.tsx
@@ -12,6 +12,12 @@ import { useRouter } from "next/navigation";
 import { MessageSquare, ChevronDown, ChevronLeft, ChevronRight, Mic } from "lucide-react";
 import { RetroOffice3D } from "@/features/retro-office/RetroOffice3D";
 import type { OfficeAgent } from "@/features/retro-office/core/types";
+import { PixelOffice2D } from "@/features/pixel-office/PixelOffice2D";
+import {
+  resolveInitialOfficeRenderMode,
+  saveOfficeRenderMode,
+  type OfficeRenderMode,
+} from "@/features/office/renderMode";
 import { RunningAvatarLoader } from "@/features/agents/components/RunningAvatarLoader";
 import { GatewayConnectScreen } from "@/features/agents/components/GatewayConnectScreen";
 import { useAgentStore, type AgentState } from "@/features/agents/state/store";
@@ -1063,6 +1069,16 @@ export function OfficeScreen({
   const [gatewayModels, setGatewayModels] = useState<GatewayModelChoice[]>([]);
   const [sidebarOpen, setSidebarOpen] = useState(false);
   const [marketplaceOpen, setMarketplaceOpen] = useState(false);
+  // Office renderer preference (3D immersive vs. 2D pixel). Resolved after
+  // mount so SSR markup stays deterministic.
+  const [officeRenderMode, setOfficeRenderMode] = useState<OfficeRenderMode>("3d");
+  useEffect(() => {
+    setOfficeRenderMode(resolveInitialOfficeRenderMode());
+  }, []);
+  const handleOfficeRenderModeChange = useCallback((mode: OfficeRenderMode) => {
+    saveOfficeRenderMode(mode);
+    setOfficeRenderMode(mode);
+  }, []);
   const [kanbanInstallPromptOpen, setKanbanInstallPromptOpen] = useState(false);
   const [kanbanInstallProgress, setKanbanInstallProgress] = useState<{
     active: boolean;
@@ -4465,6 +4481,72 @@ export function OfficeScreen({
         </div>
       ) : null}
       <section className="relative h-full min-h-0 min-w-0 overflow-hidden">
+        {officeRenderMode === "2d" ? (
+        <PixelOffice2D
+          agents={allVisibleAgents}
+          animationState={officeAnimationState}
+          streamingTextByAgentId={streamingTextByAgentId}
+          renderMode={officeRenderMode}
+          onRenderModeChange={handleOfficeRenderModeChange}
+          onAgentChatSelect={(agentId) => {
+            handleOpenAgentChat(agentId);
+          }}
+          onAddAgent={handleOpenCreateAgentWizard}
+          onAgentEdit={(agentId) => {
+            openAgentEditor(agentId, "avatar");
+          }}
+          onAgentDelete={(agentId) => {
+            void handleDeleteAgent(agentId);
+          }}
+          onJukeboxInteract={() => {
+            setJukeboxOpen(true);
+          }}
+          onKanbanInteract={() => {
+            setKanbanInstallPromptOpen(true);
+          }}
+          officeTitle={officeTitle}
+          officeTitleLoaded={officeTitleLoaded}
+          onOfficeTitleChange={setOfficeTitle}
+          gatewayStatus={status}
+          gatewayUrl={gatewayUrl}
+          gatewayToken={token}
+          selectedAdapterType={selectedAdapterType}
+          activeAdapterType={activeAdapterType}
+          onGatewayDisconnect={disconnect}
+          onGatewayConnect={() => void connect()}
+          onGatewayUrlChange={setGatewayUrl}
+          onGatewayTokenChange={setToken}
+          onGatewayAdapterTypeChange={setSelectedAdapterType}
+          onOpenOnboarding={handleOpenOnboarding}
+          remoteOfficeEnabled={remoteOfficeEnabled}
+          remoteOfficeSourceKind={remoteOfficeSourceKind}
+          remoteOfficeLabel={remoteOfficeLabel}
+          remoteOfficePresenceUrl={remoteOfficePresenceUrl}
+          remoteOfficeGatewayUrl={remoteOfficeGatewayUrl}
+          remoteOfficeTokenConfigured={remoteOfficeTokenConfigured}
+          onRemoteOfficeEnabledChange={setRemoteOfficeEnabled}
+          onRemoteOfficeSourceKindChange={setRemoteOfficeSourceKind}
+          onRemoteOfficeLabelChange={setRemoteOfficeLabel}
+          onRemoteOfficePresenceUrlChange={setRemoteOfficePresenceUrl}
+          onRemoteOfficeGatewayUrlChange={setRemoteOfficeGatewayUrl}
+          onRemoteOfficeTokenChange={setRemoteOfficeToken}
+          voiceRepliesEnabled={voiceRepliesEnabled}
+          voiceRepliesVoiceId={voiceRepliesVoiceId}
+          voiceRepliesSpeed={voiceRepliesSpeed}
+          voiceRepliesLoaded={voiceRepliesLoaded}
+          onVoiceRepliesToggle={setVoiceRepliesEnabled}
+          onVoiceRepliesVoiceChange={setVoiceRepliesVoiceId}
+          onVoiceRepliesSpeedChange={setVoiceRepliesSpeed}
+          onVoiceRepliesPreview={(voiceId, voiceName) => {
+            void previewVoiceReply({
+              text: `Hi, how can I help you? My name is ${voiceName}.`,
+              provider: voiceRepliesPreference.provider,
+              voiceId,
+              speed: voiceRepliesSpeed,
+            });
+          }}
+        />
+        ) : (
         <RetroOffice3D
           agents={allVisibleAgents}
           storageNamespace={activeFloor.id}
@@ -4532,6 +4614,8 @@ export function OfficeScreen({
           onGatewayTokenChange={setToken}
           onGatewayAdapterTypeChange={setSelectedAdapterType}
           onOpenOnboarding={handleOpenOnboarding}
+          renderMode={officeRenderMode}
+          onRenderModeChange={handleOfficeRenderModeChange}
           feedEvents={feedEvents}
           gatewayStatus={status}
           runCountByAgentId={runCountByAgentId}
@@ -4611,6 +4695,7 @@ export function OfficeScreen({
             void taskBoard.refreshCronJobs();
           }}
         />
+        )}
         {jukeboxOpen ? (
           soundhermesReady ? (
             <JukeboxPanel

--- a/src/features/office/screens/OfficeScreen.tsx
+++ b/src/features/office/screens/OfficeScreen.tsx
@@ -4422,6 +4422,10 @@ export function OfficeScreen({
     status === "disconnected" &&
     !agentsLoaded &&
     (shouldPromptForConnect || showDelayedGatewayConnectOverlay);
+  // Defer mounting the heavy office renderers (Three.js / Phaser) until a
+  // gateway connection exists, so users can pick 2D vs. 3D on the connect
+  // screen before either pipeline loads.
+  const officeSceneReady = agentsLoaded || status === "connected";
 
   const runningCount = state.agents.filter(
     (agent) =>
@@ -4461,9 +4465,11 @@ export function OfficeScreen({
         </div>
       ) : null}
       {showGatewayConnectOverlay ? (
-        <div className="pointer-events-auto absolute inset-0 z-50 flex items-start justify-center bg-[#120a05]/76 px-4 py-10">
-          <div className="w-full max-w-[860px] rounded-2xl border border-amber-900/55 bg-[#120a05]/98 p-3 shadow-2xl">
+        <div className="pointer-events-auto absolute inset-0 z-50 flex items-start justify-center overflow-y-auto bg-[#120a05]/76 px-4 py-10">
+          <div className="mb-10 w-full max-w-[860px] rounded-2xl border border-amber-900/55 bg-[#120a05]/98 p-3 shadow-2xl">
             <GatewayConnectScreen
+              renderMode={officeRenderMode}
+              onRenderModeChange={handleOfficeRenderModeChange}
               gatewayUrl={gatewayUrl}
               token={token}
               selectedAdapterType={selectedAdapterType}
@@ -4481,7 +4487,16 @@ export function OfficeScreen({
         </div>
       ) : null}
       <section className="relative h-full min-h-0 min-w-0 overflow-hidden">
-        {officeRenderMode === "2d" ? (
+        {!officeSceneReady ? (
+        <div
+          className="flex h-full w-full items-center justify-center bg-[radial-gradient(ellipse_at_center,#1c1208_0%,#0d0804_70%)]"
+          aria-hidden
+        >
+          <p className="select-none font-mono text-xs tracking-[0.4em] text-amber-100/25">
+            HERMES3D
+          </p>
+        </div>
+        ) : officeRenderMode === "2d" ? (
         <PixelOffice2D
           agents={allVisibleAgents}
           animationState={officeAnimationState}

--- a/src/features/pixel-office/PixelOffice2D.tsx
+++ b/src/features/pixel-office/PixelOffice2D.tsx
@@ -119,7 +119,9 @@ export function PixelOffice2D(props: PixelOffice2DProps) {
     const inputs = buildPixelAgentInputs({ agents, animationState, nowMs });
     const bubbleTextByAgentId: Record<string, string> = {};
     for (const input of inputs) {
-      if (!input.streaming) continue;
+      // Streamed text shows while the stream flag is up or the run is still
+      // active, so short demo replies stay readable.
+      if (!input.streaming && input.status !== "working") continue;
       const text = streamingTextByAgentId[input.id] ?? "";
       if (text.trim().length > 0) {
         bubbleTextByAgentId[input.id] = text;
@@ -210,6 +212,17 @@ export function PixelOffice2D(props: PixelOffice2DProps) {
         <div className="rounded-md border border-black/25 bg-[#11131c]/70 px-2 py-1.5 text-[10px] font-mono text-white/70 backdrop-blur-sm">
           2D PIXEL
         </div>
+        <div className="flex items-center gap-2 rounded-md border border-black/25 bg-[#11131c]/70 px-2 py-1.5 text-[10px] font-mono backdrop-blur-sm">
+          <span className="text-emerald-300/85">{workingCount} working</span>
+          <span className="text-white/25">·</span>
+          <span className="text-amber-300/85">{idleCount} idle</span>
+          {errorCount > 0 ? (
+            <>
+              <span className="text-white/25">·</span>
+              <span className="text-rose-300/85">{errorCount} error</span>
+            </>
+          ) : null}
+        </div>
       </div>
 
       {/* Toolbar — top right. */}
@@ -257,23 +270,8 @@ export function PixelOffice2D(props: PixelOffice2DProps) {
         </button>
       </div>
 
-      {/* Status bar — bottom left. */}
-      <div className="absolute bottom-3 left-3 z-10 pointer-events-none select-none">
-        <div className="flex items-center gap-3 rounded-full bg-black/60 px-3 py-1 text-[10px] font-mono backdrop-blur-sm">
-          <span className="text-emerald-300/80">{workingCount} working</span>
-          <span className="opacity-30">·</span>
-          <span className="text-amber-300/80">{idleCount} idle</span>
-          {errorCount > 0 ? (
-            <>
-              <span className="opacity-30">·</span>
-              <span className="text-rose-300/80">{errorCount} error</span>
-            </>
-          ) : null}
-        </div>
-      </div>
-
-      {/* Controls hint — bottom right. */}
-      <div className="absolute bottom-3 right-3 z-10 pointer-events-none select-none">
+      {/* Controls hint — bottom center (event console and chat own the corners). */}
+      <div className="absolute bottom-3 left-1/2 z-10 -translate-x-1/2 pointer-events-none select-none">
         <div className="rounded-full bg-black/50 px-3 py-1 text-[10px] font-mono text-white/55 backdrop-blur-sm">
           drag to pan · scroll to zoom · click an agent to chat
         </div>

--- a/src/features/pixel-office/PixelOffice2D.tsx
+++ b/src/features/pixel-office/PixelOffice2D.tsx
@@ -170,7 +170,7 @@ export function PixelOffice2D(props: PixelOffice2DProps) {
       const game = new PhaserLib.Game({
         type: PhaserLib.AUTO,
         parent: rootRef.current,
-        backgroundColor: "#6fb544",
+        backgroundColor: "#b5dc9c",
         scene: [scene],
         render: {
           antialias: false,

--- a/src/features/pixel-office/PixelOffice2D.tsx
+++ b/src/features/pixel-office/PixelOffice2D.tsx
@@ -1,0 +1,430 @@
+"use client";
+
+// React wrapper for the Gather-style 2D pixel office. Mounts the Phaser
+// scene, pushes live Hermes state through the bridge, and hosts the HUD,
+// settings modal, and agent context menu.
+
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { Boxes, Settings2, UserPlus, X } from "lucide-react";
+
+import { SettingsPanel } from "@/features/office/components/panels/SettingsPanel";
+import type { OfficeRenderMode } from "@/features/office/renderMode";
+import type { OfficeAgent } from "@/features/retro-office/core/types";
+import type { OfficeAnimationState } from "@/lib/office/eventTriggers";
+import type { StudioGatewayAdapterType } from "@/lib/studio/settings";
+import {
+  buildPixelAgentInputs,
+  isCleaningActive,
+} from "@/features/pixel-office/buildPixelInputs";
+import { buildHermesHqMap } from "@/features/pixel-office/map/hermesHqMap";
+import {
+  createPixelSceneBridge,
+  type PixelSceneBridge,
+} from "@/features/pixel-office/PixelSceneBridge";
+
+type ContextMenuState = {
+  agentId: string;
+  x: number;
+  y: number;
+};
+
+export type PixelOffice2DProps = {
+  agents: OfficeAgent[];
+  animationState?: OfficeAnimationState | null;
+  streamingTextByAgentId?: Record<string, string | null>;
+  renderMode: OfficeRenderMode;
+  onRenderModeChange: (mode: OfficeRenderMode) => void;
+  onAgentChatSelect?: (agentId: string) => void;
+  onAddAgent?: () => void;
+  onAgentEdit?: (agentId: string) => void;
+  onAgentDelete?: (agentId: string) => void;
+  onJukeboxInteract?: () => void;
+  onKanbanInteract?: () => void;
+  officeTitle: string;
+  officeTitleLoaded: boolean;
+  onOfficeTitleChange?: (title: string) => void;
+  gatewayStatus?: string;
+  gatewayUrl?: string;
+  gatewayToken?: string;
+  selectedAdapterType?: StudioGatewayAdapterType;
+  activeAdapterType?: StudioGatewayAdapterType;
+  onGatewayDisconnect?: () => void;
+  onGatewayConnect?: () => void;
+  onGatewayUrlChange?: (value: string) => void;
+  onGatewayTokenChange?: (value: string) => void;
+  onGatewayAdapterTypeChange?: (value: StudioGatewayAdapterType) => void;
+  onOpenOnboarding?: () => void;
+  remoteOfficeEnabled: boolean;
+  remoteOfficeSourceKind: "presence_endpoint" | "hermes_gateway";
+  remoteOfficeLabel: string;
+  remoteOfficePresenceUrl: string;
+  remoteOfficeGatewayUrl: string;
+  remoteOfficeTokenConfigured: boolean;
+  onRemoteOfficeEnabledChange?: (enabled: boolean) => void;
+  onRemoteOfficeSourceKindChange?: (
+    kind: "presence_endpoint" | "hermes_gateway",
+  ) => void;
+  onRemoteOfficeLabelChange?: (label: string) => void;
+  onRemoteOfficePresenceUrlChange?: (url: string) => void;
+  onRemoteOfficeGatewayUrlChange?: (url: string) => void;
+  onRemoteOfficeTokenChange?: (token: string) => void;
+  voiceRepliesEnabled: boolean;
+  voiceRepliesVoiceId: string | null;
+  voiceRepliesSpeed: number;
+  voiceRepliesLoaded: boolean;
+  onVoiceRepliesToggle?: (enabled: boolean) => void;
+  onVoiceRepliesVoiceChange?: (voiceId: string | null) => void;
+  onVoiceRepliesSpeedChange?: (speed: number) => void;
+  onVoiceRepliesPreview?: (voiceId: string | null, voiceName: string) => void;
+};
+
+export function PixelOffice2D(props: PixelOffice2DProps) {
+  const {
+    agents,
+    animationState = null,
+    streamingTextByAgentId = {},
+    renderMode,
+    onRenderModeChange,
+    onAgentChatSelect,
+    onAddAgent,
+    onAgentEdit,
+    onAgentDelete,
+    onJukeboxInteract,
+    onKanbanInteract,
+    officeTitle,
+    officeTitleLoaded,
+    gatewayStatus = "disconnected",
+    activeAdapterType = "hermes",
+  } = props;
+
+  const rootRef = useRef<HTMLDivElement | null>(null);
+  const gameRef = useRef<import("phaser").Game | null>(null);
+  const bridgeRef = useRef<PixelSceneBridge | null>(null);
+  const [settingsOpen, setSettingsOpen] = useState(false);
+  const [contextMenu, setContextMenu] = useState<ContextMenuState | null>(null);
+
+  const map = useMemo(() => buildHermesHqMap(), []);
+
+  if (!bridgeRef.current) {
+    bridgeRef.current = createPixelSceneBridge({
+      agents: [],
+      bubbleTextByAgentId: {},
+      cleaningActive: false,
+    });
+  }
+  const bridge = bridgeRef.current;
+
+  const pushBridgeState = useCallback(() => {
+    const nowMs = Date.now();
+    const inputs = buildPixelAgentInputs({ agents, animationState, nowMs });
+    const bubbleTextByAgentId: Record<string, string> = {};
+    for (const input of inputs) {
+      if (!input.streaming) continue;
+      const text = streamingTextByAgentId[input.id] ?? "";
+      if (text.trim().length > 0) {
+        bubbleTextByAgentId[input.id] = text;
+      }
+    }
+    bridge.setState({
+      agents: inputs,
+      bubbleTextByAgentId,
+      cleaningActive: isCleaningActive(animationState),
+    });
+  }, [agents, animationState, bridge, streamingTextByAgentId]);
+
+  useEffect(() => {
+    pushBridgeState();
+    // Timed holds (dance, manual gym) expire without prop changes, so keep
+    // the derived inputs fresh with a low-frequency refresh.
+    const interval = window.setInterval(pushBridgeState, 1_000);
+    return () => window.clearInterval(interval);
+  }, [pushBridgeState]);
+
+  useEffect(() => {
+    bridge.callbacks.onAgentClick = (agentId) => {
+      setContextMenu(null);
+      onAgentChatSelect?.(agentId);
+    };
+    bridge.callbacks.onAgentContextMenu = (agentId, clientX, clientY) => {
+      setContextMenu({ agentId, x: clientX, y: clientY });
+    };
+    bridge.callbacks.onStationInteract = (kind) => {
+      setContextMenu(null);
+      if (kind === "jukebox") onJukeboxInteract?.();
+      if (kind === "kanban") onKanbanInteract?.();
+    };
+  }, [bridge, onAgentChatSelect, onJukeboxInteract, onKanbanInteract]);
+
+  useEffect(() => {
+    let canceled = false;
+    const setup = async () => {
+      if (!rootRef.current) return;
+      const PhaserLib = await import("phaser");
+      const { createPixelOfficeScene } = await import(
+        "@/features/pixel-office/scene/PixelOfficeScene"
+      );
+      if (canceled || !rootRef.current) return;
+      const scene = createPixelOfficeScene({ PhaserLib, bridge, map });
+      const game = new PhaserLib.Game({
+        type: PhaserLib.AUTO,
+        parent: rootRef.current,
+        backgroundColor: "#6fb544",
+        scene: [scene],
+        render: {
+          antialias: false,
+          pixelArt: true,
+          roundPixels: true,
+        },
+        scale: {
+          mode: PhaserLib.Scale.RESIZE,
+          autoCenter: PhaserLib.Scale.CENTER_BOTH,
+        },
+      });
+      gameRef.current = game;
+    };
+    void setup();
+    return () => {
+      canceled = true;
+      gameRef.current?.destroy(true);
+      gameRef.current = null;
+    };
+  }, [bridge, map]);
+
+  const contextAgent = contextMenu
+    ? (agents.find((agent) => agent.id === contextMenu.agentId) ?? null)
+    : null;
+
+  const workingCount = agents.filter((agent) => agent.status === "working").length;
+  const idleCount = agents.filter((agent) => agent.status === "idle").length;
+  const errorCount = agents.filter((agent) => agent.status === "error").length;
+
+  return (
+    <div className="relative h-full w-full overflow-hidden bg-[#6fb544]">
+      <div className="absolute inset-0" ref={rootRef} />
+
+      {/* Office title — top left. */}
+      <div className="absolute top-3 left-3 z-20 flex items-center gap-2 select-none">
+        <div className="rounded-md border border-black/25 bg-[#11131c]/85 px-3 py-1.5 text-[11px] font-semibold uppercase tracking-[0.18em] text-amber-100 backdrop-blur-sm">
+          {officeTitleLoaded ? officeTitle : ""}
+        </div>
+        <div className="rounded-md border border-black/25 bg-[#11131c]/70 px-2 py-1.5 text-[10px] font-mono text-white/70 backdrop-blur-sm">
+          2D PIXEL
+        </div>
+      </div>
+
+      {/* Toolbar — top right. */}
+      <div className="absolute top-3 right-3 z-20 flex items-center gap-2">
+        {onAddAgent ? (
+          <button
+            onClick={onAddAgent}
+            title="Add agent"
+            className="flex h-7 items-center justify-center gap-1 rounded-md border border-cyan-500/35 bg-[#071018]/92 px-2 text-[10px] font-semibold uppercase tracking-[0.12em] text-cyan-200 transition-all backdrop-blur-sm hover:border-cyan-400/55 hover:text-white"
+          >
+            <UserPlus size={12} />
+            <span>Add</span>
+          </button>
+        ) : null}
+        <div
+          className={`flex h-7 items-center rounded-md border px-2 text-[10px] font-mono uppercase tracking-[0.12em] ${
+            gatewayStatus === "connected"
+              ? "border-emerald-400/25 bg-emerald-500/10 text-emerald-100"
+              : gatewayStatus === "connecting"
+                ? "border-amber-400/25 bg-amber-500/10 text-amber-100"
+                : "border-rose-400/25 bg-rose-500/10 text-rose-100"
+          }`}
+          title={`Runtime: ${activeAdapterType} (${gatewayStatus})`}
+        >
+          {activeAdapterType} • {gatewayStatus}
+        </div>
+        <button
+          onClick={() => onRenderModeChange("3d")}
+          title="Switch to the 3D office"
+          className="flex h-7 items-center justify-center gap-1 rounded-md border border-white/15 bg-[#11131c]/85 px-2 text-[10px] font-semibold uppercase tracking-[0.12em] text-white/75 transition-all backdrop-blur-sm hover:border-cyan-400/45 hover:text-cyan-100"
+        >
+          <Boxes size={12} />
+          <span>3D</span>
+        </button>
+        <button
+          onClick={() => setSettingsOpen(true)}
+          title="Studio settings"
+          className={`flex h-7 w-7 items-center justify-center rounded-md border transition-all backdrop-blur-sm ${
+            settingsOpen
+              ? "border-amber-500/50 bg-amber-500/30 text-amber-300"
+              : "border-white/15 bg-[#11131c]/85 text-white/60 hover:text-amber-300"
+          }`}
+        >
+          <Settings2 size={12} />
+        </button>
+      </div>
+
+      {/* Status bar — bottom left. */}
+      <div className="absolute bottom-3 left-3 z-10 pointer-events-none select-none">
+        <div className="flex items-center gap-3 rounded-full bg-black/60 px-3 py-1 text-[10px] font-mono backdrop-blur-sm">
+          <span className="text-emerald-300/80">{workingCount} working</span>
+          <span className="opacity-30">·</span>
+          <span className="text-amber-300/80">{idleCount} idle</span>
+          {errorCount > 0 ? (
+            <>
+              <span className="opacity-30">·</span>
+              <span className="text-rose-300/80">{errorCount} error</span>
+            </>
+          ) : null}
+        </div>
+      </div>
+
+      {/* Controls hint — bottom right. */}
+      <div className="absolute bottom-3 right-3 z-10 pointer-events-none select-none">
+        <div className="rounded-full bg-black/50 px-3 py-1 text-[10px] font-mono text-white/55 backdrop-blur-sm">
+          drag to pan · scroll to zoom · click an agent to chat
+        </div>
+      </div>
+
+      {/* Agent context menu. */}
+      {contextMenu && contextAgent ? (
+        <>
+          <div
+            className="fixed inset-0 z-40"
+            onClick={() => setContextMenu(null)}
+            onContextMenu={(event) => {
+              event.preventDefault();
+              setContextMenu(null);
+            }}
+          />
+          <div
+            className="fixed z-50 min-w-[140px] overflow-hidden rounded-lg border border-white/12 bg-[#0b0e16]/95 shadow-2xl backdrop-blur-sm"
+            style={{ left: contextMenu.x, top: contextMenu.y }}
+          >
+            <div className="border-b border-white/8 px-3 py-2 text-[10px] font-semibold uppercase tracking-[0.14em] text-white/50">
+              {contextAgent.name}
+            </div>
+            <button
+              className="block w-full px-3 py-2 text-left text-[11px] text-white/85 transition-colors hover:bg-cyan-500/15"
+              onClick={() => {
+                setContextMenu(null);
+                onAgentChatSelect?.(contextMenu.agentId);
+              }}
+            >
+              Open chat
+            </button>
+            {onAgentEdit ? (
+              <button
+                className="block w-full px-3 py-2 text-left text-[11px] text-white/85 transition-colors hover:bg-cyan-500/15"
+                onClick={() => {
+                  setContextMenu(null);
+                  onAgentEdit(contextMenu.agentId);
+                }}
+              >
+                Edit agent
+              </button>
+            ) : null}
+            {onAgentDelete ? (
+              <button
+                className="block w-full px-3 py-2 text-left text-[11px] text-rose-300/90 transition-colors hover:bg-rose-500/15"
+                onClick={() => {
+                  setContextMenu(null);
+                  onAgentDelete(contextMenu.agentId);
+                }}
+              >
+                Delete agent
+              </button>
+            ) : null}
+          </div>
+        </>
+      ) : null}
+
+      {/* Studio settings modal (same panel the 3D office uses). */}
+      {settingsOpen ? (
+        <div className="absolute inset-0 z-30 flex items-start justify-end overflow-y-auto bg-black/35 p-4 backdrop-blur-[1px]">
+          <div className="flex max-h-[calc(100vh-2rem)] w-full max-w-sm flex-col overflow-hidden rounded-xl border border-cyan-500/20 bg-[#05090d]/95 shadow-2xl">
+            <div className="flex items-start justify-between border-b border-cyan-500/10 px-4 py-3">
+              <div>
+                <div className="font-mono text-[10px] font-semibold tracking-[0.28em] text-cyan-300/75">
+                  STUDIO SETTINGS
+                </div>
+                <div className="mt-1 text-[11px] text-white/45">
+                  Customize the office banner and spoken replies across the app.
+                </div>
+              </div>
+              <button
+                type="button"
+                onClick={() => setSettingsOpen(false)}
+                className="flex h-7 w-7 items-center justify-center rounded-md border border-cyan-500/10 bg-black/20 text-cyan-100/70 transition-colors hover:border-cyan-400/30 hover:text-cyan-100"
+                aria-label="Close studio settings"
+              >
+                <X size={12} />
+              </button>
+            </div>
+            <div className="min-h-0 flex-1 overflow-y-auto">
+              <SettingsPanel
+                renderMode={renderMode}
+                onRenderModeChange={onRenderModeChange}
+                gatewayStatus={props.gatewayStatus}
+                gatewayUrl={props.gatewayUrl}
+                gatewayToken={props.gatewayToken}
+                selectedAdapterType={props.selectedAdapterType}
+                activeAdapterType={props.activeAdapterType}
+                onGatewayDisconnect={() => {
+                  props.onGatewayDisconnect?.();
+                  setSettingsOpen(false);
+                }}
+                onGatewayConnect={() => {
+                  props.onGatewayConnect?.();
+                }}
+                onGatewayUrlChange={(value) => props.onGatewayUrlChange?.(value)}
+                onGatewayTokenChange={(value) => props.onGatewayTokenChange?.(value)}
+                onGatewayAdapterTypeChange={(value) =>
+                  props.onGatewayAdapterTypeChange?.(value)
+                }
+                onOpenOnboarding={() => {
+                  props.onOpenOnboarding?.();
+                  setSettingsOpen(false);
+                }}
+                officeTitle={officeTitle}
+                officeTitleLoaded={officeTitleLoaded}
+                onOfficeTitleChange={(title) => props.onOfficeTitleChange?.(title)}
+                remoteOfficeEnabled={props.remoteOfficeEnabled}
+                remoteOfficeSourceKind={props.remoteOfficeSourceKind}
+                remoteOfficeLabel={props.remoteOfficeLabel}
+                remoteOfficePresenceUrl={props.remoteOfficePresenceUrl}
+                remoteOfficeGatewayUrl={props.remoteOfficeGatewayUrl}
+                remoteOfficeTokenConfigured={props.remoteOfficeTokenConfigured}
+                onRemoteOfficeEnabledChange={(enabled) =>
+                  props.onRemoteOfficeEnabledChange?.(enabled)
+                }
+                onRemoteOfficeSourceKindChange={(kind) =>
+                  props.onRemoteOfficeSourceKindChange?.(kind)
+                }
+                onRemoteOfficeLabelChange={(label) =>
+                  props.onRemoteOfficeLabelChange?.(label)
+                }
+                onRemoteOfficePresenceUrlChange={(url) =>
+                  props.onRemoteOfficePresenceUrlChange?.(url)
+                }
+                onRemoteOfficeGatewayUrlChange={(url) =>
+                  props.onRemoteOfficeGatewayUrlChange?.(url)
+                }
+                onRemoteOfficeTokenChange={(token) =>
+                  props.onRemoteOfficeTokenChange?.(token)
+                }
+                voiceRepliesEnabled={props.voiceRepliesEnabled}
+                voiceRepliesVoiceId={props.voiceRepliesVoiceId}
+                voiceRepliesSpeed={props.voiceRepliesSpeed}
+                voiceRepliesLoaded={props.voiceRepliesLoaded}
+                onVoiceRepliesToggle={(enabled) => props.onVoiceRepliesToggle?.(enabled)}
+                onVoiceRepliesVoiceChange={(voiceId) =>
+                  props.onVoiceRepliesVoiceChange?.(voiceId)
+                }
+                onVoiceRepliesSpeedChange={(speed) =>
+                  props.onVoiceRepliesSpeedChange?.(speed)
+                }
+                onVoiceRepliesPreview={(voiceId, voiceName) =>
+                  props.onVoiceRepliesPreview?.(voiceId, voiceName)
+                }
+              />
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/src/features/pixel-office/PixelSceneBridge.ts
+++ b/src/features/pixel-office/PixelSceneBridge.ts
@@ -1,0 +1,52 @@
+// Pub/sub bridge between the React wrapper and the Phaser pixel scene,
+// mirroring the pattern used by the office builder's OfficeSceneBridge.
+
+import type { PixelAgentInput } from "@/features/pixel-office/types";
+
+export type PixelInteractiveStationKind = "jukebox" | "kanban";
+
+export type PixelBridgeState = {
+  agents: PixelAgentInput[];
+  /** Streaming text tails shown as speech bubbles, keyed by agent id. */
+  bubbleTextByAgentId: Record<string, string>;
+  /** True while cleaning cues are active (spawns the janitor NPC). */
+  cleaningActive: boolean;
+};
+
+export type PixelBridgeCallbacks = {
+  onAgentClick?: (agentId: string) => void;
+  onAgentContextMenu?: (agentId: string, clientX: number, clientY: number) => void;
+  onStationInteract?: (kind: PixelInteractiveStationKind) => void;
+};
+
+export type PixelSceneBridge = {
+  getState: () => PixelBridgeState;
+  setState: (next: Partial<PixelBridgeState>) => void;
+  subscribe: (listener: () => void) => () => void;
+  /** Mutable callback slot so React can swap handlers without scene rebuilds. */
+  callbacks: PixelBridgeCallbacks;
+};
+
+export const createPixelSceneBridge = (
+  initialState: PixelBridgeState,
+): PixelSceneBridge => {
+  let state = initialState;
+  const listeners = new Set<() => void>();
+
+  return {
+    getState: () => state,
+    setState: (next) => {
+      state = { ...state, ...next };
+      for (const listener of listeners) {
+        listener();
+      }
+    },
+    subscribe: (listener) => {
+      listeners.add(listener);
+      return () => {
+        listeners.delete(listener);
+      };
+    },
+    callbacks: {},
+  };
+};

--- a/src/features/pixel-office/art/characters.ts
+++ b/src/features/pixel-office/art/characters.ts
@@ -1,0 +1,353 @@
+import {
+  CHARACTER_HEIGHT,
+  CHARACTER_WIDTH,
+  type CharacterFrameName,
+  type CharacterFrameSet,
+  type CharacterLook,
+  type PixelSprite,
+} from "../types";
+import {
+  CAP_YELLOW,
+  CHAR_EYE,
+  CHAR_OUTLINE,
+  CHAR_SHOE,
+  CHAR_WHITE,
+  FALLBACK_SHIRT,
+} from "./palette";
+import { fillRect, gridRows, hLine, makeGrid, setPx, vLine, type Grid } from "./grid";
+import { makeSprite, spriteWidth } from "./sprite";
+
+// ---------------------------------------------------------------------------
+// Appearance.
+// ---------------------------------------------------------------------------
+
+const SKIN_TONES = ["#f6d7b8", "#eebe98", "#d69a6c", "#a9714b", "#6f4a2f"] as const;
+const HAIR_COLORS = ["#2c2c34", "#6b4a2e", "#e6c15a", "#b8452f", "#9a9aa2", "#4a6fd9"] as const;
+const HAIR_STYLES = ["short", "spiky", "long", "bob"] as const;
+const PANTS_COLORS = ["#35406b", "#5a5f6e", "#5f4a33", "#24262e"] as const;
+
+type HairStyle = (typeof HAIR_STYLES)[number];
+
+type Appearance = {
+  skin: string;
+  hair: string;
+  hairStyle: HairStyle;
+  pants: string;
+  shirt: string;
+  shirtShade: string;
+  /** Janitor NPCs get a yellow cap band on the hair. */
+  cap: boolean;
+};
+
+/** Stable FNV-1a hash so a seed always maps to the same appearance. */
+function hashSeed(seed: string): number {
+  let h = 0x811c9dc5;
+  for (let i = 0; i < seed.length; i += 1) {
+    h ^= seed.charCodeAt(i);
+    h = Math.imul(h, 0x01000193);
+  }
+  return h >>> 0;
+}
+
+function normalizeHex(value: string): string | null {
+  const match = /^#?([0-9a-f]{6})$/i.exec(value.trim());
+  return match ? `#${match[1].toLowerCase()}` : null;
+}
+
+/** Darkens "#rrggbb" by multiplying each channel (0.75 = ~25% darker). */
+function darkenHex(hex: string, factor: number): string {
+  const channels = [1, 3, 5].map((i) => {
+    const v = Math.round(parseInt(hex.slice(i, i + 2), 16) * factor);
+    return Math.max(0, Math.min(255, v)).toString(16).padStart(2, "0");
+  });
+  return `#${channels.join("")}`;
+}
+
+function resolveAppearance(look: CharacterLook): Appearance {
+  const shirt = normalizeHex(look.accentColor) ?? FALLBACK_SHIRT;
+  const shirtShade = darkenHex(shirt, 0.75);
+  if (look.seed.startsWith("npc-janitor")) {
+    return {
+      skin: SKIN_TONES[2],
+      hair: HAIR_COLORS[4],
+      hairStyle: "short",
+      pants: PANTS_COLORS[0],
+      shirt,
+      shirtShade,
+      cap: true,
+    };
+  }
+  const h = hashSeed(look.seed);
+  return {
+    skin: SKIN_TONES[h % SKIN_TONES.length],
+    hair: HAIR_COLORS[(h >>> 3) % HAIR_COLORS.length],
+    hairStyle: HAIR_STYLES[(h >>> 6) % HAIR_STYLES.length],
+    pants: PANTS_COLORS[(h >>> 9) % PANTS_COLORS.length],
+    shirt,
+    shirtShade,
+    cap: false,
+  };
+}
+
+function paletteFor(app: Appearance): Record<string, string> {
+  return {
+    o: CHAR_OUTLINE,
+    h: app.hair,
+    s: app.skin,
+    t: app.shirt,
+    T: app.shirtShade,
+    p: app.pants,
+    b: CHAR_SHOE,
+    e: CHAR_EYE,
+    w: CHAR_WHITE,
+    y: CAP_YELLOW,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Frame construction.
+// ---------------------------------------------------------------------------
+
+type WalkPose = "idle" | "a" | "b";
+
+/** Rounded head outline box spanning x 3..12, y 2..11. */
+function drawHeadOutline(g: Grid): void {
+  hLine(g, 4, 2, 8, "o");
+  hLine(g, 4, 11, 8, "o");
+  vLine(g, 3, 3, 8, "o");
+  vLine(g, 12, 3, 8, "o");
+}
+
+function applyHairStyle(g: Grid, app: Appearance, facing: "down" | "up" | "left"): void {
+  if (app.hairStyle === "spiky") {
+    for (const x of [4, 6, 8, 10]) setPx(g, x, 1, "h");
+  } else if (app.hairStyle === "long") {
+    if (facing === "left") {
+      vLine(g, 13, 4, 10, "h");
+    } else {
+      vLine(g, 2, 4, 10, "h");
+      vLine(g, 13, 4, 10, "h");
+    }
+  } else if (app.hairStyle === "bob") {
+    if (facing === "left") {
+      vLine(g, 13, 4, 6, "h");
+    } else {
+      vLine(g, 2, 4, 6, "h");
+      vLine(g, 13, 4, 6, "h");
+    }
+  }
+  if (app.cap) {
+    // Yellow cap: a 2px band across the top of the hair.
+    fillRect(g, 4, 3, 8, 2, "y");
+  }
+}
+
+/** Head interior for down (face) or up (back of head). */
+function drawHeadFront(g: Grid, showFace: boolean): void {
+  fillRect(g, 4, 3, 8, 8, "h");
+  if (showFace) {
+    fillRect(g, 5, 6, 6, 5, "s");
+    fillRect(g, 5, 10, 6, 1, "s");
+    setPx(g, 4, 7, "h");
+    setPx(g, 11, 7, "h");
+    fillRect(g, 4, 8, 1, 3, "s");
+    fillRect(g, 11, 8, 1, 3, "s");
+    setPx(g, 6, 7, "e");
+    setPx(g, 9, 7, "e");
+  }
+}
+
+/** Head interior for a left-facing profile: face left, hair behind. */
+function drawHeadSide(g: Grid): void {
+  fillRect(g, 4, 3, 8, 8, "h");
+  fillRect(g, 4, 6, 4, 5, "s");
+  fillRect(g, 4, 9, 7, 2, "s");
+  setPx(g, 5, 7, "e");
+}
+
+/** Torso with outlined sides, shirt fill, and shaded hem row. */
+function drawTorso(g: Grid): void {
+  vLine(g, 4, 12, 6, "o");
+  vLine(g, 11, 12, 6, "o");
+  fillRect(g, 5, 12, 6, 5, "t");
+  fillRect(g, 5, 17, 6, 1, "T");
+}
+
+function drawFrontArms(g: Grid, pose: WalkPose): void {
+  const leftUp = pose === "a";
+  const rightUp = pose === "b";
+  const leftY = pose === "idle" ? 13 : leftUp ? 12 : 14;
+  const rightY = pose === "idle" ? 13 : rightUp ? 12 : 14;
+  vLine(g, 3, leftY, 2, "t");
+  setPx(g, 3, leftY + 2, "s");
+  vLine(g, 12, rightY, 2, "t");
+  setPx(g, 12, rightY + 2, "s");
+}
+
+function drawFrontLegs(g: Grid, pose: WalkPose): void {
+  const drawLeg = (x: number, lifted: boolean) => {
+    if (lifted) {
+      fillRect(g, x, 18, 2, 3, "p");
+      fillRect(g, x, 21, 2, 2, "b");
+    } else {
+      fillRect(g, x, 18, 2, 4, "p");
+      fillRect(g, x, 22, 2, 2, "b");
+    }
+  };
+  drawLeg(5, pose === "a");
+  drawLeg(9, pose === "b");
+}
+
+function drawSideArm(g: Grid, pose: WalkPose): void {
+  const x = pose === "idle" ? 5 : pose === "a" ? 4 : 6;
+  vLine(g, x, 13, 2, "T");
+  setPx(g, x, 15, "s");
+}
+
+function drawSideLegs(g: Grid, pose: WalkPose): void {
+  if (pose === "idle") {
+    fillRect(g, 6, 18, 4, 4, "p");
+    fillRect(g, 5, 22, 5, 1, "b");
+    fillRect(g, 5, 23, 2, 1, "b");
+    return;
+  }
+  if (pose === "a") {
+    // Front leg strides forward (toward the left), back leg trails lifted.
+    fillRect(g, 4, 18, 2, 4, "p");
+    fillRect(g, 3, 22, 3, 2, "b");
+    fillRect(g, 8, 18, 2, 3, "p");
+    fillRect(g, 8, 21, 3, 1, "b");
+    return;
+  }
+  // Pose "b": legs pass close together mid-stride.
+  fillRect(g, 6, 18, 2, 4, "p");
+  fillRect(g, 5, 22, 3, 2, "b");
+  fillRect(g, 8, 18, 2, 4, "p");
+  fillRect(g, 8, 22, 2, 1, "b");
+}
+
+function frontGrid(app: Appearance, pose: WalkPose, showFace: boolean): Grid {
+  const g = makeGrid(CHARACTER_WIDTH, CHARACTER_HEIGHT);
+  drawHeadOutline(g);
+  drawHeadFront(g, showFace);
+  applyHairStyle(g, app, showFace ? "down" : "up");
+  drawTorso(g);
+  drawFrontArms(g, pose);
+  drawFrontLegs(g, pose);
+  return g;
+}
+
+function sideGrid(app: Appearance, pose: WalkPose): Grid {
+  const g = makeGrid(CHARACTER_WIDTH, CHARACTER_HEIGHT);
+  drawHeadOutline(g);
+  drawHeadSide(g);
+  applyHairStyle(g, app, "left");
+  drawTorso(g);
+  drawSideArm(g, pose);
+  drawSideLegs(g, pose);
+  return g;
+}
+
+/** Shifts rows y0..y1 (inclusive) one pixel to the right for a head tilt. */
+function shiftRowsRight(g: Grid, y0: number, y1: number): void {
+  for (let y = y0; y <= y1 && y < g.length; y += 1) {
+    g[y].pop();
+    g[y].unshift(".");
+  }
+}
+
+function danceGrid(app: Appearance, variant: "a" | "b"): Grid {
+  const g = makeGrid(CHARACTER_WIDTH, CHARACTER_HEIGHT);
+  drawHeadOutline(g);
+  drawHeadFront(g, true);
+  applyHairStyle(g, app, "down");
+  if (variant === "b") shiftRowsRight(g, 0, 11);
+  drawTorso(g);
+  drawFrontLegs(g, "idle");
+  if (variant === "a") {
+    // Both arms straight up beside the head.
+    for (const x of [2, 13]) {
+      vLine(g, x, 10, 3, "t");
+      setPx(g, x, 9, "s");
+    }
+  } else {
+    // Arms out diagonally.
+    setPx(g, 2, 13, "t");
+    setPx(g, 1, 12, "t");
+    setPx(g, 1, 11, "s");
+    setPx(g, 13, 13, "t");
+    setPx(g, 14, 12, "t");
+    setPx(g, 14, 11, "s");
+  }
+  return g;
+}
+
+// ---------------------------------------------------------------------------
+// Sprite transforms.
+// ---------------------------------------------------------------------------
+
+/** Flips a sprite horizontally (rows padded to full width first). */
+export function mirrorSprite(sprite: PixelSprite, key: string): PixelSprite {
+  const width = spriteWidth(sprite);
+  const rows = sprite.rows.map((row) =>
+    row.padEnd(width, ".").split("").reverse().join(""),
+  );
+  return { key, rows, palette: sprite.palette };
+}
+
+/**
+ * Seated variant: drops three leg rows and re-pads the top, so the figure is
+ * shorter and reads as sitting when overlapped with a chair.
+ */
+function toSitting(sprite: PixelSprite, key: string): PixelSprite {
+  const kept = sprite.rows.filter((_, i) => i < 18 || i > 20);
+  const blank = ".".repeat(CHARACTER_WIDTH);
+  return { key, rows: [blank, blank, blank, ...kept], palette: sprite.palette };
+}
+
+// ---------------------------------------------------------------------------
+// Public API.
+// ---------------------------------------------------------------------------
+
+/** Fixed look for the cleaning-crew NPC. */
+export const JANITOR_LOOK: CharacterLook = {
+  seed: "npc-janitor",
+  accentColor: "#8a8f98",
+};
+
+/** Builds all 18 animation frames for one character look. */
+export function buildCharacterFrames(look: CharacterLook): CharacterFrameSet {
+  const app = resolveAppearance(look);
+  const pal = paletteFor(app);
+  const key = (name: CharacterFrameName) => `char_${look.seed}_${name}`;
+  const front = (name: CharacterFrameName, pose: WalkPose, showFace: boolean) =>
+    makeSprite(key(name), pal, gridRows(frontGrid(app, pose, showFace)));
+  const side = (name: CharacterFrameName, pose: WalkPose) =>
+    makeSprite(key(name), pal, gridRows(sideGrid(app, pose)));
+
+  const idleDown = front("idle_down", "idle", true);
+  const idleUp = front("idle_up", "idle", false);
+  const idleLeft = side("idle_left", "idle");
+  const idleRight = mirrorSprite(idleLeft, key("idle_right"));
+
+  return {
+    idle_down: idleDown,
+    walk_down_a: front("walk_down_a", "a", true),
+    walk_down_b: front("walk_down_b", "b", true),
+    idle_up: idleUp,
+    walk_up_a: front("walk_up_a", "a", false),
+    walk_up_b: front("walk_up_b", "b", false),
+    idle_left: idleLeft,
+    walk_left_a: side("walk_left_a", "a"),
+    walk_left_b: side("walk_left_b", "b"),
+    idle_right: idleRight,
+    walk_right_a: mirrorSprite(side("walk_left_a", "a"), key("walk_right_a")),
+    walk_right_b: mirrorSprite(side("walk_left_b", "b"), key("walk_right_b")),
+    sit_down: toSitting(idleDown, key("sit_down")),
+    sit_up: toSitting(idleUp, key("sit_up")),
+    sit_left: toSitting(idleLeft, key("sit_left")),
+    sit_right: toSitting(idleRight, key("sit_right")),
+    dance_a: makeSprite(key("dance_a"), pal, gridRows(danceGrid(app, "a"))),
+    dance_b: makeSprite(key("dance_b"), pal, gridRows(danceGrid(app, "b"))),
+  };
+}

--- a/src/features/pixel-office/art/characters.ts
+++ b/src/features/pixel-office/art/characters.ts
@@ -6,37 +6,66 @@ import {
   type CharacterLook,
   type PixelSprite,
 } from "../types";
-import {
-  CAP_YELLOW,
-  CHAR_EYE,
-  CHAR_OUTLINE,
-  CHAR_SHOE,
-  CHAR_WHITE,
-  FALLBACK_SHIRT,
-} from "./palette";
+import { CAP_YELLOW, CHAR_WHITE, FALLBACK_SHIRT } from "./palette";
 import { fillRect, gridRows, hLine, makeGrid, setPx, vLine, type Grid } from "./grid";
 import { makeSprite, spriteWidth } from "./sprite";
+
+// ---------------------------------------------------------------------------
+// Local colors for the 20x30 Gather-style avatars. Kept local on purpose:
+// palette.ts is owned by the tiles/furniture modules.
+// ---------------------------------------------------------------------------
+
+const OUTLINE_SOFT = "#2a2c38";
+const SHOE_GRAY_BLUE = "#3a4356";
+const EYE_DARK = "#20222c";
+const BLUSH_PINK = "#e59a8e";
+const MOUTH_HINT = "#b06a5a";
+const HEADPHONE_BAND = "#262a36";
+const HEADPHONE_CUP = "#4a5064";
 
 // ---------------------------------------------------------------------------
 // Appearance.
 // ---------------------------------------------------------------------------
 
 const SKIN_TONES = ["#f6d7b8", "#eebe98", "#d69a6c", "#a9714b", "#6f4a2f"] as const;
-const HAIR_COLORS = ["#2c2c34", "#6b4a2e", "#e6c15a", "#b8452f", "#9a9aa2", "#4a6fd9"] as const;
+
+/** Hair colors, each paired with a 1px-lighter highlight band. */
+const HAIR_COLORS = [
+  { base: "#2c2c34", highlight: "#4a4c5a" }, // black
+  { base: "#6b4a2e", highlight: "#8a6440" }, // brown
+  { base: "#e6c15a", highlight: "#f4d98c" }, // blonde
+  { base: "#b8452f", highlight: "#d96a48" }, // ginger
+  { base: "#9a9aa2", highlight: "#bfbfc7" }, // gray
+  { base: "#4a3a6b", highlight: "#6b5596" }, // violet
+  { base: "#3d6b52", highlight: "#579375" }, // teal-green
+] as const;
+
 const HAIR_STYLES = ["short", "spiky", "long", "bob"] as const;
 const PANTS_COLORS = ["#35406b", "#5a5f6e", "#5f4a33", "#24262e"] as const;
 
+/** Small-cap accessory colors (base + darker brim). */
+const CAP_COLORS = [
+  { base: "#c94f43", brim: "#9c382f" },
+  { base: "#4f9e43", brim: "#3c7d33" },
+  { base: "#5a8fd9", brim: "#3f6cab" },
+] as const;
+
 type HairStyle = (typeof HAIR_STYLES)[number];
+type Accessory = "none" | "headphones" | "cap";
 
 type Appearance = {
   skin: string;
   hair: string;
+  hairHighlight: string;
   hairStyle: HairStyle;
   pants: string;
   shirt: string;
   shirtShade: string;
+  accessory: Accessory;
+  capBase: string;
+  capBrim: string;
   /** Janitor NPCs get a yellow cap band on the hair. */
-  cap: boolean;
+  janitorCap: boolean;
 };
 
 /** Stable FNV-1a hash so a seed always maps to the same appearance. */
@@ -69,216 +98,407 @@ function resolveAppearance(look: CharacterLook): Appearance {
   if (look.seed.startsWith("npc-janitor")) {
     return {
       skin: SKIN_TONES[2],
-      hair: HAIR_COLORS[4],
+      hair: HAIR_COLORS[4].base,
+      hairHighlight: HAIR_COLORS[4].highlight,
       hairStyle: "short",
       pants: PANTS_COLORS[0],
       shirt,
       shirtShade,
-      cap: true,
+      accessory: "none",
+      capBase: CAP_COLORS[0].base,
+      capBrim: CAP_COLORS[0].brim,
+      janitorCap: true,
     };
   }
   const h = hashSeed(look.seed);
+  const hair = HAIR_COLORS[(h >>> 3) % HAIR_COLORS.length];
+  const accessoryRoll = (h >>> 12) % 5;
+  const cap = CAP_COLORS[(h >>> 15) % CAP_COLORS.length];
   return {
     skin: SKIN_TONES[h % SKIN_TONES.length],
-    hair: HAIR_COLORS[(h >>> 3) % HAIR_COLORS.length],
+    hair: hair.base,
+    hairHighlight: hair.highlight,
     hairStyle: HAIR_STYLES[(h >>> 6) % HAIR_STYLES.length],
     pants: PANTS_COLORS[(h >>> 9) % PANTS_COLORS.length],
     shirt,
     shirtShade,
-    cap: false,
+    accessory: accessoryRoll === 3 ? "headphones" : accessoryRoll === 4 ? "cap" : "none",
+    capBase: cap.base,
+    capBrim: cap.brim,
+    janitorCap: false,
   };
 }
 
 function paletteFor(app: Appearance): Record<string, string> {
   return {
-    o: CHAR_OUTLINE,
+    o: OUTLINE_SOFT,
     h: app.hair,
+    H: app.hairHighlight,
     s: app.skin,
+    e: EYE_DARK,
+    r: BLUSH_PINK,
+    m: MOUTH_HINT,
     t: app.shirt,
     T: app.shirtShade,
-    p: app.pants,
-    b: CHAR_SHOE,
-    e: CHAR_EYE,
     w: CHAR_WHITE,
+    p: app.pants,
+    b: SHOE_GRAY_BLUE,
     y: CAP_YELLOW,
+    k: app.capBase,
+    K: app.capBrim,
+    d: HEADPHONE_BAND,
+    D: HEADPHONE_CUP,
   };
 }
 
 // ---------------------------------------------------------------------------
-// Frame construction.
+// Frame construction. Layout at 20x30 (x 0..19, y 0..29):
+//   head  y0..9   (10px incl. hair, 10px wide at x5..14)
+//   torso y10..21 (12px: neck, collar row, shirt, belt outline)
+//   legs  y22..29 (8px: pants + 2px shoes)
+// Sitting variants redraw everything 6 rows lower and replace the legs with a
+// lap/knee band, so the figure reads 6px shorter.
 // ---------------------------------------------------------------------------
 
 type WalkPose = "idle" | "a" | "b";
 
-/** Rounded head outline box spanning x 3..12, y 2..11. */
-function drawHeadOutline(g: Grid): void {
-  hLine(g, 4, 2, 8, "o");
-  hLine(g, 4, 11, 8, "o");
-  vLine(g, 3, 3, 8, "o");
-  vLine(g, 12, 3, 8, "o");
+/** Rounded outline of the 10x10 head box spanning x5..14, y0..9. */
+function drawHeadOutline(g: Grid, dy: number): void {
+  hLine(g, 6, dy, 8, "o");
+  hLine(g, 6, dy + 9, 8, "o");
+  vLine(g, 5, dy + 1, 8, "o");
+  vLine(g, 14, dy + 1, 8, "o");
 }
 
-function applyHairStyle(g: Grid, app: Appearance, facing: "down" | "up" | "left"): void {
+/** Hair crown: rows 1..3 with the 1px lighter highlight band on row 2. */
+function drawHairCrown(g: Grid, dy: number): void {
+  fillRect(g, 6, dy + 1, 8, 1, "h");
+  setPx(g, 6, dy + 2, "h");
+  fillRect(g, 7, dy + 2, 6, 1, "H");
+  setPx(g, 13, dy + 2, "h");
+  fillRect(g, 6, dy + 3, 8, 1, "h");
+}
+
+function drawAccessoriesFront(g: Grid, app: Appearance, dy: number): void {
+  if (app.janitorCap) {
+    // Yellow cap band across the top of the (gray) hair.
+    fillRect(g, 6, dy + 1, 8, 2, "y");
+  } else if (app.accessory === "cap") {
+    fillRect(g, 6, dy + 1, 8, 3, "k");
+    hLine(g, 4, dy + 4, 12, "K");
+  } else if (app.accessory === "headphones") {
+    hLine(g, 6, dy + 1, 8, "d");
+    fillRect(g, 4, dy + 5, 2, 2, "D");
+    fillRect(g, 14, dy + 5, 2, 2, "D");
+  }
+}
+
+function drawAccessoriesSide(g: Grid, app: Appearance, dy: number): void {
+  if (app.janitorCap) {
+    fillRect(g, 6, dy + 1, 8, 2, "y");
+  } else if (app.accessory === "cap") {
+    fillRect(g, 6, dy + 1, 8, 3, "k");
+    hLine(g, 3, dy + 4, 7, "K");
+  } else if (app.accessory === "headphones") {
+    hLine(g, 6, dy + 1, 8, "d");
+    fillRect(g, 9, dy + 5, 2, 2, "D");
+  }
+}
+
+/** Front head (face) with per-style fringe, eyes, blush, and mouth hint. */
+function drawHeadFront(g: Grid, app: Appearance, dy: number): void {
+  drawHeadOutline(g, dy);
+  drawHairCrown(g, dy);
+  // Fringe row 4 + face rows 5..8.
+  fillRect(g, 6, dy + 5, 8, 4, "s");
   if (app.hairStyle === "spiky") {
-    for (const x of [4, 6, 8, 10]) setPx(g, x, 1, "h");
-  } else if (app.hairStyle === "long") {
-    if (facing === "left") {
-      vLine(g, 13, 4, 10, "h");
-    } else {
-      vLine(g, 2, 4, 10, "h");
-      vLine(g, 13, 4, 10, "h");
-    }
+    for (let x = 6; x <= 13; x += 1) setPx(g, x, dy + 4, x % 2 === 0 ? "h" : "s");
+    setPx(g, 13, dy + 4, "h");
+    setPx(g, 6, dy + 5, "h");
+    setPx(g, 13, dy + 5, "h");
+  } else if (app.hairStyle === "long" || app.hairStyle === "bob") {
+    fillRect(g, 6, dy + 4, 2, 1, "h");
+    fillRect(g, 8, dy + 4, 4, 1, "s");
+    fillRect(g, 12, dy + 4, 2, 1, "h");
+    setPx(g, 6, dy + 5, "h");
+    setPx(g, 13, dy + 5, "h");
+    const lockLen = app.hairStyle === "long" ? 9 : 6;
+    vLine(g, 4, dy + 3, lockLen, "h");
+    vLine(g, 15, dy + 3, lockLen, "h");
+  } else {
+    setPx(g, 6, dy + 4, "h");
+    fillRect(g, 7, dy + 4, 6, 1, "s");
+    setPx(g, 13, dy + 4, "h");
+  }
+  // Eyes: two 2x1 dark pixels.
+  fillRect(g, 7, dy + 6, 2, 1, "e");
+  fillRect(g, 11, dy + 6, 2, 1, "e");
+  // Blush hint on the cheeks + mouth hint (down-facing only).
+  setPx(g, 6, dy + 7, "r");
+  setPx(g, 13, dy + 7, "r");
+  fillRect(g, 9, dy + 8, 2, 1, "m");
+  drawAccessoriesFront(g, app, dy);
+}
+
+/** Back of the head (up-facing): all hair, no face. */
+function drawHeadBack(g: Grid, app: Appearance, dy: number): void {
+  drawHeadOutline(g, dy);
+  fillRect(g, 6, dy + 1, 8, 8, "h");
+  setPx(g, 6, dy + 2, "h");
+  fillRect(g, 7, dy + 2, 6, 1, "H");
+  drawAccessoriesFront(g, app, dy);
+}
+
+/** Hair falling over the shoulders, drawn AFTER the torso on up-facing frames. */
+function drawHairBackOverlay(g: Grid, app: Appearance, dy: number): void {
+  if (app.hairStyle === "long") {
+    fillRect(g, 5, dy + 9, 10, 2, "h");
+    fillRect(g, 6, dy + 11, 8, 3, "h");
+    vLine(g, 4, dy + 3, 9, "h");
+    vLine(g, 15, dy + 3, 9, "h");
   } else if (app.hairStyle === "bob") {
-    if (facing === "left") {
-      vLine(g, 13, 4, 6, "h");
-    } else {
-      vLine(g, 2, 4, 6, "h");
-      vLine(g, 13, 4, 6, "h");
-    }
-  }
-  if (app.cap) {
-    // Yellow cap: a 2px band across the top of the hair.
-    fillRect(g, 4, 3, 8, 2, "y");
+    fillRect(g, 5, dy + 9, 10, 2, "h");
+    vLine(g, 4, dy + 3, 6, "h");
+    vLine(g, 15, dy + 3, 6, "h");
   }
 }
 
-/** Head interior for down (face) or up (back of head). */
-function drawHeadFront(g: Grid, showFace: boolean): void {
-  fillRect(g, 4, 3, 8, 8, "h");
-  if (showFace) {
-    fillRect(g, 5, 6, 6, 5, "s");
-    fillRect(g, 5, 10, 6, 1, "s");
-    setPx(g, 4, 7, "h");
-    setPx(g, 11, 7, "h");
-    fillRect(g, 4, 8, 1, 3, "s");
-    fillRect(g, 11, 8, 1, 3, "s");
-    setPx(g, 6, 7, "e");
-    setPx(g, 9, 7, "e");
+/** Left-facing profile: face on the left, hair silhouette behind, one eye. */
+function drawHeadSide(g: Grid, app: Appearance, dy: number): void {
+  drawHeadOutline(g, dy);
+  drawHairCrown(g, dy);
+  // Fringe sweeps back: skin front, hair back.
+  if (app.hairStyle === "spiky") {
+    fillRect(g, 6, dy + 4, 2, 1, "s");
+    setPx(g, 8, dy + 4, "h");
+    setPx(g, 9, dy + 4, "s");
+    fillRect(g, 10, dy + 4, 4, 1, "h");
+  } else {
+    fillRect(g, 6, dy + 4, 3, 1, "s");
+    fillRect(g, 9, dy + 4, 5, 1, "h");
   }
+  fillRect(g, 6, dy + 5, 5, 1, "s");
+  fillRect(g, 11, dy + 5, 3, 1, "h");
+  fillRect(g, 6, dy + 6, 2, 1, "e"); // single profile eye
+  fillRect(g, 8, dy + 6, 3, 1, "s");
+  fillRect(g, 11, dy + 6, 3, 1, "h");
+  fillRect(g, 6, dy + 7, 5, 1, "s");
+  fillRect(g, 11, dy + 7, 3, 1, "h");
+  fillRect(g, 6, dy + 8, 6, 1, "s");
+  fillRect(g, 12, dy + 8, 2, 1, "h");
+  if (app.hairStyle === "long") {
+    fillRect(g, 12, dy + 4, 3, 9, "h");
+  } else if (app.hairStyle === "bob") {
+    fillRect(g, 12, dy + 4, 3, 6, "h");
+  }
+  drawAccessoriesSide(g, app, dy);
 }
 
-/** Head interior for a left-facing profile: face left, hair behind. */
-function drawHeadSide(g: Grid): void {
-  fillRect(g, 4, 3, 8, 8, "h");
-  fillRect(g, 4, 6, 4, 5, "s");
-  fillRect(g, 4, 9, 7, 2, "s");
-  setPx(g, 5, 7, "e");
+/** Front torso: neck, white collar row, shirt with shaded sides, belt outline. */
+function drawTorsoFront(g: Grid, dy: number): void {
+  setPx(g, 8, dy + 10, "o");
+  fillRect(g, 9, dy + 10, 2, 1, "s");
+  setPx(g, 11, dy + 10, "o");
+  setPx(g, 5, dy + 11, "o");
+  fillRect(g, 6, dy + 11, 2, 1, "t");
+  fillRect(g, 8, dy + 11, 4, 1, "w");
+  fillRect(g, 12, dy + 11, 2, 1, "t");
+  setPx(g, 14, dy + 11, "o");
+  for (let y = dy + 12; y <= dy + 19; y += 1) {
+    setPx(g, 5, y, "o");
+    setPx(g, 6, y, "T");
+    fillRect(g, 7, y, 6, 1, "t");
+    setPx(g, 13, y, "T");
+    setPx(g, 14, y, "o");
+  }
+  setPx(g, 5, dy + 20, "o");
+  fillRect(g, 6, dy + 20, 8, 1, "T");
+  setPx(g, 14, dy + 20, "o");
+  hLine(g, 6, dy + 21, 8, "o");
 }
 
-/** Torso with outlined sides, shirt fill, and shaded hem row. */
-function drawTorso(g: Grid): void {
-  vLine(g, 4, 12, 6, "o");
-  vLine(g, 11, 12, 6, "o");
-  fillRect(g, 5, 12, 6, 5, "t");
-  fillRect(g, 5, 17, 6, 1, "T");
+/** Side torso (narrower), shaded back column, collar sliver at the front. */
+function drawTorsoSide(g: Grid, dy: number): void {
+  setPx(g, 8, dy + 10, "o");
+  fillRect(g, 9, dy + 10, 2, 1, "s");
+  setPx(g, 11, dy + 10, "o");
+  setPx(g, 6, dy + 11, "o");
+  fillRect(g, 7, dy + 11, 2, 1, "w");
+  fillRect(g, 9, dy + 11, 3, 1, "t");
+  setPx(g, 12, dy + 11, "T");
+  setPx(g, 13, dy + 11, "o");
+  for (let y = dy + 12; y <= dy + 19; y += 1) {
+    setPx(g, 6, y, "o");
+    fillRect(g, 7, y, 5, 1, "t");
+    setPx(g, 12, y, "T");
+    setPx(g, 13, y, "o");
+  }
+  setPx(g, 6, dy + 20, "o");
+  fillRect(g, 7, dy + 20, 6, 1, "T");
+  setPx(g, 13, dy + 20, "o");
+  hLine(g, 7, dy + 21, 6, "o");
 }
 
-function drawFrontArms(g: Grid, pose: WalkPose): void {
-  const leftUp = pose === "a";
-  const rightUp = pose === "b";
-  const leftY = pose === "idle" ? 13 : leftUp ? 12 : 14;
-  const rightY = pose === "idle" ? 13 : rightUp ? 12 : 14;
-  vLine(g, 3, leftY, 2, "t");
-  setPx(g, 3, leftY + 2, "s");
-  vLine(g, 12, rightY, 2, "t");
-  setPx(g, 12, rightY + 2, "s");
+/** Front arms hang beside the torso; walk poses swing them 2px up/down. */
+function drawArmsFront(g: Grid, pose: WalkPose, dy: number): void {
+  const leftDy = pose === "idle" ? 0 : pose === "a" ? -2 : 2;
+  const rightDy = -leftDy;
+  vLine(g, 4, dy + 12 + leftDy, 4, "T");
+  fillRect(g, 4, dy + 16 + leftDy, 1, 2, "s");
+  vLine(g, 15, dy + 12 + rightDy, 4, "T");
+  fillRect(g, 15, dy + 16 + rightDy, 1, 2, "s");
 }
 
-function drawFrontLegs(g: Grid, pose: WalkPose): void {
+/** Single visible side arm; walk poses swing it 2px forward/back. */
+function drawArmSide(g: Grid, pose: WalkPose, dy: number): void {
+  const x = pose === "idle" ? 9 : pose === "a" ? 7 : 11;
+  fillRect(g, x, dy + 12, 2, 4, "T");
+  fillRect(g, x, dy + 16, 2, 2, "s");
+}
+
+/** Front legs: chunky 3px legs with a hip row; lifted legs raise the shoe 2px. */
+function drawLegsFront(g: Grid, pose: WalkPose): void {
+  fillRect(g, 6, 22, 8, 1, "p");
   const drawLeg = (x: number, lifted: boolean) => {
     if (lifted) {
-      fillRect(g, x, 18, 2, 3, "p");
-      fillRect(g, x, 21, 2, 2, "b");
+      fillRect(g, x, 23, 3, 3, "p");
+      fillRect(g, x, 26, 3, 2, "b");
     } else {
-      fillRect(g, x, 18, 2, 4, "p");
-      fillRect(g, x, 22, 2, 2, "b");
+      fillRect(g, x, 23, 3, 5, "p");
+      fillRect(g, x, 28, 3, 2, "b");
     }
   };
-  drawLeg(5, pose === "a");
-  drawLeg(9, pose === "b");
+  drawLeg(6, pose === "a");
+  drawLeg(11, pose === "b");
 }
 
-function drawSideArm(g: Grid, pose: WalkPose): void {
-  const x = pose === "idle" ? 5 : pose === "a" ? 4 : 6;
-  vLine(g, x, 13, 2, "T");
-  setPx(g, x, 15, "s");
-}
-
-function drawSideLegs(g: Grid, pose: WalkPose): void {
+/** Side legs: idle stands square; "a" is the stride, "b" the passing frame. */
+function drawLegsSide(g: Grid, pose: WalkPose): void {
+  fillRect(g, 7, 22, 6, 1, "p");
   if (pose === "idle") {
-    fillRect(g, 6, 18, 4, 4, "p");
-    fillRect(g, 5, 22, 5, 1, "b");
-    fillRect(g, 5, 23, 2, 1, "b");
+    fillRect(g, 8, 23, 4, 5, "p");
+    fillRect(g, 7, 28, 5, 2, "b");
     return;
   }
   if (pose === "a") {
-    // Front leg strides forward (toward the left), back leg trails lifted.
-    fillRect(g, 4, 18, 2, 4, "p");
-    fillRect(g, 3, 22, 3, 2, "b");
-    fillRect(g, 8, 18, 2, 3, "p");
-    fillRect(g, 8, 21, 3, 1, "b");
+    // Front leg strides toward the facing side; back heel lifts.
+    fillRect(g, 6, 23, 2, 5, "p");
+    fillRect(g, 5, 28, 3, 2, "b");
+    fillRect(g, 10, 23, 3, 3, "p");
+    fillRect(g, 11, 26, 3, 2, "b");
     return;
   }
-  // Pose "b": legs pass close together mid-stride.
-  fillRect(g, 6, 18, 2, 4, "p");
-  fillRect(g, 5, 22, 3, 2, "b");
-  fillRect(g, 8, 18, 2, 4, "p");
-  fillRect(g, 8, 22, 2, 1, "b");
+  // Passing frame: legs together, slight 1px bounce.
+  fillRect(g, 8, 23, 4, 4, "p");
+  fillRect(g, 8, 27, 4, 2, "b");
 }
+
+// ---------------------------------------------------------------------------
+// Full-frame grids.
+// ---------------------------------------------------------------------------
 
 function frontGrid(app: Appearance, pose: WalkPose, showFace: boolean): Grid {
   const g = makeGrid(CHARACTER_WIDTH, CHARACTER_HEIGHT);
-  drawHeadOutline(g);
-  drawHeadFront(g, showFace);
-  applyHairStyle(g, app, showFace ? "down" : "up");
-  drawTorso(g);
-  drawFrontArms(g, pose);
-  drawFrontLegs(g, pose);
+  drawTorsoFront(g, 0);
+  drawArmsFront(g, pose, 0);
+  drawLegsFront(g, pose);
+  if (showFace) {
+    drawHeadFront(g, app, 0);
+  } else {
+    drawHeadBack(g, app, 0);
+    drawHairBackOverlay(g, app, 0);
+  }
   return g;
 }
 
 function sideGrid(app: Appearance, pose: WalkPose): Grid {
   const g = makeGrid(CHARACTER_WIDTH, CHARACTER_HEIGHT);
-  drawHeadOutline(g);
-  drawHeadSide(g);
-  applyHairStyle(g, app, "left");
-  drawTorso(g);
-  drawSideArm(g, pose);
-  drawSideLegs(g, pose);
+  drawTorsoSide(g, 0);
+  drawLegsSide(g, pose);
+  drawHeadSide(g, app, 0);
+  drawArmSide(g, pose, 0);
   return g;
 }
 
-/** Shifts rows y0..y1 (inclusive) one pixel to the right for a head tilt. */
-function shiftRowsRight(g: Grid, y0: number, y1: number): void {
+/** Shifts rows y0..y1 (inclusive) horizontally by dx (-1 or 1) for head tilt. */
+function shiftRows(g: Grid, y0: number, y1: number, dx: number): void {
   for (let y = y0; y <= y1 && y < g.length; y += 1) {
-    g[y].pop();
-    g[y].unshift(".");
+    if (dx > 0) {
+      g[y].pop();
+      g[y].unshift(".");
+    } else {
+      g[y].shift();
+      g[y].push(".");
+    }
   }
 }
 
 function danceGrid(app: Appearance, variant: "a" | "b"): Grid {
   const g = makeGrid(CHARACTER_WIDTH, CHARACTER_HEIGHT);
-  drawHeadOutline(g);
-  drawHeadFront(g, true);
-  applyHairStyle(g, app, "down");
-  if (variant === "b") shiftRowsRight(g, 0, 11);
-  drawTorso(g);
-  drawFrontLegs(g, "idle");
+  // Head first so the 1px tilt only moves head pixels.
+  drawHeadFront(g, app, 0);
+  shiftRows(g, 0, 11, variant === "a" ? -1 : 1);
+  drawTorsoFront(g, 0);
+  // Legs spread wide.
+  fillRect(g, 6, 22, 8, 1, "p");
+  fillRect(g, 5, 23, 3, 5, "p");
+  fillRect(g, 5, 28, 3, 2, "b");
+  fillRect(g, 12, 23, 3, 5, "p");
+  fillRect(g, 12, 28, 3, 2, "b");
+  // Arms up, alternating heights between the two frames. Each arm gets a
+  // diagonal connector pixel so it doesn't float away from the shoulder.
+  const highArm = (x: number, shoulderX: number) => {
+    vLine(g, x, 8, 5, "T");
+    fillRect(g, x, 6, 1, 2, "s");
+    setPx(g, shoulderX, 13, "T");
+  };
+  const midArm = (x: number, shoulderX: number) => {
+    vLine(g, x, 10, 4, "T");
+    fillRect(g, x, 8, 1, 2, "s");
+    setPx(g, shoulderX, 14, "T");
+  };
   if (variant === "a") {
-    // Both arms straight up beside the head.
-    for (const x of [2, 13]) {
-      vLine(g, x, 10, 3, "t");
-      setPx(g, x, 9, "s");
-    }
+    highArm(3, 4);
+    midArm(16, 15);
   } else {
-    // Arms out diagonally.
-    setPx(g, 2, 13, "t");
-    setPx(g, 1, 12, "t");
-    setPx(g, 1, 11, "s");
-    setPx(g, 13, 13, "t");
-    setPx(g, 14, 12, "t");
-    setPx(g, 14, 11, "s");
+    midArm(3, 4);
+    highArm(16, 15);
   }
+  return g;
+}
+
+/**
+ * Seated frames: the whole figure is redrawn 6 rows lower (transparent top
+ * padding) and the legs collapse into a lap/knee band + shoes, so the sprite
+ * reads ~6px shorter when overlapped with a chair.
+ */
+function sitFrontGrid(app: Appearance, showFace: boolean): Grid {
+  const g = makeGrid(CHARACTER_WIDTH, CHARACTER_HEIGHT);
+  const dy = 6;
+  drawTorsoFront(g, dy);
+  drawArmsFront(g, "idle", dy);
+  if (showFace) {
+    drawHeadFront(g, app, dy);
+  } else {
+    drawHeadBack(g, app, dy);
+    drawHairBackOverlay(g, app, dy);
+  }
+  // Lap band + knees/shoes peeking below the torso.
+  fillRect(g, 6, 28, 8, 1, "p");
+  fillRect(g, 6, 29, 3, 1, "b");
+  fillRect(g, 11, 29, 3, 1, "b");
+  return g;
+}
+
+function sitSideGrid(app: Appearance): Grid {
+  const g = makeGrid(CHARACTER_WIDTH, CHARACTER_HEIGHT);
+  const dy = 6;
+  drawTorsoSide(g, dy);
+  drawHeadSide(g, app, dy);
+  drawArmSide(g, "idle", dy);
+  // Thigh extends toward the facing side, foot below the knee.
+  fillRect(g, 4, 28, 8, 1, "p");
+  fillRect(g, 4, 29, 3, 1, "b");
   return g;
 }
 
@@ -293,16 +513,6 @@ export function mirrorSprite(sprite: PixelSprite, key: string): PixelSprite {
     row.padEnd(width, ".").split("").reverse().join(""),
   );
   return { key, rows, palette: sprite.palette };
-}
-
-/**
- * Seated variant: drops three leg rows and re-pads the top, so the figure is
- * shorter and reads as sitting when overlapped with a chair.
- */
-function toSitting(sprite: PixelSprite, key: string): PixelSprite {
-  const kept = sprite.rows.filter((_, i) => i < 18 || i > 20);
-  const blank = ".".repeat(CHARACTER_WIDTH);
-  return { key, rows: [blank, blank, blank, ...kept], palette: sprite.palette };
 }
 
 // ---------------------------------------------------------------------------
@@ -325,28 +535,26 @@ export function buildCharacterFrames(look: CharacterLook): CharacterFrameSet {
   const side = (name: CharacterFrameName, pose: WalkPose) =>
     makeSprite(key(name), pal, gridRows(sideGrid(app, pose)));
 
-  const idleDown = front("idle_down", "idle", true);
-  const idleUp = front("idle_up", "idle", false);
   const idleLeft = side("idle_left", "idle");
-  const idleRight = mirrorSprite(idleLeft, key("idle_right"));
+  const sitLeft = makeSprite(key("sit_left"), pal, gridRows(sitSideGrid(app)));
 
   return {
-    idle_down: idleDown,
+    idle_down: front("idle_down", "idle", true),
     walk_down_a: front("walk_down_a", "a", true),
     walk_down_b: front("walk_down_b", "b", true),
-    idle_up: idleUp,
+    idle_up: front("idle_up", "idle", false),
     walk_up_a: front("walk_up_a", "a", false),
     walk_up_b: front("walk_up_b", "b", false),
     idle_left: idleLeft,
     walk_left_a: side("walk_left_a", "a"),
     walk_left_b: side("walk_left_b", "b"),
-    idle_right: idleRight,
+    idle_right: mirrorSprite(idleLeft, key("idle_right")),
     walk_right_a: mirrorSprite(side("walk_left_a", "a"), key("walk_right_a")),
     walk_right_b: mirrorSprite(side("walk_left_b", "b"), key("walk_right_b")),
-    sit_down: toSitting(idleDown, key("sit_down")),
-    sit_up: toSitting(idleUp, key("sit_up")),
-    sit_left: toSitting(idleLeft, key("sit_left")),
-    sit_right: toSitting(idleRight, key("sit_right")),
+    sit_down: makeSprite(key("sit_down"), pal, gridRows(sitFrontGrid(app, true))),
+    sit_up: makeSprite(key("sit_up"), pal, gridRows(sitFrontGrid(app, false))),
+    sit_left: sitLeft,
+    sit_right: mirrorSprite(sitLeft, key("sit_right")),
     dance_a: makeSprite(key("dance_a"), pal, gridRows(danceGrid(app, "a"))),
     dance_b: makeSprite(key("dance_b"), pal, gridRows(danceGrid(app, "b"))),
   };

--- a/src/features/pixel-office/art/characters.ts
+++ b/src/features/pixel-office/art/characters.ts
@@ -11,17 +11,21 @@ import { fillRect, gridRows, hLine, makeGrid, setPx, vLine, type Grid } from "./
 import { makeSprite, spriteWidth } from "./sprite";
 
 // ---------------------------------------------------------------------------
-// Local colors for the 20x30 Gather-style avatars. Kept local on purpose:
+// Local colors for the 40x60 Gather-style avatars. Kept local on purpose:
 // palette.ts is owned by the tiles/furniture modules.
 // ---------------------------------------------------------------------------
 
 const OUTLINE_SOFT = "#2a2c38";
-const SHOE_GRAY_BLUE = "#3a4356";
+const OUTLINE_JOINT = "#20222e";
+const SHOE_BASE = "#3a4356";
+const SHOE_LIGHT = "#8f96a8";
+const SOLE_DARK = "#262b38";
 const EYE_DARK = "#20222c";
 const BLUSH_PINK = "#e59a8e";
 const MOUTH_HINT = "#b06a5a";
 const HEADPHONE_BAND = "#262a36";
 const HEADPHONE_CUP = "#4a5064";
+const HEADPHONE_SHINE = "#7a83a0";
 
 // ---------------------------------------------------------------------------
 // Appearance.
@@ -29,21 +33,21 @@ const HEADPHONE_CUP = "#4a5064";
 
 const SKIN_TONES = ["#f6d7b8", "#eebe98", "#d69a6c", "#a9714b", "#6f4a2f"] as const;
 
-/** Hair colors, each paired with a 1px-lighter highlight band. */
+/** Hair colors: base fill, lighter highlight band, and darker underside. */
 const HAIR_COLORS = [
-  { base: "#2c2c34", highlight: "#4a4c5a" }, // black
-  { base: "#6b4a2e", highlight: "#8a6440" }, // brown
-  { base: "#e6c15a", highlight: "#f4d98c" }, // blonde
-  { base: "#b8452f", highlight: "#d96a48" }, // ginger
-  { base: "#9a9aa2", highlight: "#bfbfc7" }, // gray
-  { base: "#4a3a6b", highlight: "#6b5596" }, // violet
-  { base: "#3d6b52", highlight: "#579375" }, // teal-green
+  { base: "#2c2c34", highlight: "#4a4c5a", dark: "#1d1d24" }, // black.
+  { base: "#6b4a2e", highlight: "#8a6440", dark: "#4e3520" }, // brown.
+  { base: "#e6c15a", highlight: "#f4d98c", dark: "#b8933c" }, // blonde.
+  { base: "#b8452f", highlight: "#d96a48", dark: "#8c3222" }, // ginger.
+  { base: "#9a9aa2", highlight: "#bfbfc7", dark: "#6e6e78" }, // gray.
+  { base: "#4a3a6b", highlight: "#6b5596", dark: "#352a4e" }, // violet.
+  { base: "#3d6b52", highlight: "#579375", dark: "#2b4d3a" }, // teal-green.
 ] as const;
 
 const HAIR_STYLES = ["short", "spiky", "long", "bob"] as const;
 const PANTS_COLORS = ["#35406b", "#5a5f6e", "#5f4a33", "#24262e"] as const;
 
-/** Small-cap accessory colors (base + darker brim). */
+/** Cap accessory colors (base + darker brim). */
 const CAP_COLORS = [
   { base: "#c94f43", brim: "#9c382f" },
   { base: "#4f9e43", brim: "#3c7d33" },
@@ -55,10 +59,13 @@ type Accessory = "none" | "headphones" | "cap";
 
 type Appearance = {
   skin: string;
+  skinShade: string;
   hair: string;
   hairHighlight: string;
+  hairDark: string;
   hairStyle: HairStyle;
   pants: string;
+  pantsCrease: string;
   shirt: string;
   shirtShade: string;
   accessory: Accessory;
@@ -98,10 +105,13 @@ function resolveAppearance(look: CharacterLook): Appearance {
   if (look.seed.startsWith("npc-janitor")) {
     return {
       skin: SKIN_TONES[2],
+      skinShade: darkenHex(SKIN_TONES[2], 0.85),
       hair: HAIR_COLORS[4].base,
       hairHighlight: HAIR_COLORS[4].highlight,
+      hairDark: HAIR_COLORS[4].dark,
       hairStyle: "short",
       pants: PANTS_COLORS[0],
+      pantsCrease: darkenHex(PANTS_COLORS[0], 0.72),
       shirt,
       shirtShade,
       accessory: "none",
@@ -111,15 +121,20 @@ function resolveAppearance(look: CharacterLook): Appearance {
     };
   }
   const h = hashSeed(look.seed);
+  const skin = SKIN_TONES[h % SKIN_TONES.length];
   const hair = HAIR_COLORS[(h >>> 3) % HAIR_COLORS.length];
+  const pants = PANTS_COLORS[(h >>> 9) % PANTS_COLORS.length];
   const accessoryRoll = (h >>> 12) % 5;
   const cap = CAP_COLORS[(h >>> 15) % CAP_COLORS.length];
   return {
-    skin: SKIN_TONES[h % SKIN_TONES.length],
+    skin,
+    skinShade: darkenHex(skin, 0.85),
     hair: hair.base,
     hairHighlight: hair.highlight,
+    hairDark: hair.dark,
     hairStyle: HAIR_STYLES[(h >>> 6) % HAIR_STYLES.length],
-    pants: PANTS_COLORS[(h >>> 9) % PANTS_COLORS.length],
+    pants,
+    pantsCrease: darkenHex(pants, 0.72),
     shirt,
     shirtShade,
     accessory: accessoryRoll === 3 ? "headphones" : accessoryRoll === 4 ? "cap" : "none",
@@ -132,265 +147,446 @@ function resolveAppearance(look: CharacterLook): Appearance {
 function paletteFor(app: Appearance): Record<string, string> {
   return {
     o: OUTLINE_SOFT,
+    O: OUTLINE_JOINT,
     h: app.hair,
     H: app.hairHighlight,
+    g: app.hairDark,
     s: app.skin,
+    S: app.skinShade,
     e: EYE_DARK,
+    w: CHAR_WHITE,
     r: BLUSH_PINK,
     m: MOUTH_HINT,
     t: app.shirt,
     T: app.shirtShade,
-    w: CHAR_WHITE,
     p: app.pants,
-    b: SHOE_GRAY_BLUE,
+    P: app.pantsCrease,
+    b: SHOE_BASE,
+    c: SHOE_LIGHT,
+    B: SOLE_DARK,
     y: CAP_YELLOW,
     k: app.capBase,
     K: app.capBrim,
     d: HEADPHONE_BAND,
     D: HEADPHONE_CUP,
+    f: HEADPHONE_SHINE,
   };
 }
 
 // ---------------------------------------------------------------------------
-// Frame construction. Layout at 20x30 (x 0..19, y 0..29):
-//   head  y0..9   (10px incl. hair, 10px wide at x5..14)
-//   torso y10..21 (12px: neck, collar row, shirt, belt outline)
-//   legs  y22..29 (8px: pants + 2px shoes)
-// Sitting variants redraw everything 6 rows lower and replace the legs with a
-// lap/knee band, so the figure reads 6px shorter.
+// Frame construction. Standing layout at 40x60 (x 0..39, y 0..59):
+//   head  y0..19  (20px incl. hair volume, box at x10..29).
+//   torso y20..43 (24px: neck, collar, shirt, hem, belt, hip band).
+//   legs  y44..59 (16px: 10px pants + 6px two-tone shoes).
+// Front frames are mirror-symmetric around x = 19.5 (pairs sum to 39).
+// Walk frames drop the body 1px (bob) and lift one leg 2px; sitting frames
+// redraw everything 12 rows lower with a lap band and hands resting on it.
 // ---------------------------------------------------------------------------
 
 type WalkPose = "idle" | "a" | "b";
 
-/** Rounded outline of the 10x10 head box spanning x5..14, y0..9. */
+/** Rounded outline of the 20x20 head box at x10..29, y dy..dy+19. */
 function drawHeadOutline(g: Grid, dy: number): void {
-  hLine(g, 6, dy, 8, "o");
-  hLine(g, 6, dy + 9, 8, "o");
-  vLine(g, 5, dy + 1, 8, "o");
-  vLine(g, 14, dy + 1, 8, "o");
+  hLine(g, 12, dy, 16, "o");
+  fillRect(g, 10, dy + 1, 2, 1, "o");
+  fillRect(g, 28, dy + 1, 2, 1, "o");
+  vLine(g, 10, dy + 2, 16, "o");
+  vLine(g, 29, dy + 2, 16, "o");
+  fillRect(g, 10, dy + 18, 2, 1, "o");
+  fillRect(g, 28, dy + 18, 2, 1, "o");
+  // Jaw line with a gap over the neck so the head connects to the body.
+  hLine(g, 12, dy + 19, 5, "o");
+  hLine(g, 23, dy + 19, 5, "o");
 }
 
-/** Hair crown: rows 1..3 with the 1px lighter highlight band on row 2. */
+/** Fills the jaw gap so the chin flows into the neck without a hole. */
+function drawNeckGapFill(g: Grid, dy: number, ch: string): void {
+  fillRect(g, 17, dy + 19, 6, 1, ch);
+}
+
+/** Hair crown rows 1..7: base, tapered highlight band, dark under-edge. */
 function drawHairCrown(g: Grid, dy: number): void {
-  fillRect(g, 6, dy + 1, 8, 1, "h");
-  setPx(g, 6, dy + 2, "h");
-  fillRect(g, 7, dy + 2, 6, 1, "H");
-  setPx(g, 13, dy + 2, "h");
-  fillRect(g, 6, dy + 3, 8, 1, "h");
+  fillRect(g, 12, dy + 1, 16, 1, "h");
+  fillRect(g, 11, dy + 2, 18, 1, "h");
+  fillRect(g, 11, dy + 3, 2, 1, "h");
+  fillRect(g, 13, dy + 3, 14, 1, "H");
+  fillRect(g, 27, dy + 3, 2, 1, "h");
+  fillRect(g, 11, dy + 4, 4, 1, "h");
+  fillRect(g, 15, dy + 4, 10, 1, "H");
+  fillRect(g, 25, dy + 4, 4, 1, "h");
+  fillRect(g, 11, dy + 5, 18, 2, "h");
+  fillRect(g, 11, dy + 7, 2, 1, "g");
+  fillRect(g, 13, dy + 7, 14, 1, "h");
+  fillRect(g, 27, dy + 7, 2, 1, "g");
+}
+
+/** Face fill under the crown, with soft chin shading above the jaw. */
+function drawFaceBase(g: Grid, dy: number): void {
+  fillRect(g, 11, dy + 8, 18, 10, "s");
+  fillRect(g, 12, dy + 18, 16, 1, "s");
+  fillRect(g, 17, dy + 17, 6, 1, "S");
+  drawNeckGapFill(g, dy, "s");
+}
+
+/** Brows, glinted 2x2 eyes, cheek blush, and the 2px mouth (front only). */
+function drawFaceFeatures(g: Grid, dy: number): void {
+  fillRect(g, 14, dy + 10, 2, 1, "g");
+  fillRect(g, 24, dy + 10, 2, 1, "g");
+  fillRect(g, 14, dy + 11, 2, 2, "e");
+  fillRect(g, 24, dy + 11, 2, 2, "e");
+  setPx(g, 15, dy + 11, "w");
+  setPx(g, 24, dy + 11, "w");
+  fillRect(g, 12, dy + 14, 2, 1, "r");
+  fillRect(g, 26, dy + 14, 2, 1, "r");
+  fillRect(g, 19, dy + 15, 2, 1, "m");
+}
+
+/** Style-specific fringe and hair silhouette for front-facing heads. */
+function drawFringeFront(g: Grid, app: Appearance, dy: number): void {
+  fillRect(g, 11, dy + 8, 18, 1, "h");
+  if (app.hairStyle === "spiky") {
+    // Jagged spikes biting into the forehead.
+    for (const x of [11, 15, 19, 23, 27]) fillRect(g, x, dy + 9, 2, 1, "h");
+    setPx(g, 11, dy + 10, "g");
+    setPx(g, 28, dy + 10, "g");
+  } else if (app.hairStyle === "long") {
+    // Curtain part framing the face down to the jaw.
+    fillRect(g, 11, dy + 9, 3, 1, "h");
+    fillRect(g, 26, dy + 9, 3, 1, "h");
+    vLine(g, 11, dy + 10, 8, "h");
+    vLine(g, 28, dy + 10, 8, "h");
+    // Shoulder locks hanging outside the head outline, with dark tips.
+    fillRect(g, 8, dy + 4, 2, 26, "h");
+    fillRect(g, 30, dy + 4, 2, 26, "h");
+    fillRect(g, 8, dy + 29, 2, 1, "g");
+    fillRect(g, 30, dy + 29, 2, 1, "g");
+  } else if (app.hairStyle === "bob") {
+    // Side panels curling inward at the chin plus outer volume.
+    fillRect(g, 11, dy + 9, 2, 7, "h");
+    fillRect(g, 27, dy + 9, 2, 7, "h");
+    setPx(g, 13, dy + 15, "h");
+    setPx(g, 26, dy + 15, "h");
+    vLine(g, 9, dy + 3, 10, "h");
+    vLine(g, 30, dy + 3, 10, "h");
+  } else {
+    // Short crop: straight fringe with small sideburn shadows.
+    vLine(g, 11, dy + 9, 2, "g");
+    vLine(g, 28, dy + 9, 2, "g");
+  }
 }
 
 function drawAccessoriesFront(g: Grid, app: Appearance, dy: number): void {
   if (app.janitorCap) {
     // Yellow cap band across the top of the (gray) hair.
-    fillRect(g, 6, dy + 1, 8, 2, "y");
+    fillRect(g, 12, dy + 1, 16, 1, "y");
+    fillRect(g, 11, dy + 2, 18, 2, "y");
   } else if (app.accessory === "cap") {
-    fillRect(g, 6, dy + 1, 8, 3, "k");
-    hLine(g, 4, dy + 4, 12, "K");
+    fillRect(g, 12, dy + 1, 16, 1, "k");
+    fillRect(g, 11, dy + 2, 18, 3, "k");
+    fillRect(g, 11, dy + 5, 18, 1, "K");
+    // Wide front brim.
+    hLine(g, 7, dy + 6, 26, "K");
   } else if (app.accessory === "headphones") {
-    hLine(g, 6, dy + 1, 8, "d");
-    fillRect(g, 4, dy + 5, 2, 2, "D");
-    fillRect(g, 14, dy + 5, 2, 2, "D");
+    hLine(g, 12, dy, 16, "d");
+    fillRect(g, 12, dy + 1, 16, 1, "d");
+    fillRect(g, 8, dy + 10, 3, 4, "D");
+    fillRect(g, 29, dy + 10, 3, 4, "D");
+    setPx(g, 9, dy + 11, "f");
+    setPx(g, 30, dy + 11, "f");
   }
 }
 
-function drawAccessoriesSide(g: Grid, app: Appearance, dy: number): void {
+function drawAccessoriesBack(g: Grid, app: Appearance, dy: number): void {
   if (app.janitorCap) {
-    fillRect(g, 6, dy + 1, 8, 2, "y");
+    fillRect(g, 12, dy + 1, 16, 1, "y");
+    fillRect(g, 11, dy + 2, 18, 2, "y");
   } else if (app.accessory === "cap") {
-    fillRect(g, 6, dy + 1, 8, 3, "k");
-    hLine(g, 3, dy + 4, 7, "K");
+    fillRect(g, 12, dy + 1, 16, 1, "k");
+    fillRect(g, 11, dy + 2, 18, 3, "k");
+    fillRect(g, 11, dy + 5, 18, 1, "K");
   } else if (app.accessory === "headphones") {
-    hLine(g, 6, dy + 1, 8, "d");
-    fillRect(g, 9, dy + 5, 2, 2, "D");
+    hLine(g, 12, dy, 16, "d");
+    fillRect(g, 12, dy + 1, 16, 1, "d");
+    fillRect(g, 8, dy + 10, 3, 4, "D");
+    fillRect(g, 29, dy + 10, 3, 4, "D");
+    setPx(g, 9, dy + 11, "f");
+    setPx(g, 30, dy + 11, "f");
   }
 }
 
-/** Front head (face) with per-style fringe, eyes, blush, and mouth hint. */
+/** Front head (face) with per-style fringe, eyes, blush, and mouth. */
 function drawHeadFront(g: Grid, app: Appearance, dy: number): void {
   drawHeadOutline(g, dy);
+  drawFaceBase(g, dy);
   drawHairCrown(g, dy);
-  // Fringe row 4 + face rows 5..8.
-  fillRect(g, 6, dy + 5, 8, 4, "s");
-  if (app.hairStyle === "spiky") {
-    for (let x = 6; x <= 13; x += 1) setPx(g, x, dy + 4, x % 2 === 0 ? "h" : "s");
-    setPx(g, 13, dy + 4, "h");
-    setPx(g, 6, dy + 5, "h");
-    setPx(g, 13, dy + 5, "h");
-  } else if (app.hairStyle === "long" || app.hairStyle === "bob") {
-    fillRect(g, 6, dy + 4, 2, 1, "h");
-    fillRect(g, 8, dy + 4, 4, 1, "s");
-    fillRect(g, 12, dy + 4, 2, 1, "h");
-    setPx(g, 6, dy + 5, "h");
-    setPx(g, 13, dy + 5, "h");
-    const lockLen = app.hairStyle === "long" ? 9 : 6;
-    vLine(g, 4, dy + 3, lockLen, "h");
-    vLine(g, 15, dy + 3, lockLen, "h");
-  } else {
-    setPx(g, 6, dy + 4, "h");
-    fillRect(g, 7, dy + 4, 6, 1, "s");
-    setPx(g, 13, dy + 4, "h");
-  }
-  // Eyes: two 2x1 dark pixels.
-  fillRect(g, 7, dy + 6, 2, 1, "e");
-  fillRect(g, 11, dy + 6, 2, 1, "e");
-  // Blush hint on the cheeks + mouth hint (down-facing only).
-  setPx(g, 6, dy + 7, "r");
-  setPx(g, 13, dy + 7, "r");
-  fillRect(g, 9, dy + 8, 2, 1, "m");
+  drawFaceFeatures(g, dy);
+  drawFringeFront(g, app, dy);
   drawAccessoriesFront(g, app, dy);
 }
 
-/** Back of the head (up-facing): all hair, no face. */
+/** Back of the head (up-facing): all hair with highlight + dark edge. */
 function drawHeadBack(g: Grid, app: Appearance, dy: number): void {
   drawHeadOutline(g, dy);
-  fillRect(g, 6, dy + 1, 8, 8, "h");
-  setPx(g, 6, dy + 2, "h");
-  fillRect(g, 7, dy + 2, 6, 1, "H");
-  drawAccessoriesFront(g, app, dy);
+  fillRect(g, 12, dy + 1, 16, 1, "h");
+  fillRect(g, 11, dy + 2, 18, 16, "h");
+  fillRect(g, 13, dy + 3, 14, 1, "H");
+  fillRect(g, 15, dy + 4, 10, 1, "H");
+  fillRect(g, 12, dy + 18, 16, 1, "g");
+  drawNeckGapFill(g, dy, "h");
+  drawAccessoriesBack(g, app, dy);
 }
 
-/** Hair falling over the shoulders, drawn AFTER the torso on up-facing frames. */
+/** Hair falling over the shoulders, drawn AFTER the torso on up frames. */
 function drawHairBackOverlay(g: Grid, app: Appearance, dy: number): void {
   if (app.hairStyle === "long") {
-    fillRect(g, 5, dy + 9, 10, 2, "h");
-    fillRect(g, 6, dy + 11, 8, 3, "h");
-    vLine(g, 4, dy + 3, 9, "h");
-    vLine(g, 15, dy + 3, 9, "h");
+    fillRect(g, 11, dy + 19, 18, 5, "h");
+    fillRect(g, 12, dy + 24, 16, 4, "h");
+    fillRect(g, 12, dy + 28, 16, 1, "g");
+    fillRect(g, 8, dy + 4, 2, 26, "h");
+    fillRect(g, 30, dy + 4, 2, 26, "h");
   } else if (app.hairStyle === "bob") {
-    fillRect(g, 5, dy + 9, 10, 2, "h");
-    vLine(g, 4, dy + 3, 6, "h");
-    vLine(g, 15, dy + 3, 6, "h");
+    fillRect(g, 11, dy + 19, 18, 3, "h");
+    fillRect(g, 11, dy + 22, 18, 1, "g");
+    vLine(g, 9, dy + 3, 10, "h");
+    vLine(g, 30, dy + 3, 10, "h");
+  } else if (app.hairStyle === "spiky") {
+    // Stray spikes poking off the silhouette, kept attached to the outline.
+    setPx(g, 9, dy + 4, "h");
+    setPx(g, 30, dy + 4, "h");
+    fillRect(g, 8, dy + 7, 2, 1, "h");
+    fillRect(g, 30, dy + 7, 2, 1, "h");
+    setPx(g, 9, dy + 10, "h");
+    setPx(g, 30, dy + 10, "h");
   }
 }
 
-/** Left-facing profile: face on the left, hair silhouette behind, one eye. */
+/** Left-facing profile: nose bump, single glinted eye, swept-back hair. */
 function drawHeadSide(g: Grid, app: Appearance, dy: number): void {
   drawHeadOutline(g, dy);
+  drawFaceBase(g, dy);
   drawHairCrown(g, dy);
-  // Fringe sweeps back: skin front, hair back.
-  if (app.hairStyle === "spiky") {
-    fillRect(g, 6, dy + 4, 2, 1, "s");
-    setPx(g, 8, dy + 4, "h");
-    setPx(g, 9, dy + 4, "s");
-    fillRect(g, 10, dy + 4, 4, 1, "h");
-  } else {
-    fillRect(g, 6, dy + 4, 3, 1, "s");
-    fillRect(g, 9, dy + 4, 5, 1, "h");
+  // Swept-back hair mass with a diagonal fringe edge (dark leading pixel).
+  const hairStarts = [13, 16, 18, 20, 20, 20, 20, 20, 21, 22];
+  for (let i = 0; i < hairStarts.length; i += 1) {
+    const y = dy + 8 + i;
+    const sx = hairStarts[i];
+    setPx(g, sx, y, "g");
+    fillRect(g, sx + 1, y, 28 - sx, 1, "h");
   }
-  fillRect(g, 6, dy + 5, 5, 1, "s");
-  fillRect(g, 11, dy + 5, 3, 1, "h");
-  fillRect(g, 6, dy + 6, 2, 1, "e"); // single profile eye
-  fillRect(g, 8, dy + 6, 3, 1, "s");
-  fillRect(g, 11, dy + 6, 3, 1, "h");
-  fillRect(g, 6, dy + 7, 5, 1, "s");
-  fillRect(g, 11, dy + 7, 3, 1, "h");
-  fillRect(g, 6, dy + 8, 6, 1, "s");
-  fillRect(g, 12, dy + 8, 2, 1, "h");
-  if (app.hairStyle === "long") {
-    fillRect(g, 12, dy + 4, 3, 9, "h");
+  fillRect(g, 23, dy + 18, 5, 1, "h");
+  // Profile brow and single eye with glint.
+  fillRect(g, 13, dy + 10, 2, 1, "g");
+  fillRect(g, 13, dy + 11, 2, 2, "e");
+  setPx(g, 13, dy + 11, "w");
+  // Nose bump on the facing edge.
+  setPx(g, 9, dy + 12, "o");
+  setPx(g, 8, dy + 13, "o");
+  setPx(g, 9, dy + 13, "s");
+  setPx(g, 9, dy + 14, "o");
+  setPx(g, 10, dy + 13, "s");
+  if (app.hairStyle === "spiky") {
+    // Spike tips off the back of the head plus a jagged forehead notch.
+    fillRect(g, 30, dy + 4, 2, 1, "h");
+    fillRect(g, 30, dy + 8, 2, 1, "h");
+    setPx(g, 30, dy + 12, "h");
+    fillRect(g, 11, dy + 8, 2, 1, "h");
+    setPx(g, 12, dy + 9, "h");
+  } else if (app.hairStyle === "long") {
+    // Tail of hair running down the back, outlined on its far edge.
+    fillRect(g, 25, dy + 8, 4, 22, "h");
+    vLine(g, 29, dy + 18, 12, "o");
+    fillRect(g, 25, dy + 29, 4, 1, "g");
   } else if (app.hairStyle === "bob") {
-    fillRect(g, 12, dy + 4, 3, 6, "h");
+    // Bob mass wrapping below the jaw with a dark under-edge.
+    fillRect(g, 24, dy + 18, 4, 3, "h");
+    fillRect(g, 24, dy + 21, 4, 1, "g");
+    vLine(g, 30, dy + 4, 10, "h");
   }
   drawAccessoriesSide(g, app, dy);
 }
 
-/** Front torso: neck, white collar row, shirt with shaded sides, belt outline. */
-function drawTorsoFront(g: Grid, dy: number): void {
-  setPx(g, 8, dy + 10, "o");
-  fillRect(g, 9, dy + 10, 2, 1, "s");
-  setPx(g, 11, dy + 10, "o");
-  setPx(g, 5, dy + 11, "o");
-  fillRect(g, 6, dy + 11, 2, 1, "t");
-  fillRect(g, 8, dy + 11, 4, 1, "w");
-  fillRect(g, 12, dy + 11, 2, 1, "t");
-  setPx(g, 14, dy + 11, "o");
-  for (let y = dy + 12; y <= dy + 19; y += 1) {
-    setPx(g, 5, y, "o");
-    setPx(g, 6, y, "T");
-    fillRect(g, 7, y, 6, 1, "t");
-    setPx(g, 13, y, "T");
-    setPx(g, 14, y, "o");
+function drawAccessoriesSide(g: Grid, app: Appearance, dy: number): void {
+  if (app.janitorCap) {
+    fillRect(g, 12, dy + 1, 16, 1, "y");
+    fillRect(g, 11, dy + 2, 18, 2, "y");
+  } else if (app.accessory === "cap") {
+    fillRect(g, 12, dy + 1, 16, 1, "k");
+    fillRect(g, 11, dy + 2, 18, 3, "k");
+    fillRect(g, 11, dy + 5, 18, 1, "K");
+    // Brim pointing toward the facing side.
+    hLine(g, 4, dy + 6, 16, "K");
+  } else if (app.accessory === "headphones") {
+    hLine(g, 12, dy, 16, "d");
+    fillRect(g, 12, dy + 1, 16, 1, "d");
+    // Single cup over the ear.
+    fillRect(g, 17, dy + 10, 4, 4, "D");
+    setPx(g, 18, dy + 11, "f");
   }
-  setPx(g, 5, dy + 20, "o");
-  fillRect(g, 6, dy + 20, 8, 1, "T");
-  setPx(g, 14, dy + 20, "o");
-  hLine(g, 6, dy + 21, 8, "o");
 }
 
-/** Side torso (narrower), shaded back column, collar sliver at the front. */
-function drawTorsoSide(g: Grid, dy: number): void {
-  setPx(g, 8, dy + 10, "o");
-  fillRect(g, 9, dy + 10, 2, 1, "s");
-  setPx(g, 11, dy + 10, "o");
-  setPx(g, 6, dy + 11, "o");
-  fillRect(g, 7, dy + 11, 2, 1, "w");
-  fillRect(g, 9, dy + 11, 3, 1, "t");
-  setPx(g, 12, dy + 11, "T");
-  setPx(g, 13, dy + 11, "o");
-  for (let y = dy + 12; y <= dy + 19; y += 1) {
-    setPx(g, 6, y, "o");
-    fillRect(g, 7, y, 5, 1, "t");
-    setPx(g, 12, y, "T");
-    setPx(g, 13, y, "o");
+/** Front torso: neck, collar band with wings, shaded shirt, hem, hips. */
+function drawTorsoFront(g: Grid, dy: number): void {
+  // Neck with a shadow row under the chin.
+  setPx(g, 16, dy + 20, "o");
+  fillRect(g, 17, dy + 20, 6, 1, "s");
+  setPx(g, 23, dy + 20, "o");
+  setPx(g, 16, dy + 21, "o");
+  fillRect(g, 17, dy + 21, 6, 1, "S");
+  setPx(g, 23, dy + 21, "o");
+  // Shoulder line and white collar band.
+  hLine(g, 10, dy + 22, 6, "o");
+  fillRect(g, 16, dy + 22, 8, 1, "w");
+  hLine(g, 24, dy + 22, 6, "o");
+  // Collar row with wing tips; darker joint pixels at the shoulder corners.
+  setPx(g, 10, dy + 23, "O");
+  fillRect(g, 11, dy + 23, 2, 1, "T");
+  fillRect(g, 13, dy + 23, 2, 1, "t");
+  fillRect(g, 15, dy + 23, 10, 1, "w");
+  fillRect(g, 25, dy + 23, 2, 1, "t");
+  fillRect(g, 27, dy + 23, 2, 1, "T");
+  setPx(g, 29, dy + 23, "O");
+  // Shirt body with side shading columns.
+  for (let y = dy + 24; y <= dy + 37; y += 1) {
+    setPx(g, 10, y, "o");
+    fillRect(g, 11, y, 2, 1, "T");
+    fillRect(g, 13, y, 14, 1, "t");
+    fillRect(g, 27, y, 2, 1, "T");
+    setPx(g, 29, y, "o");
   }
-  setPx(g, 6, dy + 20, "o");
-  fillRect(g, 7, dy + 20, 6, 1, "T");
-  setPx(g, 13, dy + 20, "o");
-  hLine(g, 7, dy + 21, 6, "o");
+  // Two-row hem.
+  for (let y = dy + 38; y <= dy + 39; y += 1) {
+    setPx(g, 10, y, "o");
+    fillRect(g, 11, y, 18, 1, "T");
+    setPx(g, 29, y, "o");
+  }
+  // Belt outline between shirt and hips.
+  hLine(g, 11, dy + 40, 18, "o");
+  // Hip band with darker joint pixels at the top corners.
+  for (let y = dy + 41; y <= dy + 43; y += 1) {
+    setPx(g, 11, y, y === dy + 41 ? "O" : "o");
+    fillRect(g, 12, y, 16, 1, "p");
+    setPx(g, 28, y, y === dy + 41 ? "O" : "o");
+  }
+}
+
+/** Side torso (narrower box at x12..27) with a shaded back column. */
+function drawTorsoSide(g: Grid, dy: number): void {
+  setPx(g, 16, dy + 20, "o");
+  fillRect(g, 17, dy + 20, 6, 1, "s");
+  setPx(g, 23, dy + 20, "o");
+  setPx(g, 16, dy + 21, "o");
+  fillRect(g, 17, dy + 21, 6, 1, "S");
+  setPx(g, 23, dy + 21, "o");
+  hLine(g, 13, dy + 22, 3, "o");
+  fillRect(g, 16, dy + 22, 8, 1, "w");
+  hLine(g, 24, dy + 22, 3, "o");
+  setPx(g, 12, dy + 23, "O");
+  setPx(g, 13, dy + 23, "t");
+  fillRect(g, 14, dy + 23, 4, 1, "w");
+  fillRect(g, 18, dy + 23, 6, 1, "t");
+  fillRect(g, 24, dy + 23, 3, 1, "T");
+  setPx(g, 27, dy + 23, "O");
+  for (let y = dy + 24; y <= dy + 37; y += 1) {
+    setPx(g, 12, y, "o");
+    fillRect(g, 13, y, 11, 1, "t");
+    fillRect(g, 24, y, 3, 1, "T");
+    setPx(g, 27, y, "o");
+  }
+  for (let y = dy + 38; y <= dy + 39; y += 1) {
+    setPx(g, 12, y, "o");
+    fillRect(g, 13, y, 14, 1, "T");
+    setPx(g, 27, y, "o");
+  }
+  hLine(g, 13, dy + 40, 14, "o");
+  for (let y = dy + 41; y <= dy + 43; y += 1) {
+    setPx(g, 13, y, "o");
+    fillRect(g, 14, y, 12, 1, "p");
+    setPx(g, 26, y, "o");
+  }
+}
+
+/** One hanging front arm: outlined sleeve, cuff row, and a visible hand. */
+function drawArmFrontAt(g: Grid, sleeveX: number, outlineX: number, top: number): void {
+  hLine(g, sleeveX, top + 22, 2, "o");
+  vLine(g, outlineX, top + 23, 13, "o");
+  fillRect(g, sleeveX, top + 23, 2, 8, "t");
+  fillRect(g, sleeveX, top + 31, 2, 1, "T");
+  fillRect(g, sleeveX, top + 32, 2, 4, "s");
+  hLine(g, sleeveX, top + 36, 2, "o");
 }
 
 /** Front arms hang beside the torso; walk poses swing them 2px up/down. */
 function drawArmsFront(g: Grid, pose: WalkPose, dy: number): void {
-  const leftDy = pose === "idle" ? 0 : pose === "a" ? -2 : 2;
-  const rightDy = -leftDy;
-  vLine(g, 4, dy + 12 + leftDy, 4, "T");
-  fillRect(g, 4, dy + 16 + leftDy, 1, 2, "s");
-  vLine(g, 15, dy + 12 + rightDy, 4, "T");
-  fillRect(g, 15, dy + 16 + rightDy, 1, 2, "s");
+  const lift = pose === "idle" ? 0 : pose === "a" ? -2 : 2;
+  drawArmFrontAt(g, 8, 7, dy + lift);
+  drawArmFrontAt(g, 30, 32, dy - lift);
 }
 
-/** Single visible side arm; walk poses swing it 2px forward/back. */
+/** Single visible side arm; walk poses swing it 4px forward/back. */
 function drawArmSide(g: Grid, pose: WalkPose, dy: number): void {
-  const x = pose === "idle" ? 9 : pose === "a" ? 7 : 11;
-  fillRect(g, x, dy + 12, 2, 4, "T");
-  fillRect(g, x, dy + 16, 2, 2, "s");
+  const x = pose === "idle" ? 16 : pose === "a" ? 12 : 20;
+  vLine(g, x - 1, dy + 24, 13, "o");
+  fillRect(g, x, dy + 24, 4, 8, "T");
+  fillRect(g, x, dy + 32, 4, 1, "w");
+  fillRect(g, x + 1, dy + 33, 2, 4, "s");
+  hLine(g, x + 1, dy + 37, 2, "o");
 }
 
-/** Front legs: chunky 3px legs with a hip row; lifted legs raise the shoe 2px. */
+/** One outlined front leg with a crease line and a three-tone shoe. */
+function drawLegFront(g: Grid, x: number, creaseX: number, lift: number): void {
+  const h = 10 - lift;
+  vLine(g, x - 1, 44, h, "o");
+  vLine(g, x + 6, 44, h, "o");
+  fillRect(g, x, 44, 6, h, "p");
+  vLine(g, creaseX, 44, h, "P");
+  const sy = 54 - lift;
+  fillRect(g, x - 1, sy, 8, 3, "b");
+  fillRect(g, x - 1, sy + 3, 8, 2, "c");
+  fillRect(g, x - 1, sy + 5, 8, 1, "B");
+}
+
+/** Front legs: chunky 6px legs; the swing leg lifts its shoe 2px. */
 function drawLegsFront(g: Grid, pose: WalkPose): void {
-  fillRect(g, 6, 22, 8, 1, "p");
-  const drawLeg = (x: number, lifted: boolean) => {
-    if (lifted) {
-      fillRect(g, x, 23, 3, 3, "p");
-      fillRect(g, x, 26, 3, 2, "b");
-    } else {
-      fillRect(g, x, 23, 3, 5, "p");
-      fillRect(g, x, 28, 3, 2, "b");
-    }
-  };
-  drawLeg(6, pose === "a");
-  drawLeg(11, pose === "b");
+  drawLegFront(g, 12, 14, pose === "a" ? 2 : 0);
+  drawLegFront(g, 22, 25, pose === "b" ? 2 : 0);
+}
+
+/** Side shoe with a rounded toe: upper, light midsole, and dark sole line. */
+function drawShoeSide(g: Grid, x: number, y: number, w: number): void {
+  fillRect(g, x, y, w, 3, "b");
+  fillRect(g, x, y + 3, w, 2, "c");
+  fillRect(g, x, y + 5, w, 1, "B");
+  setPx(g, x, y, ".");
 }
 
 /** Side legs: idle stands square; "a" is the stride, "b" the passing frame. */
 function drawLegsSide(g: Grid, pose: WalkPose): void {
-  fillRect(g, 7, 22, 6, 1, "p");
   if (pose === "idle") {
-    fillRect(g, 8, 23, 4, 5, "p");
-    fillRect(g, 7, 28, 5, 2, "b");
+    vLine(g, 15, 44, 10, "o");
+    fillRect(g, 16, 44, 7, 10, "p");
+    vLine(g, 19, 44, 10, "P");
+    vLine(g, 23, 44, 10, "o");
+    drawShoeSide(g, 13, 54, 11);
     return;
   }
   if (pose === "a") {
-    // Front leg strides toward the facing side; back heel lifts.
-    fillRect(g, 6, 23, 2, 5, "p");
-    fillRect(g, 5, 28, 3, 2, "b");
-    fillRect(g, 10, 23, 3, 3, "p");
-    fillRect(g, 11, 26, 3, 2, "b");
+    // Front leg strides forward and stays planted; back leg lifts 2px.
+    vLine(g, 11, 44, 10, "o");
+    fillRect(g, 12, 44, 5, 10, "p");
+    vLine(g, 14, 44, 10, "P");
+    fillRect(g, 21, 44, 5, 8, "p");
+    vLine(g, 23, 44, 8, "P");
+    vLine(g, 26, 44, 8, "o");
+    drawShoeSide(g, 9, 54, 8);
+    drawShoeSide(g, 20, 52, 8);
     return;
   }
-  // Passing frame: legs together, slight 1px bounce.
-  fillRect(g, 8, 23, 4, 4, "p");
-  fillRect(g, 8, 27, 4, 2, "b");
+  // Passing frame: legs together with a 1px bounce off the ground.
+  vLine(g, 15, 44, 9, "o");
+  fillRect(g, 16, 44, 7, 9, "p");
+  vLine(g, 19, 44, 9, "P");
+  vLine(g, 23, 44, 9, "o");
+  drawShoeSide(g, 13, 53, 11);
 }
 
 // ---------------------------------------------------------------------------
@@ -399,24 +595,27 @@ function drawLegsSide(g: Grid, pose: WalkPose): void {
 
 function frontGrid(app: Appearance, pose: WalkPose, showFace: boolean): Grid {
   const g = makeGrid(CHARACTER_WIDTH, CHARACTER_HEIGHT);
-  drawTorsoFront(g, 0);
-  drawArmsFront(g, pose, 0);
+  // Walk frames drop the body 1px for the bob while the legs stay grounded.
+  const dy = pose === "idle" ? 0 : 1;
   drawLegsFront(g, pose);
+  drawTorsoFront(g, dy);
+  drawArmsFront(g, pose, dy);
   if (showFace) {
-    drawHeadFront(g, app, 0);
+    drawHeadFront(g, app, dy);
   } else {
-    drawHeadBack(g, app, 0);
-    drawHairBackOverlay(g, app, 0);
+    drawHeadBack(g, app, dy);
+    drawHairBackOverlay(g, app, dy);
   }
   return g;
 }
 
 function sideGrid(app: Appearance, pose: WalkPose): Grid {
   const g = makeGrid(CHARACTER_WIDTH, CHARACTER_HEIGHT);
-  drawTorsoSide(g, 0);
+  const dy = pose === "idle" ? 0 : 1;
   drawLegsSide(g, pose);
-  drawHeadSide(g, app, 0);
-  drawArmSide(g, pose, 0);
+  drawTorsoSide(g, dy);
+  drawHeadSide(g, app, dy);
+  drawArmSide(g, pose, dy);
   return g;
 }
 
@@ -435,70 +634,106 @@ function shiftRows(g: Grid, y0: number, y1: number, dx: number): void {
 
 function danceGrid(app: Appearance, variant: "a" | "b"): Grid {
   const g = makeGrid(CHARACTER_WIDTH, CHARACTER_HEIGHT);
-  // Head first so the 1px tilt only moves head pixels.
+  // Head first so the 1px tilt only moves head (and hair) pixels.
   drawHeadFront(g, app, 0);
-  shiftRows(g, 0, 11, variant === "a" ? -1 : 1);
+  shiftRows(g, 0, CHARACTER_HEIGHT - 1, variant === "a" ? -1 : 1);
   drawTorsoFront(g, 0);
-  // Legs spread wide.
-  fillRect(g, 6, 22, 8, 1, "p");
-  fillRect(g, 5, 23, 3, 5, "p");
-  fillRect(g, 5, 28, 3, 2, "b");
-  fillRect(g, 12, 23, 3, 5, "p");
-  fillRect(g, 12, 28, 3, 2, "b");
-  // Arms up, alternating heights between the two frames. Each arm gets a
-  // diagonal connector pixel so it doesn't float away from the shoulder.
-  const highArm = (x: number, shoulderX: number) => {
-    vLine(g, x, 8, 5, "T");
-    fillRect(g, x, 6, 1, 2, "s");
-    setPx(g, shoulderX, 13, "T");
+  // Wide stance.
+  drawLegFront(g, 10, 12, 0);
+  drawLegFront(g, 24, 27, 0);
+  // Arms up, alternating heights between the two frames. Each arm gets
+  // diagonal connector pixels so it doesn't float away from the shoulder.
+  const highArm = (x: number, cx: number, cdir: number) => {
+    fillRect(g, x, 10, 3, 4, "s");
+    fillRect(g, x, 14, 3, 1, "w");
+    fillRect(g, x, 15, 3, 8, "T");
+    setPx(g, cx, 23, "T");
+    setPx(g, cx + cdir, 24, "T");
   };
-  const midArm = (x: number, shoulderX: number) => {
-    vLine(g, x, 10, 4, "T");
-    fillRect(g, x, 8, 1, 2, "s");
-    setPx(g, shoulderX, 14, "T");
+  const midArm = (x: number, cx: number, cdir: number) => {
+    fillRect(g, x, 16, 3, 4, "s");
+    fillRect(g, x, 20, 3, 1, "w");
+    fillRect(g, x, 21, 3, 7, "T");
+    setPx(g, cx, 26, "T");
+    setPx(g, cx + cdir, 25, "T");
   };
   if (variant === "a") {
-    highArm(3, 4);
-    midArm(16, 15);
+    highArm(5, 8, 1);
+    midArm(32, 31, -1);
   } else {
-    midArm(3, 4);
-    highArm(16, 15);
+    midArm(5, 8, 1);
+    highArm(32, 31, -1);
   }
   return g;
 }
 
 /**
- * Seated frames: the whole figure is redrawn 6 rows lower (transparent top
- * padding) and the legs collapse into a lap/knee band + shoes, so the sprite
- * reads ~6px shorter when overlapped with a chair.
+ * Seated front frames: the figure is redrawn 12 rows lower (transparent top
+ * padding) with a lap band, knees, feet stubs, and hands resting on the lap,
+ * so the sprite reads ~12px shorter when overlapped with a chair.
  */
 function sitFrontGrid(app: Appearance, showFace: boolean): Grid {
   const g = makeGrid(CHARACTER_WIDTH, CHARACTER_HEIGHT);
-  const dy = 6;
+  const dy = 12;
   drawTorsoFront(g, dy);
-  drawArmsFront(g, "idle", dy);
   if (showFace) {
     drawHeadFront(g, app, dy);
   } else {
     drawHeadBack(g, app, dy);
     drawHairBackOverlay(g, app, dy);
   }
-  // Lap band + knees/shoes peeking below the torso.
-  fillRect(g, 6, 28, 8, 1, "p");
-  fillRect(g, 6, 29, 3, 1, "b");
-  fillRect(g, 11, 29, 3, 1, "b");
+  // Lap band with knee shading at the outer edges.
+  for (let y = 56; y <= 57; y += 1) {
+    setPx(g, 10, y, "o");
+    fillRect(g, 11, y, 18, 1, "p");
+    setPx(g, 29, y, "o");
+  }
+  fillRect(g, 12, 56, 2, 2, "P");
+  fillRect(g, 26, 56, 2, 2, "P");
+  // Feet peeking below the lap.
+  fillRect(g, 12, 58, 5, 1, "b");
+  fillRect(g, 12, 59, 5, 1, "B");
+  fillRect(g, 23, 58, 5, 1, "b");
+  fillRect(g, 23, 59, 5, 1, "B");
+  // Bent arms: sleeve down the side, forearm crossing to hands on the lap.
+  hLine(g, 8, 34, 2, "o");
+  vLine(g, 7, 35, 18, "o");
+  fillRect(g, 8, 35, 2, 14, "t");
+  fillRect(g, 8, 49, 2, 2, "T");
+  fillRect(g, 8, 51, 2, 3, "s");
+  vLine(g, 10, 52, 2, "o");
+  fillRect(g, 10, 54, 6, 2, "s");
+  fillRect(g, 16, 55, 3, 2, "s");
+  hLine(g, 30, 34, 2, "o");
+  vLine(g, 32, 35, 18, "o");
+  fillRect(g, 30, 35, 2, 14, "t");
+  fillRect(g, 30, 49, 2, 2, "T");
+  fillRect(g, 30, 51, 2, 3, "s");
+  vLine(g, 29, 52, 2, "o");
+  fillRect(g, 24, 54, 6, 2, "s");
+  fillRect(g, 21, 55, 3, 2, "s");
   return g;
 }
 
 function sitSideGrid(app: Appearance): Grid {
   const g = makeGrid(CHARACTER_WIDTH, CHARACTER_HEIGHT);
-  const dy = 6;
+  const dy = 12;
   drawTorsoSide(g, dy);
+  // Thigh extends toward the facing side with knee shading, shin drops down.
+  hLine(g, 6, 52, 9, "o");
+  for (let y = 53; y <= 55; y += 1) {
+    setPx(g, 5, y, "o");
+    fillRect(g, 6, y, 8, 1, "p");
+  }
+  fillRect(g, 6, 53, 2, 3, "P");
+  fillRect(g, 6, 56, 3, 2, "p");
+  fillRect(g, 4, 58, 6, 1, "b");
+  fillRect(g, 4, 59, 6, 1, "B");
   drawHeadSide(g, app, dy);
-  drawArmSide(g, "idle", dy);
-  // Thigh extends toward the facing side, foot below the knee.
-  fillRect(g, 4, 28, 8, 1, "p");
-  fillRect(g, 4, 29, 3, 1, "b");
+  // Arm resting down toward the thigh.
+  fillRect(g, 15, dy + 24, 4, 8, "T");
+  fillRect(g, 15, dy + 32, 4, 1, "w");
+  fillRect(g, 16, dy + 33, 2, 7, "s");
   return g;
 }
 

--- a/src/features/pixel-office/art/furniture.ts
+++ b/src/features/pixel-office/art/furniture.ts
@@ -1,44 +1,5 @@
 import { OBJECT_FOOTPRINT, PIXEL_TILE_SIZE, type PixelObjectKind, type PixelSprite } from "../types";
-import {
-  ACCENT_AMBER,
-  ACCENT_BLUE,
-  ACCENT_BLUE_DARK,
-  ACCENT_MAGENTA,
-  ACCENT_PURPLE,
-  ACCENT_RED,
-  ACCENT_RED_DARK,
-  ACCENT_TEAL,
-  ACCENT_TEAL_DARK,
-  ACCENT_YELLOW,
-  DESK_WHITE,
-  DESK_WHITE_SHADE,
-  FLOOR_CREAM,
-  FURN_WOOD,
-  FURN_WOOD_DARK,
-  FURN_WOOD_LIGHT,
-  LEAF_GREEN,
-  LEAF_GREEN_DARK,
-  LEAF_GREEN_LIGHT,
-  LED_GREEN,
-  MONITOR_DARK,
-  NEAR_BLACK,
-  OUTLINE,
-  PAPER_SHADE,
-  PAPER_WHITE,
-  RUG_RED,
-  RUG_RED_DARK,
-  SCREEN_OFF,
-  SCREEN_ON,
-  SOFA_ORANGE,
-  SOFA_ORANGE_DARK,
-  SOFA_ORANGE_LIGHT,
-  SOFT_SHADOW,
-  STEEL,
-  STEEL_DARK,
-  WARM_GLOW,
-  WATER_AQUA,
-  WATER_AQUA_DARK,
-} from "./palette";
+import { LED_GREEN, NEAR_BLACK, PAPER_SHADE, PAPER_WHITE } from "./palette";
 import {
   fillRect,
   gridRows,
@@ -51,46 +12,134 @@ import {
 } from "./grid";
 import { makeSprite } from "./sprite";
 
+// ---------------------------------------------------------------------------
+// Local colors for the soft "Gather" furniture look. New hues live here (not
+// in palette.ts) so the shared palette stays owned by the tile/character art.
+// ---------------------------------------------------------------------------
+
+const OUTLINE_SOFT = "#3a3f4d";
+const GROUND_SHADOW = "#00000026";
+
+const WHITE_TOP = "#f7f5f0";
+const WHITE_EDGE = "#dcd8cf";
+
+const MONITOR_BODY = "#343a4a";
+const SCREEN_DARK = "#262b3a";
+const CODE_BLUE = "#6ec3f0";
+const CODE_PINK = "#f27ebd";
+const BRIGHT_GREEN = "#7ee08c";
+
+const WOOD = "#d9b183";
+const WOOD_DARK = "#c0925c";
+const WOOD_LIGHT = "#ecd2a9";
+const TRUNK_BROWN = "#9a7150";
+
+const CHAIR_SEAT = "#4a4f5e";
+const CHAIR_BACK = "#6a7080";
+const GRAY_BLUE_LIGHT = "#8d93a6";
+
+const SOFA_PEACH = "#f0c39a";
+const SOFA_CUSHION = "#f7d7b7";
+const SOFA_BASE = "#d9a877";
+
+const LEAF_MID = "#68b258";
+const LEAF_DARK = "#4f9a44";
+const LEAF_LIGHT = "#86c977";
+const LEAF_HI = "#a5dc93";
+
+const TERRACOTTA = "#c98a66";
+const TERRACOTTA_DARK = "#a86f4e";
+
+const SOFT_RED = "#e0645a";
+const SOFT_YELLOW = "#f2cf5b";
+const SOFT_AMBER = "#eda75c";
+const SOFT_BLUE = "#6a9fe0";
+const SOFT_BLUE_DARK = "#4d7fc4";
+const SOFT_PINK = "#f09ac0";
+const SOFT_PURPLE = "#a08fd8";
+const BOOTH_TEAL = "#5fb3a8";
+const BOOTH_TEAL_DARK = "#478f86";
+const WATER_BLUE = "#9fd4ec";
+const WATER_BLUE_DARK = "#77b4d6";
+
+const STEEL_LIGHT = "#c3cad4";
+const STEEL_SHADE = "#98a1b0";
+const CASE_GRAY_BLUE = "#7d8597";
+const CASE_GRAY_DARK = "#666e80";
+const SLATE = "#4e576a";
+const SLATE_DARK = "#3d4454";
+
+const SAGE = "#cfd6cd";
+const SAGE_DARK = "#b2bcb0";
+
+const INDIGO = "#6f7fc9";
+const INDIGO_DARK = "#5b69ab";
+
+const CORAL = "#e08a7a";
+const CORAL_DARK = "#c26e5e";
+
+const RUG_CREAM = "#f1e6d4";
+const RUG_TERRA = "#d99a76";
+
+const WARM_GLOW = "#ffe9b0";
+
 /** Shared palette for every furniture sprite. */
 const PAL: Record<string, string> = {
-  o: OUTLINE,
+  o: OUTLINE_SOFT,
   x: NEAR_BLACK,
-  w: FURN_WOOD,
-  W: FURN_WOOD_DARK,
-  k: FURN_WOOD_LIGHT,
-  d: DESK_WHITE,
-  D: DESK_WHITE_SHADE,
-  m: MONITOR_DARK,
-  c: SCREEN_ON,
-  C: SCREEN_OFF,
+  z: GROUND_SHADOW,
+  d: WHITE_TOP,
+  D: WHITE_EDGE,
   n: PAPER_WHITE,
   N: PAPER_SHADE,
-  s: STEEL,
-  S: STEEL_DARK,
-  g: LEAF_GREEN,
-  G: LEAF_GREEN_DARK,
-  l: LEAF_GREEN_LIGHT,
-  r: ACCENT_RED,
-  R: ACCENT_RED_DARK,
-  e: SOFA_ORANGE,
-  E: SOFA_ORANGE_DARK,
-  f: SOFA_ORANGE_LIGHT,
-  y: ACCENT_YELLOW,
+  m: MONITOR_BODY,
+  M: SCREEN_DARK,
+  c: CODE_BLUE,
+  P: CODE_PINK,
+  "1": BRIGHT_GREEN,
+  w: WOOD,
+  W: WOOD_DARK,
+  k: WOOD_LIGHT,
+  h: TRUNK_BROWN,
+  i: CHAIR_SEAT,
+  I: CHAIR_BACK,
+  j: GRAY_BLUE_LIGHT,
+  e: SOFA_PEACH,
+  f: SOFA_CUSHION,
+  E: SOFA_BASE,
+  g: LEAF_MID,
+  G: LEAF_DARK,
+  l: LEAF_LIGHT,
+  H: LEAF_HI,
+  "2": TERRACOTTA,
+  "3": TERRACOTTA_DARK,
+  r: SOFT_RED,
+  y: SOFT_YELLOW,
+  a: SOFT_AMBER,
+  b: SOFT_BLUE,
+  B: SOFT_BLUE_DARK,
+  p: SOFT_PINK,
+  u: SOFT_PURPLE,
+  t: BOOTH_TEAL,
+  T: BOOTH_TEAL_DARK,
+  q: WATER_BLUE,
+  Q: WATER_BLUE_DARK,
+  s: STEEL_LIGHT,
+  S: STEEL_SHADE,
+  C: CASE_GRAY_BLUE,
+  F: CASE_GRAY_DARK,
+  v: SLATE,
+  V: SLATE_DARK,
+  "4": SAGE,
+  "5": SAGE_DARK,
+  "6": INDIGO,
+  "7": INDIGO_DARK,
+  "8": CORAL,
+  "9": CORAL_DARK,
+  "0": RUG_CREAM,
+  R: RUG_TERRA,
   Y: WARM_GLOW,
-  a: ACCENT_AMBER,
-  b: ACCENT_BLUE,
-  B: ACCENT_BLUE_DARK,
-  q: WATER_AQUA,
-  Q: WATER_AQUA_DARK,
-  t: ACCENT_TEAL,
-  T: ACCENT_TEAL_DARK,
-  u: ACCENT_PURPLE,
-  p: ACCENT_MAGENTA,
-  v: RUG_RED,
-  V: RUG_RED_DARK,
-  h: FLOOR_CREAM,
   L: LED_GREEN,
-  z: SOFT_SHADOW,
 };
 
 function sprite(kind: PixelObjectKind, grid: Grid): PixelSprite {
@@ -102,618 +151,992 @@ function gridFor(kind: PixelObjectKind, height: number): Grid {
   return makeGrid(OBJECT_FOOTPRINT[kind][0] * PIXEL_TILE_SIZE, height);
 }
 
-/** Desk slab with outline, white top, shaded lip, and two wood legs. */
-function drawDeskBody(g: Grid, x: number, y: number, w: number, h: number): void {
-  outlineRect(g, x, y, w, h - 3, "o");
-  fillRect(g, x + 1, y + 1, w - 2, h - 6, "d");
-  fillRect(g, x + 1, y + h - 5, w - 2, 2, "D");
-  fillRect(g, x + 2, y + h - 3, 3, 3, "W");
-  fillRect(g, x + w - 5, y + h - 3, 3, 3, "W");
+/** 2-row translucent ground shadow; draw before the body so feet overlap it. */
+function drawShadow(g: Grid, x: number, y: number, w: number): void {
+  hLine(g, x, y, w, "z");
+  hLine(g, x + 2, y + 1, w - 4, "z");
+}
+
+/** Knocks the four corner pixels out of an outlined rect (soft rounding). */
+function trimCorners(g: Grid, x: number, y: number, w: number, h: number): void {
+  setPx(g, x, y, ".");
+  setPx(g, x + w - 1, y, ".");
+  setPx(g, x, y + h - 1, ".");
+  setPx(g, x + w - 1, y + h - 1, ".");
+}
+
+/** Outlined rect with rounded corners; only safe over transparent ground. */
+function roundRect(g: Grid, x: number, y: number, w: number, h: number): void {
+  outlineRect(g, x, y, w, h, "o");
+  trimCorners(g, x, y, w, h);
+}
+
+// ---------------------------------------------------------------------------
+// Foliage (plants + tree) built from hard-threshold circle unions.
+// ---------------------------------------------------------------------------
+
+type FoliageBlob = [cx: number, cy: number, r: number];
+
+type FoliageOpts = {
+  /** x + y below this reads as top-lit (light leaf). */
+  light: number;
+  /** x + y above this reads as shaded (dark leaf). */
+  dark: number;
+  /** Highlight clusters [x, y, w, h], painted only over leaf pixels. */
+  highlights: Array<[number, number, number, number]>;
+};
+
+/** Fluffy outlined canopy: soft outline, lit top-left, shaded bottom-right. */
+function drawFoliage(g: Grid, blobs: FoliageBlob[], opts: FoliageOpts): void {
+  const height = g.length;
+  const width = g[0]?.length ?? 0;
+  const member = (x: number, y: number): boolean => {
+    if (x < 0 || y < 0 || x >= width || y >= height) return false;
+    for (const [cx, cy, r] of blobs) {
+      if ((x - cx) * (x - cx) + (y - cy) * (y - cy) <= r * r) return true;
+    }
+    return false;
+  };
+  // Body + outline pass.
+  for (let y = 0; y < height; y += 1) {
+    for (let x = 0; x < width; x += 1) {
+      if (!member(x, y)) continue;
+      // Skip isolated 1px-wide circle tangents; they read as stray dots.
+      if (!member(x - 1, y) && !member(x + 1, y)) continue;
+      const edge =
+        !member(x - 1, y) || !member(x + 1, y) || !member(x, y - 1) || !member(x, y + 1);
+      if (edge) {
+        setPx(g, x, y, "o");
+      } else if (x + y < opts.light) {
+        setPx(g, x, y, "l");
+      } else if (x + y > opts.dark) {
+        setPx(g, x, y, "G");
+      } else {
+        setPx(g, x, y, "g");
+      }
+    }
+  }
+  // Inner rim just inside the outline: lit up-left, dark down-right.
+  for (let y = 0; y < height; y += 1) {
+    for (let x = 0; x < width; x += 1) {
+      const ch = g[y][x];
+      if (ch !== "g" && ch !== "l" && ch !== "G") continue;
+      const nearOutline =
+        g[y]?.[x - 1] === "o" || g[y]?.[x + 1] === "o" || g[y - 1]?.[x] === "o" || g[y + 1]?.[x] === "o";
+      if (!nearOutline) continue;
+      setPx(g, x, y, x + y > (opts.light + opts.dark) / 2 ? "G" : "l");
+    }
+  }
+  // Highlight clusters, clipped to leaf pixels.
+  for (const [hx, hy, hw, hh] of opts.highlights) {
+    for (let y = hy; y < hy + hh; y += 1) {
+      for (let x = hx; x < hx + hw; x += 1) {
+        const ch = g[y]?.[x];
+        if (ch === "g" || ch === "l") setPx(g, x, y, "H");
+      }
+    }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Desks
+// ---------------------------------------------------------------------------
+
+/** White pod desk slab: rounded top, shaded lip, legs, ground shadow. */
+function drawDeskBody(g: Grid, y: number): void {
+  drawShadow(g, 3, y + 16, 26);
+  // Legs.
+  fillRect(g, 2, y + 15, 3, 3, "D");
+  fillRect(g, 27, y + 15, 3, 3, "D");
+  hLine(g, 2, y + 17, 3, "S");
+  hLine(g, 27, y + 17, 3, "S");
+  // Slab.
+  roundRect(g, 0, y, 32, 15);
+  fillRect(g, 1, y + 1, 30, 10, "d");
+  fillRect(g, 1, y + 11, 30, 3, "D");
 }
 
 function desk(): PixelSprite {
-  const g = gridFor("desk", 16);
-  drawDeskBody(g, 0, 2, 32, 14);
+  const g = gridFor("desk", 18);
+  drawDeskBody(g, 0);
+  // Paper stack.
+  fillRect(g, 5, 3, 7, 5, "n");
+  hLine(g, 5, 7, 7, "N");
+  hLine(g, 6, 4, 4, "N");
+  hLine(g, 6, 6, 3, "N");
+  // Coffee mug with handle.
+  fillRect(g, 23, 4, 3, 3, "r");
+  hLine(g, 23, 4, 3, "9");
+  setPx(g, 26, 5, "9");
   return sprite("desk", g);
 }
 
 function deskMonitor(): PixelSprite {
-  const g = gridFor("desk_monitor", 28);
-  drawDeskBody(g, 0, 14, 32, 14);
-  // Monitor above the desk with a lit screen and a stand.
-  outlineRect(g, 10, 0, 12, 10, "o");
-  fillRect(g, 11, 1, 10, 8, "m");
-  fillRect(g, 12, 2, 8, 6, "c");
-  setPx(g, 13, 3, "n");
-  fillRect(g, 15, 10, 2, 3, "m");
-  hLine(g, 13, 13, 6, "m");
-  // Keyboard on the desk surface.
-  fillRect(g, 12, 17, 8, 3, "m");
-  hLine(g, 13, 18, 6, "C");
+  const g = gridFor("desk_monitor", 30);
+  drawDeskBody(g, 12);
+  // Monitor with a colorful code editor screen.
+  outlineRect(g, 7, 0, 14, 11, "o");
+  fillRect(g, 8, 1, 12, 9, "m");
+  fillRect(g, 9, 2, 10, 7, "M");
+  hLine(g, 10, 3, 2, "P");
+  hLine(g, 13, 3, 3, "c");
+  hLine(g, 10, 5, 2, "c");
+  hLine(g, 13, 5, 2, "1");
+  setPx(g, 16, 5, "n");
+  setPx(g, 10, 7, "n");
+  hLine(g, 12, 7, 2, "P");
+  hLine(g, 15, 7, 2, "1");
+  // Stand.
+  fillRect(g, 13, 11, 2, 2, "m");
+  hLine(g, 11, 13, 6, "m");
+  // Keyboard + mouse on the desk top.
+  fillRect(g, 8, 17, 9, 3, "s");
+  hLine(g, 9, 18, 7, "S");
+  fillRect(g, 19, 18, 2, 2, "s");
+  // Small potted plant on the right.
+  setPx(g, 26, 12, "l");
+  setPx(g, 27, 12, "g");
+  fillRect(g, 25, 13, 4, 2, "g");
+  setPx(g, 25, 13, "l");
+  setPx(g, 28, 14, "G");
+  fillRect(g, 25, 15, 4, 2, "2");
+  hLine(g, 25, 17, 4, "3");
+  // Loose papers on the left.
+  fillRect(g, 3, 16, 4, 3, "n");
+  hLine(g, 4, 17, 2, "N");
   return sprite("desk_monitor", g);
 }
 
+// ---------------------------------------------------------------------------
+// Seating
+// ---------------------------------------------------------------------------
+
 function chair(): PixelSprite {
   const g = gridFor("chair", 16);
-  // Backrest, then seat, seen from above/behind.
-  outlineRect(g, 3, 1, 10, 5, "o");
-  fillRect(g, 4, 2, 8, 3, "x");
-  outlineRect(g, 3, 6, 10, 7, "o");
-  fillRect(g, 4, 7, 8, 5, "C");
-  fillRect(g, 5, 8, 6, 2, "x");
-  // Base feet.
-  setPx(g, 4, 13, "o");
-  setPx(g, 11, 13, "o");
-  hLine(g, 5, 14, 6, "o");
+  drawShadow(g, 3, 14, 10);
+  // Star base + post.
+  hLine(g, 4, 13, 8, "o");
+  setPx(g, 4, 14, "o");
+  setPx(g, 11, 14, "o");
+  fillRect(g, 7, 11, 2, 2, "V");
+  // Seat pan.
+  outlineRect(g, 2, 6, 12, 6, "o");
+  fillRect(g, 3, 7, 10, 4, "i");
+  hLine(g, 3, 10, 10, "V");
+  // Backrest with highlight (seen from behind).
+  outlineRect(g, 3, 0, 10, 7, "o");
+  fillRect(g, 4, 1, 8, 5, "I");
+  hLine(g, 5, 1, 6, "j");
+  setPx(g, 4, 2, "j");
   return sprite("chair", g);
 }
 
-function meetingTable(): PixelSprite {
-  const g = gridFor("meeting_table", 32);
-  outlineRect(g, 1, 3, 46, 26, "o");
-  fillRect(g, 2, 4, 44, 20, "w");
-  hLine(g, 2, 4, 44, "k");
-  fillRect(g, 2, 24, 44, 4, "W");
-  // Rounded corners.
-  for (const [cx, cy] of [
-    [1, 3],
-    [46, 3],
-    [1, 28],
-    [46, 28],
-  ]) {
-    setPx(g, cx, cy, ".");
-  }
-  return sprite("meeting_table", g);
-}
-
 function sofaH(): PixelSprite {
-  const g = gridFor("sofa_h", 20);
+  const g = gridFor("sofa_h", 22);
+  drawShadow(g, 2, 20, 28);
   // Backrest.
-  outlineRect(g, 2, 1, 28, 7, "o");
-  fillRect(g, 3, 2, 26, 5, "e");
-  // Armrests.
-  outlineRect(g, 0, 5, 5, 13, "o");
-  fillRect(g, 1, 6, 3, 11, "e");
-  outlineRect(g, 27, 5, 5, 13, "o");
-  fillRect(g, 28, 6, 3, 11, "e");
-  // Seat cushions facing down.
-  outlineRect(g, 4, 7, 24, 9, "o");
-  fillRect(g, 5, 8, 22, 5, "f");
-  vLine(g, 15, 8, 5, "E");
-  fillRect(g, 5, 13, 22, 2, "E");
+  outlineRect(g, 2, 0, 28, 8, "o");
+  trimCorners(g, 2, 0, 28, 8);
+  fillRect(g, 3, 1, 26, 6, "e");
+  hLine(g, 4, 1, 24, "f");
+  // Front base bar.
+  outlineRect(g, 4, 16, 24, 4, "o");
+  fillRect(g, 5, 17, 22, 2, "E");
+  // Seat cushions with a divot line.
+  outlineRect(g, 5, 7, 22, 10, "o");
+  fillRect(g, 6, 8, 20, 8, "f");
+  vLine(g, 16, 8, 7, "E");
+  hLine(g, 6, 14, 20, "e");
+  hLine(g, 6, 15, 20, "E");
+  // Armrests on top.
+  outlineRect(g, 0, 5, 6, 14, "o");
+  setPx(g, 0, 5, ".");
+  setPx(g, 0, 18, ".");
+  fillRect(g, 1, 6, 4, 12, "e");
+  hLine(g, 1, 6, 4, "f");
+  outlineRect(g, 26, 5, 6, 14, "o");
+  setPx(g, 31, 5, ".");
+  setPx(g, 31, 18, ".");
+  fillRect(g, 27, 6, 4, 12, "e");
+  hLine(g, 27, 6, 4, "f");
   return sprite("sofa_h", g);
 }
 
 function sofaV(): PixelSprite {
-  const g = gridFor("sofa_v", 32);
+  const g = gridFor("sofa_v", 34);
+  drawShadow(g, 2, 32, 12);
   // Backrest along the left edge (sofa faces right).
-  outlineRect(g, 0, 1, 6, 29, "o");
-  fillRect(g, 1, 2, 4, 27, "e");
-  // Armrests top and bottom.
-  outlineRect(g, 4, 0, 11, 5, "o");
-  fillRect(g, 5, 1, 9, 3, "e");
-  outlineRect(g, 4, 26, 11, 5, "o");
-  fillRect(g, 5, 27, 9, 3, "e");
+  outlineRect(g, 0, 2, 7, 28, "o");
+  trimCorners(g, 0, 2, 7, 28);
+  fillRect(g, 1, 3, 5, 26, "e");
+  vLine(g, 1, 3, 26, "f");
   // Seat cushions.
-  outlineRect(g, 5, 4, 10, 23, "o");
-  fillRect(g, 6, 5, 7, 21, "f");
-  hLine(g, 6, 15, 7, "E");
-  vLine(g, 13, 5, 21, "E");
+  outlineRect(g, 6, 5, 10, 22, "o");
+  fillRect(g, 7, 6, 8, 20, "f");
+  hLine(g, 7, 16, 8, "E");
+  vLine(g, 14, 6, 20, "e");
+  // Armrests top and bottom.
+  outlineRect(g, 4, 0, 12, 6, "o");
+  setPx(g, 15, 0, ".");
+  fillRect(g, 5, 1, 10, 4, "e");
+  hLine(g, 5, 1, 10, "f");
+  outlineRect(g, 4, 26, 12, 6, "o");
+  setPx(g, 15, 31, ".");
+  setPx(g, 4, 31, ".");
+  fillRect(g, 5, 27, 10, 4, "e");
   return sprite("sofa_v", g);
 }
 
 function coffeeTable(): PixelSprite {
   const g = gridFor("coffee_table", 16);
-  outlineRect(g, 1, 3, 14, 9, "o");
-  fillRect(g, 2, 4, 12, 5, "w");
-  hLine(g, 2, 4, 12, "k");
-  fillRect(g, 2, 9, 12, 2, "W");
-  fillRect(g, 2, 12, 2, 3, "W");
-  fillRect(g, 12, 12, 2, 3, "W");
+  drawShadow(g, 2, 14, 12);
+  // Legs.
+  fillRect(g, 3, 11, 2, 3, "W");
+  fillRect(g, 11, 11, 2, 3, "W");
+  // Light wood top with a magazine.
+  roundRect(g, 1, 2, 14, 9);
+  fillRect(g, 2, 3, 12, 5, "k");
+  fillRect(g, 2, 8, 12, 2, "w");
+  fillRect(g, 5, 4, 5, 3, "n");
+  hLine(g, 6, 5, 2, "b");
+  setPx(g, 9, 5, "p");
   return sprite("coffee_table", g);
 }
 
-/** Leafy blob with light and dark shading. */
-function drawFoliage(g: Grid, x: number, y: number, w: number, h: number): void {
-  fillRect(g, x + 2, y, w - 4, h, "g");
-  fillRect(g, x, y + 2, w, h - 4, "g");
-  fillRect(g, x + 1, y + 1, w - 2, h - 2, "g");
-  setPx(g, x + 2, y + 1, "l");
-  setPx(g, x + 3, y + 1, "l");
-  setPx(g, x + 1, y + 2, "l");
-  fillRect(g, x + 2, y + h - 2, w - 4, 2, "G");
-  setPx(g, x + w - 2, y + h - 4, "G");
+// ---------------------------------------------------------------------------
+// Tables
+// ---------------------------------------------------------------------------
+
+function meetingTable(): PixelSprite {
+  const g = gridFor("meeting_table", 32);
+  roundRect(g, 1, 2, 46, 30);
+  fillRect(g, 2, 3, 44, 28, "w");
+  hLine(g, 3, 3, 42, "k");
+  // Apron / front edge.
+  fillRect(g, 2, 28, 44, 3, "W");
+  // Subtle placemats.
+  fillRect(g, 8, 6, 8, 4, "k");
+  fillRect(g, 32, 6, 8, 4, "k");
+  fillRect(g, 8, 18, 8, 4, "k");
+  fillRect(g, 32, 18, 8, 4, "k");
+  // Tiny centerpiece plant.
+  fillRect(g, 22, 12, 4, 2, "g");
+  setPx(g, 22, 12, "l");
+  hLine(g, 22, 14, 4, "2");
+  hLine(g, 22, 15, 4, "3");
+  return sprite("meeting_table", g);
 }
 
-/** Terracotta pot with rim and shaded base. */
-function drawPot(g: Grid, x: number, y: number, w: number, h: number): void {
-  outlineRect(g, x, y, w, h, "o");
-  fillRect(g, x + 1, y + 1, w - 2, 1, "r");
-  fillRect(g, x + 1, y + 2, w - 2, h - 4, "r");
-  fillRect(g, x + 1, y + h - 2, w - 2, 1, "R");
-}
+// ---------------------------------------------------------------------------
+// Plants + outdoor
+// ---------------------------------------------------------------------------
 
 function plant(): PixelSprite {
-  const g = gridFor("plant", 20);
-  drawFoliage(g, 3, 1, 10, 11);
-  drawPot(g, 4, 12, 8, 7);
+  const g = gridFor("plant", 22);
+  drawShadow(g, 4, 20, 8);
+  // Terracotta pot.
+  outlineRect(g, 4, 13, 8, 7, "o");
+  fillRect(g, 5, 14, 6, 4, "2");
+  hLine(g, 5, 18, 6, "3");
+  drawFoliage(
+    g,
+    [
+      [7, 6, 5],
+      [5, 9, 4],
+      [10, 9, 4],
+    ],
+    { light: 10, dark: 22, highlights: [[5, 4, 3, 2], [9, 7, 2, 2]] },
+  );
   return sprite("plant", g);
 }
 
 function plantTall(): PixelSprite {
-  const g = gridFor("plant_tall", 28);
-  drawFoliage(g, 3, 0, 10, 12);
-  drawFoliage(g, 4, 12, 8, 6);
-  drawPot(g, 4, 19, 8, 8);
+  const g = gridFor("plant_tall", 30);
+  drawShadow(g, 4, 28, 8);
+  // White pot.
+  outlineRect(g, 4, 20, 8, 8, "o");
+  fillRect(g, 5, 21, 6, 6, "d");
+  hLine(g, 5, 26, 6, "D");
+  drawFoliage(
+    g,
+    [
+      [8, 5, 5],
+      [5, 10, 4],
+      [11, 10, 4],
+      [8, 16, 4],
+    ],
+    { light: 10, dark: 24, highlights: [[6, 3, 3, 2], [4, 9, 2, 2], [10, 12, 2, 2]] },
+  );
   return sprite("plant_tall", g);
 }
 
+function tree(): PixelSprite {
+  const g = gridFor("tree", 40);
+  drawShadow(g, 6, 38, 20);
+  // Trunk (top tucks under the canopy).
+  outlineRect(g, 12, 22, 8, 16, "o");
+  fillRect(g, 14, 23, 5, 14, "h");
+  vLine(g, 13, 23, 14, "W");
+  // Big fluffy canopy: three heavily overlapping lobes.
+  drawFoliage(
+    g,
+    [
+      [15, 12, 11],
+      [9, 10, 8],
+      [22, 10, 8],
+    ],
+    {
+      light: 16,
+      dark: 34,
+      highlights: [
+        [8, 5, 4, 2],
+        [14, 3, 4, 2],
+        [5, 10, 3, 2],
+        [19, 6, 3, 2],
+        [12, 8, 2, 2],
+      ],
+    },
+  );
+  return sprite("tree", g);
+}
+
+/** Small plus-shaped bloom with a contrasting center. */
+function drawBloom(g: Grid, x: number, y: number, petal: string, center: string): void {
+  setPx(g, x, y - 1, petal);
+  setPx(g, x - 1, y, petal);
+  setPx(g, x + 1, y, petal);
+  setPx(g, x, y + 1, petal);
+  setPx(g, x, y, center);
+}
+
+function flower(): PixelSprite {
+  const g = gridFor("flower", 16);
+  hLine(g, 3, 15, 10, "z");
+  // Wooden planter with soil.
+  outlineRect(g, 1, 9, 14, 6, "o");
+  fillRect(g, 2, 10, 12, 3, "w");
+  hLine(g, 2, 10, 12, "3");
+  hLine(g, 2, 13, 12, "W");
+  // Stems, leaves, blooms.
+  vLine(g, 4, 7, 3, "g");
+  vLine(g, 8, 6, 4, "g");
+  vLine(g, 12, 7, 3, "g");
+  setPx(g, 5, 8, "l");
+  setPx(g, 11, 8, "l");
+  drawBloom(g, 4, 5, "p", "y");
+  drawBloom(g, 8, 3, "y", "a");
+  drawBloom(g, 12, 5, "p", "y");
+  return sprite("flower", g);
+}
+
+// ---------------------------------------------------------------------------
+// Storage + library
+// ---------------------------------------------------------------------------
+
 function bookshelf(): PixelSprite {
-  const g = gridFor("bookshelf", 28);
-  outlineRect(g, 0, 0, 32, 27, "o");
-  fillRect(g, 1, 1, 30, 25, "w");
-  // Two shelf openings with colorful book spines.
-  const spineColors = ["r", "b", "y", "g", "u", "t", "e", "p"];
-  for (const [shelfY] of [[3], [13]] as Array<[number]>) {
-    fillRect(g, 2, shelfY, 28, 8, "x");
-    let ci = shelfY === 3 ? 0 : 3;
-    for (let bx = 3; bx <= 26; bx += 3) {
-      fillRect(g, bx, shelfY + 1, 2, 7, spineColors[ci % spineColors.length]);
-      ci += 1;
-    }
-    hLine(g, 2, shelfY + 8, 28, "W");
+  const g = gridFor("bookshelf", 30);
+  drawShadow(g, 2, 28, 28);
+  // Gray-blue case.
+  outlineRect(g, 0, 0, 32, 28, "o");
+  fillRect(g, 1, 1, 30, 26, "C");
+  fillRect(g, 1, 1, 30, 2, "j");
+  // Two shelf openings.
+  fillRect(g, 2, 4, 28, 9, "V");
+  hLine(g, 2, 13, 28, "F");
+  fillRect(g, 2, 15, 28, 9, "V");
+  hLine(g, 2, 24, 28, "F");
+  // Colorful book spines with varied heights.
+  const topColors = ["r", "b", "y", "1", "u", "p", "a", "t", "r"];
+  const topHeights = [6, 8, 5, 7, 6, 8, 5, 7, 6];
+  for (let i = 0; i < 9; i += 1) {
+    fillRect(g, 3 + i * 3, 13 - topHeights[i], 2, topHeights[i], topColors[i]);
   }
-  // Cabinet base.
-  fillRect(g, 2, 23, 28, 3, "W");
-  vLine(g, 15, 23, 3, "o");
+  const lowColors = ["t", "p", "1", "y", "b", "u", "r", "a"];
+  const lowHeights = [7, 5, 8, 6, 7, 5, 6, 8];
+  for (let i = 0; i < 8; i += 1) {
+    fillRect(g, 3 + i * 3, 24 - lowHeights[i], 2, lowHeights[i], lowColors[i]);
+  }
+  // Tiny plant at the end of the lower shelf.
+  fillRect(g, 27, 21, 2, 3, "2");
+  setPx(g, 27, 19, "g");
+  setPx(g, 28, 19, "l");
+  setPx(g, 28, 20, "g");
+  // Plinth.
+  fillRect(g, 1, 25, 30, 2, "F");
   return sprite("bookshelf", g);
 }
 
+// ---------------------------------------------------------------------------
+// Kitchen
+// ---------------------------------------------------------------------------
+
 function kitchenCounter(): PixelSprite {
-  const g = gridFor("kitchen_counter", 24);
-  // Items on top: a jar and a mug.
-  fillRect(g, 5, 1, 3, 5, "b");
-  setPx(g, 5, 1, "B");
-  fillRect(g, 24, 2, 3, 4, "r");
-  setPx(g, 27, 3, "r");
-  // Counter top.
-  outlineRect(g, 0, 6, 32, 5, "o");
-  fillRect(g, 1, 7, 30, 3, "d");
-  hLine(g, 1, 7, 30, "n");
-  // Cabinet body with door seams and handles.
+  const g = gridFor("kitchen_counter", 25);
+  drawShadow(g, 2, 23, 28);
+  // Faucet.
+  vLine(g, 7, 1, 3, "S");
+  setPx(g, 8, 1, "S");
+  // Steel top with sink + cutting board.
+  outlineRect(g, 0, 4, 32, 6, "o");
+  fillRect(g, 1, 5, 30, 4, "s");
+  hLine(g, 1, 8, 30, "S");
+  fillRect(g, 4, 5, 8, 3, "S");
+  fillRect(g, 5, 6, 6, 2, "F");
+  fillRect(g, 20, 5, 7, 3, "w");
+  hLine(g, 21, 6, 5, "k");
+  setPx(g, 25, 5, "r");
+  // Sage cabinets.
   outlineRect(g, 0, 10, 32, 13, "o");
-  fillRect(g, 1, 11, 30, 11, "w");
-  vLine(g, 15, 11, 11, "W");
-  setPx(g, 12, 15, "W");
-  setPx(g, 19, 15, "W");
-  hLine(g, 1, 21, 30, "W");
+  fillRect(g, 1, 11, 30, 11, "4");
+  vLine(g, 15, 11, 11, "5");
+  vLine(g, 13, 14, 3, "S");
+  vLine(g, 18, 14, 3, "S");
+  hLine(g, 1, 21, 30, "5");
   return sprite("kitchen_counter", g);
 }
 
 function fridge(): PixelSprite {
-  const g = gridFor("fridge", 28);
-  outlineRect(g, 2, 0, 12, 27, "o");
-  fillRect(g, 3, 1, 10, 25, "d");
-  vLine(g, 12, 1, 25, "D");
-  hLine(g, 3, 9, 10, "S");
-  // Handles.
-  vLine(g, 11, 3, 3, "S");
-  vLine(g, 11, 12, 5, "S");
+  const g = gridFor("fridge", 30);
+  drawShadow(g, 3, 28, 10);
+  roundRect(g, 2, 0, 12, 28);
+  fillRect(g, 3, 1, 10, 26, "d");
+  vLine(g, 12, 1, 26, "D");
+  hLine(g, 4, 1, 6, "n");
+  // Freezer seam + handles.
+  hLine(g, 3, 9, 10, "D");
+  vLine(g, 4, 3, 4, "S");
+  vLine(g, 4, 11, 7, "S");
   hLine(g, 3, 26, 10, "D");
   return sprite("fridge", g);
 }
 
 function coffeeMachine(): PixelSprite {
-  const g = gridFor("coffee_machine", 24);
-  outlineRect(g, 3, 2, 10, 20, "o");
-  fillRect(g, 4, 3, 8, 18, "m");
-  hLine(g, 4, 3, 8, "S");
-  // Ready light.
-  setPx(g, 10, 6, "r");
-  // Dispenser cavity with a cup.
-  fillRect(g, 5, 9, 6, 7, "C");
-  fillRect(g, 7, 12, 2, 3, "n");
-  // Drip tray.
-  fillRect(g, 4, 19, 8, 2, "S");
+  const g = gridFor("coffee_machine", 26);
+  drawShadow(g, 3, 24, 10);
+  roundRect(g, 2, 2, 12, 22);
+  fillRect(g, 3, 3, 10, 20, "v");
+  hLine(g, 3, 3, 10, "j");
+  // Display + red brew light.
+  fillRect(g, 5, 5, 4, 2, "M");
+  setPx(g, 6, 5, "c");
+  setPx(g, 11, 5, "r");
+  // Brew cavity with mug + pouring coffee.
+  fillRect(g, 4, 9, 8, 8, "V");
+  hLine(g, 7, 9, 2, "S");
+  vLine(g, 7, 10, 3, "h");
+  fillRect(g, 6, 13, 3, 3, "n");
+  setPx(g, 9, 14, "n");
+  // Drip tray + base.
+  fillRect(g, 4, 17, 8, 2, "S");
+  hLine(g, 5, 21, 6, "V");
+  hLine(g, 3, 22, 10, "V");
   return sprite("coffee_machine", g);
 }
 
 function waterCooler(): PixelSprite {
-  const g = gridFor("water_cooler", 24);
+  const g = gridFor("water_cooler", 26);
+  drawShadow(g, 3, 24, 10);
   // Blue bottle.
   outlineRect(g, 4, 0, 8, 8, "o");
-  fillRect(g, 5, 1, 6, 6, "b");
-  setPx(g, 6, 2, "q");
-  setPx(g, 6, 3, "q");
-  // Body.
-  outlineRect(g, 3, 8, 10, 15, "o");
+  trimCorners(g, 4, 0, 8, 8);
+  fillRect(g, 5, 1, 6, 6, "q");
+  vLine(g, 6, 2, 3, "n");
+  hLine(g, 5, 6, 6, "Q");
+  // White body with taps + recess.
+  outlineRect(g, 3, 8, 10, 14, "o");
   fillRect(g, 4, 9, 8, 12, "d");
-  // Taps.
+  fillRect(g, 6, 12, 4, 4, "D");
   setPx(g, 5, 12, "b");
   setPx(g, 10, 12, "r");
   fillRect(g, 4, 19, 8, 2, "D");
+  // Feet.
+  fillRect(g, 5, 22, 2, 2, "S");
+  fillRect(g, 9, 22, 2, 2, "S");
   return sprite("water_cooler", g);
 }
 
 function vendingMachine(): PixelSprite {
-  const g = gridFor("vending_machine", 28);
-  outlineRect(g, 2, 0, 12, 28, "o");
-  fillRect(g, 3, 1, 10, 26, "B");
-  // Glass window with colorful items on two shelves.
-  fillRect(g, 4, 2, 8, 12, "x");
-  for (const [row, colors] of [
-    [4, ["y", "r", "g"]],
-    [9, ["e", "b", "p"]],
-  ] as Array<[number, string[]]>) {
-    colors.forEach((ch, i) => {
-      fillRect(g, 5 + i * 3, row, 2, 2, ch);
-    });
-    hLine(g, 4, row + 2, 8, "S");
-  }
-  // Coin panel and dispenser flap.
-  fillRect(g, 10, 16, 2, 3, "s");
-  fillRect(g, 4, 22, 8, 3, "x");
-  hLine(g, 5, 23, 6, "S");
+  const g = gridFor("vending_machine", 31);
+  drawShadow(g, 3, 29, 10);
+  roundRect(g, 2, 0, 12, 29);
+  fillRect(g, 3, 1, 10, 27, "b");
+  vLine(g, 12, 2, 26, "B");
+  // Glass window with can rows.
+  outlineRect(g, 4, 3, 8, 14, "o");
+  fillRect(g, 5, 4, 6, 12, "M");
+  hLine(g, 5, 7, 6, "F");
+  hLine(g, 5, 11, 6, "F");
+  hLine(g, 5, 15, 6, "F");
+  fillRect(g, 5, 5, 2, 2, "r");
+  fillRect(g, 8, 5, 2, 2, "y");
+  fillRect(g, 5, 9, 2, 2, "1");
+  fillRect(g, 8, 9, 2, 2, "p");
+  fillRect(g, 5, 13, 2, 2, "a");
+  fillRect(g, 8, 13, 2, 2, "c");
+  setPx(g, 10, 4, "n");
+  setPx(g, 9, 5, "n");
+  // Coin panel + dispenser flap.
+  fillRect(g, 9, 18, 3, 4, "v");
+  setPx(g, 10, 19, "x");
+  setPx(g, 10, 21, "L");
+  fillRect(g, 4, 23, 8, 3, "v");
+  hLine(g, 5, 24, 6, "x");
+  hLine(g, 3, 27, 10, "B");
   return sprite("vending_machine", g);
 }
 
+// ---------------------------------------------------------------------------
+// Game room
+// ---------------------------------------------------------------------------
+
 function pingPongTable(): PixelSprite {
   const g = gridFor("ping_pong_table", 32);
-  outlineRect(g, 1, 2, 46, 28, "o");
-  fillRect(g, 2, 3, 44, 26, "g");
-  // White boundary lines and center net line.
-  outlineRect(g, 3, 4, 42, 24, "n");
-  vLine(g, 23, 3, 26, "n");
-  vLine(g, 24, 3, 26, "n");
-  // Paddle and ball for flavor.
-  fillRect(g, 8, 8, 3, 3, "r");
-  setPx(g, 10, 11, "w");
-  setPx(g, 36, 22, "n");
+  drawShadow(g, 3, 30, 42);
+  // Indigo table with a soft edge.
+  roundRect(g, 1, 0, 46, 30);
+  fillRect(g, 2, 1, 44, 28, "6");
+  fillRect(g, 2, 27, 44, 2, "7");
+  // White boundary + centerline.
+  outlineRect(g, 3, 2, 42, 24, "n");
+  hLine(g, 4, 14, 40, "n");
+  // Net across the middle.
+  vLine(g, 23, 1, 28, "n");
+  vLine(g, 24, 1, 28, "S");
+  fillRect(g, 23, 0, 2, 1, "x");
+  fillRect(g, 23, 29, 2, 1, "x");
+  // Paddles + ball.
+  fillRect(g, 9, 6, 3, 3, "r");
+  setPx(g, 11, 8, "9");
+  setPx(g, 12, 9, "w");
+  setPx(g, 13, 10, "w");
+  fillRect(g, 35, 20, 3, 3, "b");
+  setPx(g, 35, 22, "B");
+  setPx(g, 34, 23, "w");
+  setPx(g, 33, 24, "w");
+  setPx(g, 30, 8, "n");
   return sprite("ping_pong_table", g);
 }
 
 function arcade(): PixelSprite {
-  const g = gridFor("arcade", 28);
-  outlineRect(g, 2, 0, 12, 28, "o");
-  fillRect(g, 3, 1, 10, 26, "m");
+  const g = gridFor("arcade", 29);
+  drawShadow(g, 3, 27, 10);
+  roundRect(g, 2, 0, 12, 27);
+  fillRect(g, 3, 1, 10, 25, "u");
   // Marquee.
-  fillRect(g, 4, 1, 8, 2, "p");
-  // Glowing cyan screen.
-  fillRect(g, 4, 4, 8, 6, "c");
-  setPx(g, 5, 5, "n");
-  hLine(g, 4, 10, 8, "C");
-  // Control panel with buttons and stick.
-  fillRect(g, 4, 12, 8, 3, "S");
-  setPx(g, 6, 13, "r");
-  setPx(g, 8, 13, "y");
-  setPx(g, 10, 13, "b");
-  // Front body panel.
-  fillRect(g, 4, 17, 8, 8, "C");
+  fillRect(g, 3, 1, 10, 2, "p");
+  setPx(g, 5, 2, "y");
+  setPx(g, 7, 2, "n");
+  setPx(g, 9, 2, "y");
+  // Bright screen with tiny game pixels.
+  outlineRect(g, 4, 4, 8, 8, "o");
+  fillRect(g, 5, 5, 6, 6, "M");
+  setPx(g, 5, 5, "y");
+  setPx(g, 6, 6, "1");
+  setPx(g, 8, 6, "1");
+  setPx(g, 10, 6, "1");
+  setPx(g, 7, 8, "n");
+  setPx(g, 7, 9, "c");
+  hLine(g, 6, 10, 3, "c");
+  // Control deck: joystick + buttons.
+  fillRect(g, 4, 13, 8, 3, "j");
+  setPx(g, 6, 12, "r");
+  setPx(g, 6, 13, "x");
+  setPx(g, 9, 14, "y");
+  setPx(g, 11, 14, "b");
+  // Front panel decal + vents.
+  fillRect(g, 6, 19, 4, 4, "p");
+  hLine(g, 5, 24, 6, "V");
+  hLine(g, 3, 25, 10, "V");
   return sprite("arcade", g);
 }
 
 function jukebox(): PixelSprite {
-  const g = gridFor("jukebox", 28);
-  outlineRect(g, 2, 1, 12, 27, "o");
-  fillRect(g, 3, 2, 10, 25, "E");
-  // Glowing arch: magenta outer, amber inner.
-  hLine(g, 5, 2, 6, "p");
-  setPx(g, 4, 3, "p");
-  setPx(g, 11, 3, "p");
-  vLine(g, 3, 4, 6, "p");
-  vLine(g, 12, 4, 6, "p");
-  hLine(g, 6, 3, 4, "a");
-  setPx(g, 5, 4, "a");
-  setPx(g, 10, 4, "a");
-  vLine(g, 4, 5, 4, "a");
-  vLine(g, 11, 5, 4, "a");
+  const g = gridFor("jukebox", 30);
+  drawShadow(g, 3, 28, 10);
+  // Rounded dome top.
+  hLine(g, 5, 0, 6, "o");
+  setPx(g, 4, 1, "o");
+  setPx(g, 11, 1, "o");
+  fillRect(g, 5, 1, 6, 1, "p");
+  setPx(g, 3, 2, "o");
+  setPx(g, 12, 2, "o");
+  setPx(g, 4, 2, "p");
+  setPx(g, 11, 2, "p");
+  fillRect(g, 5, 2, 6, 1, "Y");
+  // Body.
+  vLine(g, 2, 3, 25, "o");
+  vLine(g, 13, 3, 25, "o");
+  fillRect(g, 3, 3, 10, 24, "w");
+  hLine(g, 2, 27, 12, "o");
+  // Glow arch.
+  vLine(g, 3, 3, 6, "p");
+  vLine(g, 12, 3, 6, "p");
+  vLine(g, 4, 3, 6, "Y");
+  vLine(g, 11, 3, 6, "Y");
   // Record window.
-  fillRect(g, 6, 5, 4, 4, "x");
-  setPx(g, 7, 6, "n");
+  fillRect(g, 6, 4, 4, 4, "M");
+  fillRect(g, 7, 5, 2, 2, "x");
+  setPx(g, 6, 4, "n");
+  // Song list + colorful buttons.
+  fillRect(g, 4, 10, 8, 3, "n");
+  hLine(g, 5, 11, 6, "N");
+  setPx(g, 5, 13, "r");
+  setPx(g, 7, 13, "y");
+  setPx(g, 9, 13, "1");
+  setPx(g, 11, 13, "b");
   // Speaker grill.
-  fillRect(g, 4, 13, 8, 11, "W");
-  for (const y of [15, 18, 21]) hLine(g, 5, y, 6, "x");
+  fillRect(g, 4, 15, 8, 10, "h");
+  hLine(g, 5, 17, 6, "x");
+  hLine(g, 5, 20, 6, "x");
+  hLine(g, 5, 23, 6, "x");
+  // Base.
+  hLine(g, 3, 25, 10, "W");
+  hLine(g, 3, 26, 10, "W");
   return sprite("jukebox", g);
 }
 
+// ---------------------------------------------------------------------------
+// Boards
+// ---------------------------------------------------------------------------
+
+/** White board face on slate legs with a ground shadow. */
+function drawBoardFrame(g: Grid): void {
+  drawShadow(g, 3, 28, 26);
+  fillRect(g, 6, 21, 2, 7, "v");
+  fillRect(g, 24, 21, 2, 7, "v");
+  hLine(g, 5, 27, 4, "v");
+  hLine(g, 23, 27, 4, "v");
+  outlineRect(g, 1, 0, 30, 22, "o");
+  fillRect(g, 2, 1, 28, 20, "n");
+}
+
 function kanbanBoard(): PixelSprite {
-  const g = gridFor("kanban_board", 28);
-  // Board face.
-  outlineRect(g, 1, 0, 30, 21, "o");
-  fillRect(g, 2, 1, 28, 19, "n");
-  // Three columns.
-  vLine(g, 11, 1, 19, "N");
-  vLine(g, 21, 1, 19, "N");
-  hLine(g, 2, 3, 28, "N");
-  // Tiny sticky notes per column.
+  const g = gridFor("kanban_board", 30);
+  drawBoardFrame(g);
+  // Column dividers + header rule.
+  hLine(g, 2, 4, 28, "N");
+  vLine(g, 11, 1, 20, "N");
+  vLine(g, 21, 1, 20, "N");
+  hLine(g, 4, 2, 5, "S");
+  hLine(g, 13, 2, 6, "S");
+  hLine(g, 23, 2, 6, "S");
+  // Sticky notes.
   const notes: Array<[number, number, string]> = [
-    [4, 5, "y"],
-    [7, 8, "r"],
-    [4, 12, "b"],
-    [13, 5, "g"],
-    [16, 9, "y"],
+    [3, 6, "y"],
+    [7, 7, "p"],
+    [3, 11, "b"],
+    [6, 15, "y"],
+    [13, 6, "1"],
+    [16, 10, "y"],
     [13, 14, "u"],
     [23, 6, "b"],
-    [26, 10, "g"],
-    [23, 15, "r"],
+    [26, 10, "p"],
+    [23, 15, "1"],
   ];
-  for (const [x, y, ch] of notes) fillRect(g, x, y, 2, 2, ch);
-  // Stand legs.
-  fillRect(g, 4, 21, 2, 7, "o");
-  fillRect(g, 26, 21, 2, 7, "o");
+  for (const [x, y, ch] of notes) fillRect(g, x, y, 3, 3, ch);
   return sprite("kanban_board", g);
 }
 
-/** Tall booth body shared by phone and sms booths. */
+function whiteboard(): PixelSprite {
+  const g = gridFor("whiteboard", 30);
+  drawBoardFrame(g);
+  // Marker scribbles.
+  hLine(g, 4, 3, 12, "b");
+  hLine(g, 4, 5, 16, "S");
+  hLine(g, 4, 7, 10, "S");
+  setPx(g, 3, 5, "r");
+  setPx(g, 3, 7, "r");
+  // Bar chart.
+  outlineRect(g, 19, 3, 9, 8, "S");
+  fillRect(g, 20, 8, 1, 2, "t");
+  fillRect(g, 22, 6, 1, 4, "b");
+  fillRect(g, 24, 7, 1, 3, "r");
+  fillRect(g, 26, 5, 1, 5, "1");
+  // Green arrow.
+  hLine(g, 4, 12, 8, "1");
+  setPx(g, 11, 11, "1");
+  setPx(g, 12, 12, "1");
+  setPx(g, 11, 13, "1");
+  // Note line + pink sticky.
+  hLine(g, 4, 16, 11, "m");
+  fillRect(g, 25, 14, 3, 3, "p");
+  // Marker tray with markers.
+  hLine(g, 3, 22, 26, "s");
+  setPx(g, 6, 21, "r");
+  setPx(g, 8, 21, "b");
+  setPx(g, 10, 21, "1");
+  return sprite("whiteboard", g);
+}
+
+// ---------------------------------------------------------------------------
+// Booths
+// ---------------------------------------------------------------------------
+
+/** Tall booth: rounded casing, glass pane, sign icon plate, base + shadow. */
 function drawBooth(g: Grid, body: string, shade: string): void {
-  outlineRect(g, 2, 0, 12, 39, "o");
-  fillRect(g, 3, 1, 10, 37, body);
-  // Roof band.
-  fillRect(g, 3, 1, 10, 2, shade);
-  // Window.
-  outlineRect(g, 4, 4, 8, 11, "o");
-  fillRect(g, 5, 5, 6, 9, "q");
-  setPx(g, 6, 6, "n");
-  // Base.
-  fillRect(g, 3, 35, 10, 3, shade);
+  drawShadow(g, 3, 38, 10);
+  roundRect(g, 2, 0, 12, 38);
+  fillRect(g, 3, 1, 10, 36, body);
+  fillRect(g, 3, 1, 10, 3, shade);
+  // Glass pane with a shine.
+  outlineRect(g, 4, 5, 8, 17, "o");
+  fillRect(g, 5, 6, 6, 15, "q");
+  vLine(g, 6, 7, 5, "n");
+  // Icon plate + base.
+  fillRect(g, 5, 24, 6, 6, shade);
+  fillRect(g, 3, 34, 10, 3, shade);
 }
 
 function phoneBooth(): PixelSprite {
   const g = gridFor("phone_booth", 40);
-  drawBooth(g, "r", "R");
-  // Handset icon on the lower panel.
-  hLine(g, 6, 20, 4, "n");
-  setPx(g, 5, 21, "n");
-  setPx(g, 10, 21, "n");
+  drawBooth(g, "t", "T");
+  // Handset icon on the roof band and the plate.
+  setPx(g, 5, 2, "n");
+  setPx(g, 10, 2, "n");
+  hLine(g, 6, 3, 4, "n");
+  setPx(g, 6, 26, "n");
+  setPx(g, 9, 26, "n");
+  hLine(g, 6, 27, 4, "n");
   return sprite("phone_booth", g);
 }
 
 function smsBooth(): PixelSprite {
   const g = gridFor("sms_booth", 40);
-  drawBooth(g, "t", "T");
-  // Speech bubble icon with a tail.
-  fillRect(g, 5, 18, 6, 5, "n");
-  setPx(g, 6, 23, "n");
-  setPx(g, 6, 20, "T");
-  setPx(g, 8, 20, "T");
+  drawBooth(g, "8", "9");
+  // Speech bubble icons.
+  fillRect(g, 6, 2, 4, 2, "n");
+  setPx(g, 6, 4, "n");
+  fillRect(g, 5, 25, 6, 4, "n");
+  setPx(g, 6, 29, "n");
+  setPx(g, 6, 26, "9");
+  setPx(g, 8, 26, "9");
   return sprite("sms_booth", g);
 }
 
+// ---------------------------------------------------------------------------
+// Gym
+// ---------------------------------------------------------------------------
+
 function treadmill(): PixelSprite {
   const g = gridFor("treadmill", 32);
-  // Console at the top, seen from above.
-  outlineRect(g, 2, 0, 12, 5, "o");
-  fillRect(g, 3, 1, 10, 3, "m");
-  fillRect(g, 5, 2, 6, 1, "c");
+  // Console (top-down).
+  roundRect(g, 2, 0, 12, 6);
+  fillRect(g, 3, 1, 10, 4, "m");
+  fillRect(g, 5, 2, 6, 2, "c");
+  setPx(g, 6, 2, "n");
+  setPx(g, 11, 2, "r");
+  setPx(g, 11, 3, "y");
   // Side rails.
-  vLine(g, 2, 5, 26, "o");
-  vLine(g, 3, 5, 26, "S");
-  vLine(g, 13, 5, 26, "o");
-  vLine(g, 12, 5, 26, "S");
-  // Belt with tread stripes.
-  fillRect(g, 4, 5, 8, 26, "x");
-  for (let y = 7; y < 30; y += 4) hLine(g, 4, y, 8, "C");
+  vLine(g, 1, 5, 26, "o");
+  vLine(g, 2, 5, 26, "s");
+  vLine(g, 14, 5, 26, "o");
+  vLine(g, 13, 5, 26, "s");
+  // Gray-blue belt with tread stripes.
+  fillRect(g, 3, 6, 10, 24, "v");
+  hLine(g, 3, 6, 10, "V");
+  for (let y = 8; y < 30; y += 4) hLine(g, 3, y, 10, "V");
+  hLine(g, 3, 30, 10, "v");
+  hLine(g, 1, 31, 14, "o");
   return sprite("treadmill", g);
 }
 
+/** Dumbbell: two colored plates and a steel bar. */
+function drawDumbbell(g: Grid, x: number, y: number, ch: string): void {
+  fillRect(g, x, y, 2, 4, ch);
+  hLine(g, x + 2, y + 1, 2, "s");
+  hLine(g, x + 2, y + 2, 2, "S");
+  fillRect(g, x + 4, y, 2, 4, ch);
+}
+
 function dumbbellRack(): PixelSprite {
-  const g = gridFor("dumbbell_rack", 20);
-  // Frame posts and two shelf bars.
-  vLine(g, 1, 2, 17, "o");
-  vLine(g, 30, 2, 17, "o");
-  hLine(g, 1, 8, 30, "W");
-  hLine(g, 1, 9, 30, "o");
-  hLine(g, 1, 15, 30, "W");
-  hLine(g, 1, 16, 30, "o");
-  // Dumbbells resting on each shelf.
-  for (const [x, y] of [
-    [4, 5],
-    [13, 5],
-    [22, 5],
-    [8, 12],
-    [18, 12],
-  ] as Array<[number, number]>) {
-    fillRect(g, x, y, 2, 3, "x");
-    hLine(g, x + 2, y + 1, 3, "S");
-    fillRect(g, x + 5, y, 2, 3, "x");
-  }
-  hLine(g, 1, 19, 30, "o");
+  const g = gridFor("dumbbell_rack", 22);
+  drawShadow(g, 2, 20, 28);
+  // Slate posts.
+  vLine(g, 1, 3, 17, "v");
+  vLine(g, 2, 3, 17, "V");
+  vLine(g, 29, 3, 17, "V");
+  vLine(g, 30, 3, 17, "v");
+  // Two shelf bars.
+  hLine(g, 3, 9, 26, "v");
+  hLine(g, 3, 10, 26, "V");
+  hLine(g, 3, 16, 26, "v");
+  hLine(g, 3, 17, 26, "V");
+  // Weights.
+  drawDumbbell(g, 4, 5, "r");
+  drawDumbbell(g, 13, 5, "b");
+  drawDumbbell(g, 22, 5, "y");
+  drawDumbbell(g, 8, 12, "1");
+  drawDumbbell(g, 18, 12, "u");
   return sprite("dumbbell_rack", g);
 }
 
+// ---------------------------------------------------------------------------
+// Tech
+// ---------------------------------------------------------------------------
+
 function serverRack(): PixelSprite {
-  const g = gridFor("server_rack", 28);
+  const g = gridFor("server_rack", 30);
+  drawShadow(g, 3, 28, 10);
   outlineRect(g, 2, 0, 12, 28, "o");
-  fillRect(g, 3, 1, 10, 26, "x");
-  // Rack units with blinking LEDs.
-  for (let unitY = 2; unitY <= 22; unitY += 5) {
-    hLine(g, 3, unitY + 3, 10, "C");
-    setPx(g, 4, unitY + 1, "L");
-    setPx(g, 6, unitY + 1, unitY % 2 === 0 ? "a" : "L");
-    setPx(g, 8, unitY + 1, "L");
-    hLine(g, 10, unitY + 1, 2, "S");
+  fillRect(g, 3, 1, 10, 26, "v");
+  hLine(g, 3, 1, 10, "j");
+  // Rack units with vents and green + amber LEDs.
+  for (let i = 0; i < 4; i += 1) {
+    const y = 3 + i * 6;
+    fillRect(g, 4, y, 8, 4, "V");
+    hLine(g, 5, y + 2, 4, "x");
+    setPx(g, 10, y + 1, "L");
+    setPx(g, 11, y + 1, i % 2 === 0 ? "a" : "L");
   }
+  hLine(g, 3, 26, 10, "V");
   return sprite("server_rack", g);
 }
 
 function tvStand(): PixelSprite {
-  const g = gridFor("tv_stand", 24);
-  // Wide TV.
-  outlineRect(g, 3, 0, 26, 12, "o");
-  fillRect(g, 4, 1, 24, 10, "m");
-  fillRect(g, 5, 2, 22, 8, "c");
-  setPx(g, 6, 3, "n");
-  // TV feet.
-  hLine(g, 6, 12, 3, "m");
-  hLine(g, 23, 12, 3, "m");
-  // Wood cabinet.
-  outlineRect(g, 1, 14, 30, 10, "o");
-  fillRect(g, 2, 15, 28, 7, "w");
-  vLine(g, 15, 15, 7, "W");
+  const g = gridFor("tv_stand", 26);
+  drawShadow(g, 2, 24, 28);
+  // Wood console.
+  roundRect(g, 1, 13, 30, 10);
+  fillRect(g, 2, 14, 28, 8, "w");
+  hLine(g, 2, 14, 28, "k");
+  vLine(g, 11, 15, 6, "W");
+  vLine(g, 21, 15, 6, "W");
+  setPx(g, 9, 17, "W");
+  setPx(g, 23, 17, "W");
   hLine(g, 2, 21, 28, "W");
-  fillRect(g, 2, 22, 28, 1, "W");
+  fillRect(g, 3, 23, 2, 1, "W");
+  fillRect(g, 27, 23, 2, 1, "W");
+  // TV with a colorful sunset scene.
+  outlineRect(g, 4, 0, 24, 12, "o");
+  fillRect(g, 5, 1, 22, 10, "m");
+  fillRect(g, 6, 2, 20, 4, "c");
+  fillRect(g, 21, 3, 3, 2, "y");
+  fillRect(g, 6, 6, 20, 4, "1");
+  fillRect(g, 6, 8, 20, 2, "g");
+  hLine(g, 8, 12, 3, "m");
+  hLine(g, 21, 12, 3, "m");
   return sprite("tv_stand", g);
 }
 
-function whiteboard(): PixelSprite {
-  const g = gridFor("whiteboard", 24);
-  outlineRect(g, 1, 0, 30, 18, "o");
-  fillRect(g, 2, 1, 28, 16, "n");
-  // Scribbles.
-  hLine(g, 4, 4, 10, "b");
-  hLine(g, 4, 7, 14, "b");
-  hLine(g, 4, 10, 8, "r");
-  fillRect(g, 20, 3, 7, 6, "x");
-  fillRect(g, 21, 4, 5, 4, "n");
-  hLine(g, 22, 5, 3, "r");
-  hLine(g, 4, 13, 12, "x");
-  // Marker tray and legs.
-  hLine(g, 3, 18, 26, "S");
-  fillRect(g, 5, 19, 2, 5, "o");
-  fillRect(g, 25, 19, 2, 5, "o");
-  return sprite("whiteboard", g);
+function atm(): PixelSprite {
+  const g = gridFor("atm", 26);
+  drawShadow(g, 3, 24, 10);
+  roundRect(g, 2, 0, 12, 24);
+  fillRect(g, 3, 1, 10, 22, "s");
+  vLine(g, 12, 2, 21, "S");
+  fillRect(g, 3, 1, 10, 2, "t");
+  // Small green screen.
+  outlineRect(g, 4, 4, 8, 6, "o");
+  fillRect(g, 5, 5, 6, 4, "M");
+  hLine(g, 6, 6, 3, "1");
+  hLine(g, 6, 8, 2, "1");
+  // Keypad, card slot, cash tray.
+  for (const y of [12, 14]) {
+    setPx(g, 5, y, "x");
+    setPx(g, 7, y, "x");
+    setPx(g, 9, y, "x");
+  }
+  hLine(g, 5, 17, 6, "x");
+  fillRect(g, 5, 19, 6, 2, "V");
+  hLine(g, 6, 20, 4, "x");
+  hLine(g, 3, 22, 10, "S");
+  return sprite("atm", g);
 }
+
+// ---------------------------------------------------------------------------
+// Decor
+// ---------------------------------------------------------------------------
 
 function rug(): PixelSprite {
   const g = gridFor("rug", 32);
-  // Round-ish rug from hard-threshold circles (no anti-aliasing).
+  // Round cream rug with a terracotta ring (hard threshold, no AA).
   const cx = 15.5;
   const cy = 15.5;
-  const radius = 14.5;
+  const radius = 16;
   for (let y = 0; y < 32; y += 1) {
     for (let x = 0; x < 32; x += 1) {
       const nx = (x - cx) / radius;
       const ny = (y - cy) / radius;
       const rr = nx * nx + ny * ny;
       if (rr > 1) continue;
-      if (rr > 0.82) setPx(g, x, y, "V");
-      else if (rr > 0.45) setPx(g, x, y, "v");
-      else if (rr > 0.32) setPx(g, x, y, "h");
-      else setPx(g, x, y, "v");
+      if (rr > 0.8) setPx(g, x, y, "R");
+      else if (rr > 0.36) setPx(g, x, y, "0");
+      else if (rr > 0.22) setPx(g, x, y, "R");
+      else setPx(g, x, y, "0");
     }
   }
-  setPx(g, 15, 15, "h");
-  setPx(g, 16, 15, "h");
-  setPx(g, 15, 16, "h");
-  setPx(g, 16, 16, "h");
+  // Small center motif.
+  fillRect(g, 15, 15, 2, 2, "R");
   return sprite("rug", g);
 }
 
-function tree(): PixelSprite {
-  const g = gridFor("tree", 40);
-  // Soft ground shadow.
-  fillRect(g, 8, 36, 16, 3, "z");
-  setPx(g, 7, 37, "z");
-  setPx(g, 24, 37, "z");
-  // Trunk.
-  outlineRect(g, 12, 24, 8, 13, "o");
-  fillRect(g, 13, 25, 6, 11, "W");
-  vLine(g, 14, 25, 11, "w");
-  // Leafy crown from hard-threshold circle.
-  const cx = 15.5;
-  const cy = 13;
-  const radius = 13.5;
-  for (let y = 0; y < 27; y += 1) {
-    for (let x = 0; x < 32; x += 1) {
-      const nx = (x - cx) / radius;
-      const ny = (y - cy) / (radius * 0.95);
-      const rr = nx * nx + ny * ny;
-      if (rr > 1) continue;
-      if (rr > 0.8) setPx(g, x, y, "G");
-      else setPx(g, x, y, "g");
-    }
-  }
-  // Highlights top-left, shade bottom-right.
-  fillRect(g, 8, 4, 5, 3, "l");
-  fillRect(g, 6, 8, 3, 2, "l");
-  fillRect(g, 18, 18, 6, 3, "G");
-  return sprite("tree", g);
-}
-
-function flower(): PixelSprite {
-  const g = gridFor("flower", 16);
-  // Three small flowers with stems and leaves.
-  const blooms: Array<[number, number, string]> = [
-    [3, 3, "r"],
-    [10, 2, "y"],
-    [7, 8, "p"],
-  ];
-  for (const [x, y, ch] of blooms) {
-    setPx(g, x, y - 1, ch);
-    setPx(g, x - 1, y, ch);
-    setPx(g, x + 1, y, ch);
-    setPx(g, x, y + 1, ch);
-    setPx(g, x, y, "y");
-    vLine(g, x, y + 2, 3, "g");
-    setPx(g, x + 1, y + 3, "l");
-  }
-  setPx(g, 2, 13, "l");
-  setPx(g, 12, 12, "l");
-  return sprite("flower", g);
-}
-
-function atm(): PixelSprite {
-  const g = gridFor("atm", 24);
-  outlineRect(g, 3, 1, 10, 21, "o");
-  fillRect(g, 4, 2, 8, 19, "s");
-  hLine(g, 4, 2, 8, "S");
-  // Green screen.
-  outlineRect(g, 4, 4, 8, 6, "o");
-  fillRect(g, 5, 5, 6, 4, "L");
-  setPx(g, 6, 6, "n");
-  // Keypad dots.
-  for (const y of [12, 14]) {
-    setPx(g, 5, y, "x");
-    setPx(g, 7, y, "x");
-    setPx(g, 9, y, "x");
-  }
-  // Card slot and cash slot.
-  hLine(g, 5, 17, 6, "x");
-  hLine(g, 5, 19, 6, "S");
-  return sprite("atm", g);
-}
-
 function lamp(): PixelSprite {
-  const g = gridFor("lamp", 28);
-  // Warm glow halo around the shade.
-  fillRect(g, 3, 1, 10, 7, "Y");
-  setPx(g, 3, 1, ".");
-  setPx(g, 12, 1, ".");
-  // Shade.
-  outlineRect(g, 4, 1, 8, 6, "o");
-  fillRect(g, 5, 2, 6, 4, "y");
-  hLine(g, 5, 5, 6, "a");
-  // Pole and base.
-  vLine(g, 7, 7, 17, "o");
-  vLine(g, 8, 7, 17, "x");
-  hLine(g, 4, 24, 8, "x");
-  hLine(g, 3, 25, 10, "o");
+  const g = gridFor("lamp", 30);
+  drawShadow(g, 4, 28, 8);
+  // Warm halo.
+  fillRect(g, 3, 0, 10, 9, "Y");
+  trimCorners(g, 3, 0, 10, 9);
+  // Shade (trapezoid).
+  hLine(g, 6, 1, 4, "o");
+  setPx(g, 5, 2, "o");
+  fillRect(g, 6, 2, 4, 1, "y");
+  setPx(g, 10, 2, "o");
+  setPx(g, 5, 3, "o");
+  fillRect(g, 6, 3, 4, 1, "y");
+  setPx(g, 10, 3, "o");
+  setPx(g, 4, 4, "o");
+  fillRect(g, 5, 4, 6, 1, "y");
+  setPx(g, 11, 4, "o");
+  setPx(g, 4, 5, "o");
+  fillRect(g, 5, 5, 6, 1, "a");
+  setPx(g, 11, 5, "o");
+  hLine(g, 4, 6, 8, "o");
+  // Pole + base.
+  vLine(g, 7, 7, 18, "o");
+  vLine(g, 8, 7, 18, "v");
+  hLine(g, 6, 25, 4, "v");
+  hLine(g, 5, 26, 6, "v");
+  hLine(g, 4, 27, 8, "V");
   return sprite("lamp", g);
 }
 
+/** Small orange fish; dir 1 faces right, -1 faces left. */
+function drawFish(g: Grid, x: number, y: number, dir: 1 | -1): void {
+  fillRect(g, x, y, 3, 2, "a");
+  const tailX = dir === 1 ? x - 1 : x + 3;
+  setPx(g, tailX, y, "8");
+  setPx(g, tailX, y + 1, "8");
+  setPx(g, dir === 1 ? x + 2 : x, y, "x");
+}
+
 function aquarium(): PixelSprite {
-  const g = gridFor("aquarium", 24);
-  // Tank with rim.
-  outlineRect(g, 1, 0, 30, 18, "o");
-  hLine(g, 2, 1, 28, "S");
-  fillRect(g, 2, 2, 28, 15, "q");
-  fillRect(g, 2, 13, 28, 4, "Q");
-  // Orange fish.
-  fillRect(g, 8, 6, 3, 2, "e");
-  setPx(g, 7, 7, "e");
-  setPx(g, 11, 6, "E");
-  fillRect(g, 20, 10, 3, 2, "e");
-  setPx(g, 23, 11, "E");
-  // Bubbles and seaweed.
+  const g = gridFor("aquarium", 26);
+  drawShadow(g, 2, 24, 28);
+  // Tank.
+  outlineRect(g, 1, 0, 30, 17, "o");
+  hLine(g, 2, 1, 28, "s");
+  fillRect(g, 2, 2, 28, 14, "q");
+  fillRect(g, 2, 11, 28, 5, "Q");
+  hLine(g, 2, 15, 28, "S");
+  // Plants.
+  vLine(g, 4, 9, 6, "g");
+  setPx(g, 3, 10, "l");
+  setPx(g, 5, 12, "l");
+  vLine(g, 27, 8, 7, "g");
+  setPx(g, 26, 9, "l");
+  setPx(g, 28, 12, "G");
+  // Fish + bubbles.
+  drawFish(g, 8, 5, 1);
+  drawFish(g, 19, 9, -1);
   setPx(g, 14, 4, "n");
   setPx(g, 15, 7, "n");
-  vLine(g, 5, 12, 5, "g");
-  vLine(g, 26, 11, 6, "g");
-  setPx(g, 25, 13, "l");
-  // Wood stand.
-  outlineRect(g, 1, 18, 30, 6, "o");
-  fillRect(g, 2, 19, 28, 4, "w");
-  hLine(g, 2, 22, 28, "W");
+  setPx(g, 13, 10, "n");
+  setPx(g, 24, 4, "n");
+  // Slate stand.
+  outlineRect(g, 1, 17, 30, 7, "o");
+  fillRect(g, 2, 18, 28, 5, "v");
+  vLine(g, 15, 18, 5, "V");
+  hLine(g, 2, 22, 28, "V");
   return sprite("aquarium", g);
 }
 

--- a/src/features/pixel-office/art/furniture.ts
+++ b/src/features/pixel-office/art/furniture.ts
@@ -1,0 +1,756 @@
+import { OBJECT_FOOTPRINT, PIXEL_TILE_SIZE, type PixelObjectKind, type PixelSprite } from "../types";
+import {
+  ACCENT_AMBER,
+  ACCENT_BLUE,
+  ACCENT_BLUE_DARK,
+  ACCENT_MAGENTA,
+  ACCENT_PURPLE,
+  ACCENT_RED,
+  ACCENT_RED_DARK,
+  ACCENT_TEAL,
+  ACCENT_TEAL_DARK,
+  ACCENT_YELLOW,
+  DESK_WHITE,
+  DESK_WHITE_SHADE,
+  FLOOR_CREAM,
+  FURN_WOOD,
+  FURN_WOOD_DARK,
+  FURN_WOOD_LIGHT,
+  LEAF_GREEN,
+  LEAF_GREEN_DARK,
+  LEAF_GREEN_LIGHT,
+  LED_GREEN,
+  MONITOR_DARK,
+  NEAR_BLACK,
+  OUTLINE,
+  PAPER_SHADE,
+  PAPER_WHITE,
+  RUG_RED,
+  RUG_RED_DARK,
+  SCREEN_OFF,
+  SCREEN_ON,
+  SOFA_ORANGE,
+  SOFA_ORANGE_DARK,
+  SOFA_ORANGE_LIGHT,
+  SOFT_SHADOW,
+  STEEL,
+  STEEL_DARK,
+  WARM_GLOW,
+  WATER_AQUA,
+  WATER_AQUA_DARK,
+} from "./palette";
+import {
+  fillRect,
+  gridRows,
+  hLine,
+  makeGrid,
+  outlineRect,
+  setPx,
+  vLine,
+  type Grid,
+} from "./grid";
+import { makeSprite } from "./sprite";
+
+/** Shared palette for every furniture sprite. */
+const PAL: Record<string, string> = {
+  o: OUTLINE,
+  x: NEAR_BLACK,
+  w: FURN_WOOD,
+  W: FURN_WOOD_DARK,
+  k: FURN_WOOD_LIGHT,
+  d: DESK_WHITE,
+  D: DESK_WHITE_SHADE,
+  m: MONITOR_DARK,
+  c: SCREEN_ON,
+  C: SCREEN_OFF,
+  n: PAPER_WHITE,
+  N: PAPER_SHADE,
+  s: STEEL,
+  S: STEEL_DARK,
+  g: LEAF_GREEN,
+  G: LEAF_GREEN_DARK,
+  l: LEAF_GREEN_LIGHT,
+  r: ACCENT_RED,
+  R: ACCENT_RED_DARK,
+  e: SOFA_ORANGE,
+  E: SOFA_ORANGE_DARK,
+  f: SOFA_ORANGE_LIGHT,
+  y: ACCENT_YELLOW,
+  Y: WARM_GLOW,
+  a: ACCENT_AMBER,
+  b: ACCENT_BLUE,
+  B: ACCENT_BLUE_DARK,
+  q: WATER_AQUA,
+  Q: WATER_AQUA_DARK,
+  t: ACCENT_TEAL,
+  T: ACCENT_TEAL_DARK,
+  u: ACCENT_PURPLE,
+  p: ACCENT_MAGENTA,
+  v: RUG_RED,
+  V: RUG_RED_DARK,
+  h: FLOOR_CREAM,
+  L: LED_GREEN,
+  z: SOFT_SHADOW,
+};
+
+function sprite(kind: PixelObjectKind, grid: Grid): PixelSprite {
+  return makeSprite(`furn_${kind}`, PAL, gridRows(grid));
+}
+
+/** Grid sized to the kind's footprint width and the requested height. */
+function gridFor(kind: PixelObjectKind, height: number): Grid {
+  return makeGrid(OBJECT_FOOTPRINT[kind][0] * PIXEL_TILE_SIZE, height);
+}
+
+/** Desk slab with outline, white top, shaded lip, and two wood legs. */
+function drawDeskBody(g: Grid, x: number, y: number, w: number, h: number): void {
+  outlineRect(g, x, y, w, h - 3, "o");
+  fillRect(g, x + 1, y + 1, w - 2, h - 6, "d");
+  fillRect(g, x + 1, y + h - 5, w - 2, 2, "D");
+  fillRect(g, x + 2, y + h - 3, 3, 3, "W");
+  fillRect(g, x + w - 5, y + h - 3, 3, 3, "W");
+}
+
+function desk(): PixelSprite {
+  const g = gridFor("desk", 16);
+  drawDeskBody(g, 0, 2, 32, 14);
+  return sprite("desk", g);
+}
+
+function deskMonitor(): PixelSprite {
+  const g = gridFor("desk_monitor", 28);
+  drawDeskBody(g, 0, 14, 32, 14);
+  // Monitor above the desk with a lit screen and a stand.
+  outlineRect(g, 10, 0, 12, 10, "o");
+  fillRect(g, 11, 1, 10, 8, "m");
+  fillRect(g, 12, 2, 8, 6, "c");
+  setPx(g, 13, 3, "n");
+  fillRect(g, 15, 10, 2, 3, "m");
+  hLine(g, 13, 13, 6, "m");
+  // Keyboard on the desk surface.
+  fillRect(g, 12, 17, 8, 3, "m");
+  hLine(g, 13, 18, 6, "C");
+  return sprite("desk_monitor", g);
+}
+
+function chair(): PixelSprite {
+  const g = gridFor("chair", 16);
+  // Backrest, then seat, seen from above/behind.
+  outlineRect(g, 3, 1, 10, 5, "o");
+  fillRect(g, 4, 2, 8, 3, "x");
+  outlineRect(g, 3, 6, 10, 7, "o");
+  fillRect(g, 4, 7, 8, 5, "C");
+  fillRect(g, 5, 8, 6, 2, "x");
+  // Base feet.
+  setPx(g, 4, 13, "o");
+  setPx(g, 11, 13, "o");
+  hLine(g, 5, 14, 6, "o");
+  return sprite("chair", g);
+}
+
+function meetingTable(): PixelSprite {
+  const g = gridFor("meeting_table", 32);
+  outlineRect(g, 1, 3, 46, 26, "o");
+  fillRect(g, 2, 4, 44, 20, "w");
+  hLine(g, 2, 4, 44, "k");
+  fillRect(g, 2, 24, 44, 4, "W");
+  // Rounded corners.
+  for (const [cx, cy] of [
+    [1, 3],
+    [46, 3],
+    [1, 28],
+    [46, 28],
+  ]) {
+    setPx(g, cx, cy, ".");
+  }
+  return sprite("meeting_table", g);
+}
+
+function sofaH(): PixelSprite {
+  const g = gridFor("sofa_h", 20);
+  // Backrest.
+  outlineRect(g, 2, 1, 28, 7, "o");
+  fillRect(g, 3, 2, 26, 5, "e");
+  // Armrests.
+  outlineRect(g, 0, 5, 5, 13, "o");
+  fillRect(g, 1, 6, 3, 11, "e");
+  outlineRect(g, 27, 5, 5, 13, "o");
+  fillRect(g, 28, 6, 3, 11, "e");
+  // Seat cushions facing down.
+  outlineRect(g, 4, 7, 24, 9, "o");
+  fillRect(g, 5, 8, 22, 5, "f");
+  vLine(g, 15, 8, 5, "E");
+  fillRect(g, 5, 13, 22, 2, "E");
+  return sprite("sofa_h", g);
+}
+
+function sofaV(): PixelSprite {
+  const g = gridFor("sofa_v", 32);
+  // Backrest along the left edge (sofa faces right).
+  outlineRect(g, 0, 1, 6, 29, "o");
+  fillRect(g, 1, 2, 4, 27, "e");
+  // Armrests top and bottom.
+  outlineRect(g, 4, 0, 11, 5, "o");
+  fillRect(g, 5, 1, 9, 3, "e");
+  outlineRect(g, 4, 26, 11, 5, "o");
+  fillRect(g, 5, 27, 9, 3, "e");
+  // Seat cushions.
+  outlineRect(g, 5, 4, 10, 23, "o");
+  fillRect(g, 6, 5, 7, 21, "f");
+  hLine(g, 6, 15, 7, "E");
+  vLine(g, 13, 5, 21, "E");
+  return sprite("sofa_v", g);
+}
+
+function coffeeTable(): PixelSprite {
+  const g = gridFor("coffee_table", 16);
+  outlineRect(g, 1, 3, 14, 9, "o");
+  fillRect(g, 2, 4, 12, 5, "w");
+  hLine(g, 2, 4, 12, "k");
+  fillRect(g, 2, 9, 12, 2, "W");
+  fillRect(g, 2, 12, 2, 3, "W");
+  fillRect(g, 12, 12, 2, 3, "W");
+  return sprite("coffee_table", g);
+}
+
+/** Leafy blob with light and dark shading. */
+function drawFoliage(g: Grid, x: number, y: number, w: number, h: number): void {
+  fillRect(g, x + 2, y, w - 4, h, "g");
+  fillRect(g, x, y + 2, w, h - 4, "g");
+  fillRect(g, x + 1, y + 1, w - 2, h - 2, "g");
+  setPx(g, x + 2, y + 1, "l");
+  setPx(g, x + 3, y + 1, "l");
+  setPx(g, x + 1, y + 2, "l");
+  fillRect(g, x + 2, y + h - 2, w - 4, 2, "G");
+  setPx(g, x + w - 2, y + h - 4, "G");
+}
+
+/** Terracotta pot with rim and shaded base. */
+function drawPot(g: Grid, x: number, y: number, w: number, h: number): void {
+  outlineRect(g, x, y, w, h, "o");
+  fillRect(g, x + 1, y + 1, w - 2, 1, "r");
+  fillRect(g, x + 1, y + 2, w - 2, h - 4, "r");
+  fillRect(g, x + 1, y + h - 2, w - 2, 1, "R");
+}
+
+function plant(): PixelSprite {
+  const g = gridFor("plant", 20);
+  drawFoliage(g, 3, 1, 10, 11);
+  drawPot(g, 4, 12, 8, 7);
+  return sprite("plant", g);
+}
+
+function plantTall(): PixelSprite {
+  const g = gridFor("plant_tall", 28);
+  drawFoliage(g, 3, 0, 10, 12);
+  drawFoliage(g, 4, 12, 8, 6);
+  drawPot(g, 4, 19, 8, 8);
+  return sprite("plant_tall", g);
+}
+
+function bookshelf(): PixelSprite {
+  const g = gridFor("bookshelf", 28);
+  outlineRect(g, 0, 0, 32, 27, "o");
+  fillRect(g, 1, 1, 30, 25, "w");
+  // Two shelf openings with colorful book spines.
+  const spineColors = ["r", "b", "y", "g", "u", "t", "e", "p"];
+  for (const [shelfY] of [[3], [13]] as Array<[number]>) {
+    fillRect(g, 2, shelfY, 28, 8, "x");
+    let ci = shelfY === 3 ? 0 : 3;
+    for (let bx = 3; bx <= 26; bx += 3) {
+      fillRect(g, bx, shelfY + 1, 2, 7, spineColors[ci % spineColors.length]);
+      ci += 1;
+    }
+    hLine(g, 2, shelfY + 8, 28, "W");
+  }
+  // Cabinet base.
+  fillRect(g, 2, 23, 28, 3, "W");
+  vLine(g, 15, 23, 3, "o");
+  return sprite("bookshelf", g);
+}
+
+function kitchenCounter(): PixelSprite {
+  const g = gridFor("kitchen_counter", 24);
+  // Items on top: a jar and a mug.
+  fillRect(g, 5, 1, 3, 5, "b");
+  setPx(g, 5, 1, "B");
+  fillRect(g, 24, 2, 3, 4, "r");
+  setPx(g, 27, 3, "r");
+  // Counter top.
+  outlineRect(g, 0, 6, 32, 5, "o");
+  fillRect(g, 1, 7, 30, 3, "d");
+  hLine(g, 1, 7, 30, "n");
+  // Cabinet body with door seams and handles.
+  outlineRect(g, 0, 10, 32, 13, "o");
+  fillRect(g, 1, 11, 30, 11, "w");
+  vLine(g, 15, 11, 11, "W");
+  setPx(g, 12, 15, "W");
+  setPx(g, 19, 15, "W");
+  hLine(g, 1, 21, 30, "W");
+  return sprite("kitchen_counter", g);
+}
+
+function fridge(): PixelSprite {
+  const g = gridFor("fridge", 28);
+  outlineRect(g, 2, 0, 12, 27, "o");
+  fillRect(g, 3, 1, 10, 25, "d");
+  vLine(g, 12, 1, 25, "D");
+  hLine(g, 3, 9, 10, "S");
+  // Handles.
+  vLine(g, 11, 3, 3, "S");
+  vLine(g, 11, 12, 5, "S");
+  hLine(g, 3, 26, 10, "D");
+  return sprite("fridge", g);
+}
+
+function coffeeMachine(): PixelSprite {
+  const g = gridFor("coffee_machine", 24);
+  outlineRect(g, 3, 2, 10, 20, "o");
+  fillRect(g, 4, 3, 8, 18, "m");
+  hLine(g, 4, 3, 8, "S");
+  // Ready light.
+  setPx(g, 10, 6, "r");
+  // Dispenser cavity with a cup.
+  fillRect(g, 5, 9, 6, 7, "C");
+  fillRect(g, 7, 12, 2, 3, "n");
+  // Drip tray.
+  fillRect(g, 4, 19, 8, 2, "S");
+  return sprite("coffee_machine", g);
+}
+
+function waterCooler(): PixelSprite {
+  const g = gridFor("water_cooler", 24);
+  // Blue bottle.
+  outlineRect(g, 4, 0, 8, 8, "o");
+  fillRect(g, 5, 1, 6, 6, "b");
+  setPx(g, 6, 2, "q");
+  setPx(g, 6, 3, "q");
+  // Body.
+  outlineRect(g, 3, 8, 10, 15, "o");
+  fillRect(g, 4, 9, 8, 12, "d");
+  // Taps.
+  setPx(g, 5, 12, "b");
+  setPx(g, 10, 12, "r");
+  fillRect(g, 4, 19, 8, 2, "D");
+  return sprite("water_cooler", g);
+}
+
+function vendingMachine(): PixelSprite {
+  const g = gridFor("vending_machine", 28);
+  outlineRect(g, 2, 0, 12, 28, "o");
+  fillRect(g, 3, 1, 10, 26, "B");
+  // Glass window with colorful items on two shelves.
+  fillRect(g, 4, 2, 8, 12, "x");
+  for (const [row, colors] of [
+    [4, ["y", "r", "g"]],
+    [9, ["e", "b", "p"]],
+  ] as Array<[number, string[]]>) {
+    colors.forEach((ch, i) => {
+      fillRect(g, 5 + i * 3, row, 2, 2, ch);
+    });
+    hLine(g, 4, row + 2, 8, "S");
+  }
+  // Coin panel and dispenser flap.
+  fillRect(g, 10, 16, 2, 3, "s");
+  fillRect(g, 4, 22, 8, 3, "x");
+  hLine(g, 5, 23, 6, "S");
+  return sprite("vending_machine", g);
+}
+
+function pingPongTable(): PixelSprite {
+  const g = gridFor("ping_pong_table", 32);
+  outlineRect(g, 1, 2, 46, 28, "o");
+  fillRect(g, 2, 3, 44, 26, "g");
+  // White boundary lines and center net line.
+  outlineRect(g, 3, 4, 42, 24, "n");
+  vLine(g, 23, 3, 26, "n");
+  vLine(g, 24, 3, 26, "n");
+  // Paddle and ball for flavor.
+  fillRect(g, 8, 8, 3, 3, "r");
+  setPx(g, 10, 11, "w");
+  setPx(g, 36, 22, "n");
+  return sprite("ping_pong_table", g);
+}
+
+function arcade(): PixelSprite {
+  const g = gridFor("arcade", 28);
+  outlineRect(g, 2, 0, 12, 28, "o");
+  fillRect(g, 3, 1, 10, 26, "m");
+  // Marquee.
+  fillRect(g, 4, 1, 8, 2, "p");
+  // Glowing cyan screen.
+  fillRect(g, 4, 4, 8, 6, "c");
+  setPx(g, 5, 5, "n");
+  hLine(g, 4, 10, 8, "C");
+  // Control panel with buttons and stick.
+  fillRect(g, 4, 12, 8, 3, "S");
+  setPx(g, 6, 13, "r");
+  setPx(g, 8, 13, "y");
+  setPx(g, 10, 13, "b");
+  // Front body panel.
+  fillRect(g, 4, 17, 8, 8, "C");
+  return sprite("arcade", g);
+}
+
+function jukebox(): PixelSprite {
+  const g = gridFor("jukebox", 28);
+  outlineRect(g, 2, 1, 12, 27, "o");
+  fillRect(g, 3, 2, 10, 25, "E");
+  // Glowing arch: magenta outer, amber inner.
+  hLine(g, 5, 2, 6, "p");
+  setPx(g, 4, 3, "p");
+  setPx(g, 11, 3, "p");
+  vLine(g, 3, 4, 6, "p");
+  vLine(g, 12, 4, 6, "p");
+  hLine(g, 6, 3, 4, "a");
+  setPx(g, 5, 4, "a");
+  setPx(g, 10, 4, "a");
+  vLine(g, 4, 5, 4, "a");
+  vLine(g, 11, 5, 4, "a");
+  // Record window.
+  fillRect(g, 6, 5, 4, 4, "x");
+  setPx(g, 7, 6, "n");
+  // Speaker grill.
+  fillRect(g, 4, 13, 8, 11, "W");
+  for (const y of [15, 18, 21]) hLine(g, 5, y, 6, "x");
+  return sprite("jukebox", g);
+}
+
+function kanbanBoard(): PixelSprite {
+  const g = gridFor("kanban_board", 28);
+  // Board face.
+  outlineRect(g, 1, 0, 30, 21, "o");
+  fillRect(g, 2, 1, 28, 19, "n");
+  // Three columns.
+  vLine(g, 11, 1, 19, "N");
+  vLine(g, 21, 1, 19, "N");
+  hLine(g, 2, 3, 28, "N");
+  // Tiny sticky notes per column.
+  const notes: Array<[number, number, string]> = [
+    [4, 5, "y"],
+    [7, 8, "r"],
+    [4, 12, "b"],
+    [13, 5, "g"],
+    [16, 9, "y"],
+    [13, 14, "u"],
+    [23, 6, "b"],
+    [26, 10, "g"],
+    [23, 15, "r"],
+  ];
+  for (const [x, y, ch] of notes) fillRect(g, x, y, 2, 2, ch);
+  // Stand legs.
+  fillRect(g, 4, 21, 2, 7, "o");
+  fillRect(g, 26, 21, 2, 7, "o");
+  return sprite("kanban_board", g);
+}
+
+/** Tall booth body shared by phone and sms booths. */
+function drawBooth(g: Grid, body: string, shade: string): void {
+  outlineRect(g, 2, 0, 12, 39, "o");
+  fillRect(g, 3, 1, 10, 37, body);
+  // Roof band.
+  fillRect(g, 3, 1, 10, 2, shade);
+  // Window.
+  outlineRect(g, 4, 4, 8, 11, "o");
+  fillRect(g, 5, 5, 6, 9, "q");
+  setPx(g, 6, 6, "n");
+  // Base.
+  fillRect(g, 3, 35, 10, 3, shade);
+}
+
+function phoneBooth(): PixelSprite {
+  const g = gridFor("phone_booth", 40);
+  drawBooth(g, "r", "R");
+  // Handset icon on the lower panel.
+  hLine(g, 6, 20, 4, "n");
+  setPx(g, 5, 21, "n");
+  setPx(g, 10, 21, "n");
+  return sprite("phone_booth", g);
+}
+
+function smsBooth(): PixelSprite {
+  const g = gridFor("sms_booth", 40);
+  drawBooth(g, "t", "T");
+  // Speech bubble icon with a tail.
+  fillRect(g, 5, 18, 6, 5, "n");
+  setPx(g, 6, 23, "n");
+  setPx(g, 6, 20, "T");
+  setPx(g, 8, 20, "T");
+  return sprite("sms_booth", g);
+}
+
+function treadmill(): PixelSprite {
+  const g = gridFor("treadmill", 32);
+  // Console at the top, seen from above.
+  outlineRect(g, 2, 0, 12, 5, "o");
+  fillRect(g, 3, 1, 10, 3, "m");
+  fillRect(g, 5, 2, 6, 1, "c");
+  // Side rails.
+  vLine(g, 2, 5, 26, "o");
+  vLine(g, 3, 5, 26, "S");
+  vLine(g, 13, 5, 26, "o");
+  vLine(g, 12, 5, 26, "S");
+  // Belt with tread stripes.
+  fillRect(g, 4, 5, 8, 26, "x");
+  for (let y = 7; y < 30; y += 4) hLine(g, 4, y, 8, "C");
+  return sprite("treadmill", g);
+}
+
+function dumbbellRack(): PixelSprite {
+  const g = gridFor("dumbbell_rack", 20);
+  // Frame posts and two shelf bars.
+  vLine(g, 1, 2, 17, "o");
+  vLine(g, 30, 2, 17, "o");
+  hLine(g, 1, 8, 30, "W");
+  hLine(g, 1, 9, 30, "o");
+  hLine(g, 1, 15, 30, "W");
+  hLine(g, 1, 16, 30, "o");
+  // Dumbbells resting on each shelf.
+  for (const [x, y] of [
+    [4, 5],
+    [13, 5],
+    [22, 5],
+    [8, 12],
+    [18, 12],
+  ] as Array<[number, number]>) {
+    fillRect(g, x, y, 2, 3, "x");
+    hLine(g, x + 2, y + 1, 3, "S");
+    fillRect(g, x + 5, y, 2, 3, "x");
+  }
+  hLine(g, 1, 19, 30, "o");
+  return sprite("dumbbell_rack", g);
+}
+
+function serverRack(): PixelSprite {
+  const g = gridFor("server_rack", 28);
+  outlineRect(g, 2, 0, 12, 28, "o");
+  fillRect(g, 3, 1, 10, 26, "x");
+  // Rack units with blinking LEDs.
+  for (let unitY = 2; unitY <= 22; unitY += 5) {
+    hLine(g, 3, unitY + 3, 10, "C");
+    setPx(g, 4, unitY + 1, "L");
+    setPx(g, 6, unitY + 1, unitY % 2 === 0 ? "a" : "L");
+    setPx(g, 8, unitY + 1, "L");
+    hLine(g, 10, unitY + 1, 2, "S");
+  }
+  return sprite("server_rack", g);
+}
+
+function tvStand(): PixelSprite {
+  const g = gridFor("tv_stand", 24);
+  // Wide TV.
+  outlineRect(g, 3, 0, 26, 12, "o");
+  fillRect(g, 4, 1, 24, 10, "m");
+  fillRect(g, 5, 2, 22, 8, "c");
+  setPx(g, 6, 3, "n");
+  // TV feet.
+  hLine(g, 6, 12, 3, "m");
+  hLine(g, 23, 12, 3, "m");
+  // Wood cabinet.
+  outlineRect(g, 1, 14, 30, 10, "o");
+  fillRect(g, 2, 15, 28, 7, "w");
+  vLine(g, 15, 15, 7, "W");
+  hLine(g, 2, 21, 28, "W");
+  fillRect(g, 2, 22, 28, 1, "W");
+  return sprite("tv_stand", g);
+}
+
+function whiteboard(): PixelSprite {
+  const g = gridFor("whiteboard", 24);
+  outlineRect(g, 1, 0, 30, 18, "o");
+  fillRect(g, 2, 1, 28, 16, "n");
+  // Scribbles.
+  hLine(g, 4, 4, 10, "b");
+  hLine(g, 4, 7, 14, "b");
+  hLine(g, 4, 10, 8, "r");
+  fillRect(g, 20, 3, 7, 6, "x");
+  fillRect(g, 21, 4, 5, 4, "n");
+  hLine(g, 22, 5, 3, "r");
+  hLine(g, 4, 13, 12, "x");
+  // Marker tray and legs.
+  hLine(g, 3, 18, 26, "S");
+  fillRect(g, 5, 19, 2, 5, "o");
+  fillRect(g, 25, 19, 2, 5, "o");
+  return sprite("whiteboard", g);
+}
+
+function rug(): PixelSprite {
+  const g = gridFor("rug", 32);
+  // Round-ish rug from hard-threshold circles (no anti-aliasing).
+  const cx = 15.5;
+  const cy = 15.5;
+  const radius = 14.5;
+  for (let y = 0; y < 32; y += 1) {
+    for (let x = 0; x < 32; x += 1) {
+      const nx = (x - cx) / radius;
+      const ny = (y - cy) / radius;
+      const rr = nx * nx + ny * ny;
+      if (rr > 1) continue;
+      if (rr > 0.82) setPx(g, x, y, "V");
+      else if (rr > 0.45) setPx(g, x, y, "v");
+      else if (rr > 0.32) setPx(g, x, y, "h");
+      else setPx(g, x, y, "v");
+    }
+  }
+  setPx(g, 15, 15, "h");
+  setPx(g, 16, 15, "h");
+  setPx(g, 15, 16, "h");
+  setPx(g, 16, 16, "h");
+  return sprite("rug", g);
+}
+
+function tree(): PixelSprite {
+  const g = gridFor("tree", 40);
+  // Soft ground shadow.
+  fillRect(g, 8, 36, 16, 3, "z");
+  setPx(g, 7, 37, "z");
+  setPx(g, 24, 37, "z");
+  // Trunk.
+  outlineRect(g, 12, 24, 8, 13, "o");
+  fillRect(g, 13, 25, 6, 11, "W");
+  vLine(g, 14, 25, 11, "w");
+  // Leafy crown from hard-threshold circle.
+  const cx = 15.5;
+  const cy = 13;
+  const radius = 13.5;
+  for (let y = 0; y < 27; y += 1) {
+    for (let x = 0; x < 32; x += 1) {
+      const nx = (x - cx) / radius;
+      const ny = (y - cy) / (radius * 0.95);
+      const rr = nx * nx + ny * ny;
+      if (rr > 1) continue;
+      if (rr > 0.8) setPx(g, x, y, "G");
+      else setPx(g, x, y, "g");
+    }
+  }
+  // Highlights top-left, shade bottom-right.
+  fillRect(g, 8, 4, 5, 3, "l");
+  fillRect(g, 6, 8, 3, 2, "l");
+  fillRect(g, 18, 18, 6, 3, "G");
+  return sprite("tree", g);
+}
+
+function flower(): PixelSprite {
+  const g = gridFor("flower", 16);
+  // Three small flowers with stems and leaves.
+  const blooms: Array<[number, number, string]> = [
+    [3, 3, "r"],
+    [10, 2, "y"],
+    [7, 8, "p"],
+  ];
+  for (const [x, y, ch] of blooms) {
+    setPx(g, x, y - 1, ch);
+    setPx(g, x - 1, y, ch);
+    setPx(g, x + 1, y, ch);
+    setPx(g, x, y + 1, ch);
+    setPx(g, x, y, "y");
+    vLine(g, x, y + 2, 3, "g");
+    setPx(g, x + 1, y + 3, "l");
+  }
+  setPx(g, 2, 13, "l");
+  setPx(g, 12, 12, "l");
+  return sprite("flower", g);
+}
+
+function atm(): PixelSprite {
+  const g = gridFor("atm", 24);
+  outlineRect(g, 3, 1, 10, 21, "o");
+  fillRect(g, 4, 2, 8, 19, "s");
+  hLine(g, 4, 2, 8, "S");
+  // Green screen.
+  outlineRect(g, 4, 4, 8, 6, "o");
+  fillRect(g, 5, 5, 6, 4, "L");
+  setPx(g, 6, 6, "n");
+  // Keypad dots.
+  for (const y of [12, 14]) {
+    setPx(g, 5, y, "x");
+    setPx(g, 7, y, "x");
+    setPx(g, 9, y, "x");
+  }
+  // Card slot and cash slot.
+  hLine(g, 5, 17, 6, "x");
+  hLine(g, 5, 19, 6, "S");
+  return sprite("atm", g);
+}
+
+function lamp(): PixelSprite {
+  const g = gridFor("lamp", 28);
+  // Warm glow halo around the shade.
+  fillRect(g, 3, 1, 10, 7, "Y");
+  setPx(g, 3, 1, ".");
+  setPx(g, 12, 1, ".");
+  // Shade.
+  outlineRect(g, 4, 1, 8, 6, "o");
+  fillRect(g, 5, 2, 6, 4, "y");
+  hLine(g, 5, 5, 6, "a");
+  // Pole and base.
+  vLine(g, 7, 7, 17, "o");
+  vLine(g, 8, 7, 17, "x");
+  hLine(g, 4, 24, 8, "x");
+  hLine(g, 3, 25, 10, "o");
+  return sprite("lamp", g);
+}
+
+function aquarium(): PixelSprite {
+  const g = gridFor("aquarium", 24);
+  // Tank with rim.
+  outlineRect(g, 1, 0, 30, 18, "o");
+  hLine(g, 2, 1, 28, "S");
+  fillRect(g, 2, 2, 28, 15, "q");
+  fillRect(g, 2, 13, 28, 4, "Q");
+  // Orange fish.
+  fillRect(g, 8, 6, 3, 2, "e");
+  setPx(g, 7, 7, "e");
+  setPx(g, 11, 6, "E");
+  fillRect(g, 20, 10, 3, 2, "e");
+  setPx(g, 23, 11, "E");
+  // Bubbles and seaweed.
+  setPx(g, 14, 4, "n");
+  setPx(g, 15, 7, "n");
+  vLine(g, 5, 12, 5, "g");
+  vLine(g, 26, 11, 6, "g");
+  setPx(g, 25, 13, "l");
+  // Wood stand.
+  outlineRect(g, 1, 18, 30, 6, "o");
+  fillRect(g, 2, 19, 28, 4, "w");
+  hLine(g, 2, 22, 28, "W");
+  return sprite("aquarium", g);
+}
+
+/** Builds one sprite per PixelObjectKind, keyed `furn_<kind>`. */
+export function buildFurnitureSprites(): PixelSprite[] {
+  return [
+    desk(),
+    deskMonitor(),
+    chair(),
+    meetingTable(),
+    sofaH(),
+    sofaV(),
+    coffeeTable(),
+    plant(),
+    plantTall(),
+    bookshelf(),
+    kitchenCounter(),
+    fridge(),
+    coffeeMachine(),
+    waterCooler(),
+    vendingMachine(),
+    pingPongTable(),
+    arcade(),
+    jukebox(),
+    kanbanBoard(),
+    phoneBooth(),
+    smsBooth(),
+    treadmill(),
+    dumbbellRack(),
+    serverRack(),
+    tvStand(),
+    whiteboard(),
+    rug(),
+    tree(),
+    flower(),
+    atm(),
+    lamp(),
+    aquarium(),
+  ];
+}

--- a/src/features/pixel-office/art/furniture.ts
+++ b/src/features/pixel-office/art/furniture.ts
@@ -57,10 +57,12 @@ const SOFT_BLUE = "#6a9fe0";
 const SOFT_BLUE_DARK = "#4d7fc4";
 const SOFT_PINK = "#f09ac0";
 const SOFT_PURPLE = "#a08fd8";
+const PURPLE_DARK = "#8474c2";
 const BOOTH_TEAL = "#5fb3a8";
 const BOOTH_TEAL_DARK = "#478f86";
 const WATER_BLUE = "#9fd4ec";
 const WATER_BLUE_DARK = "#77b4d6";
+const PALE_GLASS = "#d8eef8";
 
 const STEEL_LIGHT = "#c3cad4";
 const STEEL_SHADE = "#98a1b0";
@@ -74,6 +76,7 @@ const SAGE_DARK = "#b2bcb0";
 
 const INDIGO = "#6f7fc9";
 const INDIGO_DARK = "#5b69ab";
+const INDIGO_LIGHT = "#8b98d9";
 
 const CORAL = "#e08a7a";
 const CORAL_DARK = "#c26e5e";
@@ -82,6 +85,8 @@ const RUG_CREAM = "#f1e6d4";
 const RUG_TERRA = "#d99a76";
 
 const WARM_GLOW = "#ffe9b0";
+const GLOW_HALO = "#ffe9b04d";
+const STEAM_WHITE = "#ffffff59";
 
 /** Shared palette for every furniture sprite. */
 const PAL: Record<string, string> = {
@@ -120,10 +125,12 @@ const PAL: Record<string, string> = {
   B: SOFT_BLUE_DARK,
   p: SOFT_PINK,
   u: SOFT_PURPLE,
+  X: PURPLE_DARK,
   t: BOOTH_TEAL,
   T: BOOTH_TEAL_DARK,
   q: WATER_BLUE,
   Q: WATER_BLUE_DARK,
+  A: PALE_GLASS,
   s: STEEL_LIGHT,
   S: STEEL_SHADE,
   C: CASE_GRAY_BLUE,
@@ -134,11 +141,14 @@ const PAL: Record<string, string> = {
   "5": SAGE_DARK,
   "6": INDIGO,
   "7": INDIGO_DARK,
+  J: INDIGO_LIGHT,
   "8": CORAL,
   "9": CORAL_DARK,
   "0": RUG_CREAM,
   R: RUG_TERRA,
   Y: WARM_GLOW,
+  K: GLOW_HALO,
+  "*": STEAM_WHITE,
   L: LED_GREEN,
 };
 
@@ -151,13 +161,14 @@ function gridFor(kind: PixelObjectKind, height: number): Grid {
   return makeGrid(OBJECT_FOOTPRINT[kind][0] * PIXEL_TILE_SIZE, height);
 }
 
-/** 2-row translucent ground shadow; draw before the body so feet overlap it. */
+/** 3-row translucent ground shadow; draw before the body so feet overlap it. */
 function drawShadow(g: Grid, x: number, y: number, w: number): void {
-  hLine(g, x, y, w, "z");
-  hLine(g, x + 2, y + 1, w - 4, "z");
+  hLine(g, x + 2, y, w - 4, "z");
+  hLine(g, x, y + 1, w, "z");
+  hLine(g, x + 4, y + 2, w - 8, "z");
 }
 
-/** Knocks the four corner pixels out of an outlined rect (soft rounding). */
+/** Knocks the four corner pixels out of a rect (radius-1 soft rounding). */
 function trimCorners(g: Grid, x: number, y: number, w: number, h: number): void {
   setPx(g, x, y, ".");
   setPx(g, x + w - 1, y, ".");
@@ -165,10 +176,22 @@ function trimCorners(g: Grid, x: number, y: number, w: number, h: number): void 
   setPx(g, x + w - 1, y + h - 1, ".");
 }
 
-/** Outlined rect with rounded corners; only safe over transparent ground. */
+/** Outlined rect with radius-2 rounded corners; only safe over transparent ground. */
 function roundRect(g: Grid, x: number, y: number, w: number, h: number): void {
-  outlineRect(g, x, y, w, h, "o");
-  trimCorners(g, x, y, w, h);
+  hLine(g, x + 2, y, w - 4, "o");
+  hLine(g, x + 2, y + h - 1, w - 4, "o");
+  vLine(g, x, y + 2, h - 4, "o");
+  vLine(g, x + w - 1, y + 2, h - 4, "o");
+  setPx(g, x + 1, y + 1, "o");
+  setPx(g, x + w - 2, y + 1, "o");
+  setPx(g, x + 1, y + h - 2, "o");
+  setPx(g, x + w - 2, y + h - 2, "o");
+}
+
+/** Fills the interior of a radius-2 roundRect with one color. */
+function fillRound(g: Grid, x: number, y: number, w: number, h: number, ch: string): void {
+  fillRect(g, x + 1, y + 2, w - 2, h - 4, ch);
+  fillRect(g, x + 2, y + 1, w - 4, h - 2, ch);
 }
 
 // ---------------------------------------------------------------------------
@@ -242,68 +265,124 @@ function drawFoliage(g: Grid, blobs: FoliageBlob[], opts: FoliageOpts): void {
 // Desks
 // ---------------------------------------------------------------------------
 
-/** White pod desk slab: rounded top, shaded lip, legs, ground shadow. */
+/** White pod desk slab: rounded top with sheen, shaded lip, legs, shadow. */
 function drawDeskBody(g: Grid, y: number): void {
-  drawShadow(g, 3, y + 16, 26);
-  // Legs.
-  fillRect(g, 2, y + 15, 3, 3, "D");
-  fillRect(g, 27, y + 15, 3, 3, "D");
-  hLine(g, 2, y + 17, 3, "S");
-  hLine(g, 27, y + 17, 3, "S");
-  // Slab.
-  roundRect(g, 0, y, 32, 15);
-  fillRect(g, 1, y + 1, 30, 10, "d");
-  fillRect(g, 1, y + 11, 30, 3, "D");
+  drawShadow(g, 3, y + 33, 58);
+  // Legs with an inner shade column.
+  fillRect(g, 5, y + 26, 6, 8, "D");
+  vLine(g, 10, y + 26, 8, "S");
+  hLine(g, 5, y + 33, 6, "S");
+  fillRect(g, 53, y + 26, 6, 8, "D");
+  vLine(g, 58, y + 26, 8, "S");
+  hLine(g, 53, y + 33, 6, "S");
+  // Slab with rounded corners.
+  roundRect(g, 0, y, 64, 28);
+  fillRound(g, 0, y, 64, 28, "d");
+  // Top sheen.
+  hLine(g, 3, y + 1, 58, "n");
+  hLine(g, 2, y + 2, 8, "n");
+  // Front lip with a base line.
+  fillRect(g, 1, y + 20, 62, 6, "D");
+  hLine(g, 1, y + 26, 62, "S");
 }
 
 function desk(): PixelSprite {
-  const g = gridFor("desk", 18);
+  const g = gridFor("desk", 36);
   drawDeskBody(g, 0);
-  // Paper stack.
-  fillRect(g, 5, 3, 7, 5, "n");
-  hLine(g, 5, 7, 7, "N");
-  hLine(g, 6, 4, 4, "N");
-  hLine(g, 6, 6, 3, "N");
-  // Coffee mug with handle.
-  fillRect(g, 23, 4, 3, 3, "r");
-  hLine(g, 23, 4, 3, "9");
-  setPx(g, 26, 5, "9");
+  // Two loosely stacked paper sheets.
+  fillRect(g, 10, 4, 11, 8, "n");
+  vLine(g, 20, 5, 6, "N");
+  fillRect(g, 6, 7, 12, 9, "n");
+  hLine(g, 8, 9, 8, "N");
+  hLine(g, 8, 11, 6, "N");
+  hLine(g, 8, 13, 8, "N");
+  // Blue notebook with a spine and label band.
+  fillRect(g, 27, 9, 11, 8, "b");
+  vLine(g, 27, 9, 8, "B");
+  hLine(g, 29, 11, 7, "n");
+  // Pen.
+  hLine(g, 30, 18, 4, "x");
+  // Coffee mug with rim, coffee, handle, and a steam hint.
+  fillRect(g, 44, 7, 8, 8, "r");
+  hLine(g, 44, 7, 8, "9");
+  hLine(g, 46, 8, 4, "h");
+  hLine(g, 45, 13, 6, "9");
+  outlineRect(g, 52, 9, 3, 4, "9");
+  setPx(g, 47, 2, "*");
+  setPx(g, 46, 4, "*");
+  setPx(g, 49, 3, "*");
+  setPx(g, 48, 5, "*");
   return sprite("desk", g);
 }
 
 function deskMonitor(): PixelSprite {
-  const g = gridFor("desk_monitor", 30);
-  drawDeskBody(g, 12);
-  // Monitor with a colorful code editor screen.
-  outlineRect(g, 7, 0, 14, 11, "o");
-  fillRect(g, 8, 1, 12, 9, "m");
-  fillRect(g, 9, 2, 10, 7, "M");
-  hLine(g, 10, 3, 2, "P");
-  hLine(g, 13, 3, 3, "c");
-  hLine(g, 10, 5, 2, "c");
-  hLine(g, 13, 5, 2, "1");
-  setPx(g, 16, 5, "n");
-  setPx(g, 10, 7, "n");
-  hLine(g, 12, 7, 2, "P");
-  hLine(g, 15, 7, 2, "1");
-  // Stand.
-  fillRect(g, 13, 11, 2, 2, "m");
-  hLine(g, 11, 13, 6, "m");
-  // Keyboard + mouse on the desk top.
-  fillRect(g, 8, 17, 9, 3, "s");
-  hLine(g, 9, 18, 7, "S");
-  fillRect(g, 19, 18, 2, 2, "s");
+  const g = gridFor("desk_monitor", 60);
+  drawDeskBody(g, 24);
+  // Monitor panel with a rounded bezel.
+  roundRect(g, 14, 0, 36, 21);
+  fillRound(g, 14, 0, 36, 21, "m");
+  fillRect(g, 17, 3, 30, 15, "M");
+  // Window chrome bar with traffic-light dots and a title dash.
+  fillRect(g, 17, 3, 30, 3, "v");
+  setPx(g, 19, 4, "r");
+  setPx(g, 21, 4, "y");
+  setPx(g, 23, 4, "1");
+  hLine(g, 28, 4, 10, "S");
+  // Six colored code lines with varied indents.
+  hLine(g, 19, 7, 4, "P");
+  hLine(g, 24, 7, 9, "c");
+  hLine(g, 21, 9, 5, "c");
+  hLine(g, 27, 9, 6, "1");
+  hLine(g, 19, 11, 3, "y");
+  hLine(g, 23, 11, 6, "P");
+  hLine(g, 30, 11, 4, "n");
+  hLine(g, 21, 13, 10, "c");
+  hLine(g, 32, 13, 3, "1");
+  hLine(g, 19, 15, 5, "P");
+  hLine(g, 25, 15, 4, "c");
+  hLine(g, 30, 15, 6, "n");
+  // Stand neck + base plate on the desk.
+  fillRect(g, 30, 20, 4, 5, "m");
+  fillRect(g, 26, 25, 12, 2, "m");
+  hLine(g, 26, 26, 12, "V");
+  // Keyboard with key rows and a space bar.
+  outlineRect(g, 15, 31, 20, 9, "o");
+  fillRect(g, 16, 32, 18, 7, "s");
+  for (let ky = 33; ky <= 35; ky += 2) {
+    for (let kx = 17; kx <= 31; kx += 3) hLine(g, kx, ky, 2, "S");
+  }
+  hLine(g, 21, 37, 8, "S");
+  // Mouse pad + mouse.
+  fillRect(g, 38, 32, 12, 9, "v");
+  trimCorners(g, 38, 32, 12, 9);
+  fillRect(g, 42, 34, 4, 6, "s");
+  vLine(g, 43, 37, 2, "S");
+  setPx(g, 42, 34, "n");
+  // Mug with steam beside the stand.
+  fillRect(g, 40, 25, 6, 6, "r");
+  hLine(g, 40, 25, 6, "9");
+  hLine(g, 41, 26, 3, "h");
+  outlineRect(g, 46, 26, 2, 3, "9");
+  setPx(g, 42, 23, "*");
+  setPx(g, 44, 22, "*");
+  setPx(g, 43, 21, "*");
   // Small potted plant on the right.
-  setPx(g, 26, 12, "l");
-  setPx(g, 27, 12, "g");
-  fillRect(g, 25, 13, 4, 2, "g");
-  setPx(g, 25, 13, "l");
-  setPx(g, 28, 14, "G");
-  fillRect(g, 25, 15, 4, 2, "2");
-  hLine(g, 25, 17, 4, "3");
+  fillRect(g, 52, 32, 7, 6, "2");
+  hLine(g, 52, 32, 7, "e");
+  hLine(g, 52, 37, 7, "3");
+  fillRect(g, 52, 26, 7, 6, "g");
+  trimCorners(g, 52, 26, 7, 6);
+  setPx(g, 53, 26, "l");
+  setPx(g, 54, 27, "l");
+  setPx(g, 52, 28, "l");
+  setPx(g, 57, 30, "G");
+  setPx(g, 58, 31, "G");
+  setPx(g, 55, 24, "g");
+  setPx(g, 56, 25, "l");
   // Loose papers on the left.
-  fillRect(g, 3, 16, 4, 3, "n");
-  hLine(g, 4, 17, 2, "N");
+  fillRect(g, 3, 29, 10, 8, "n");
+  hLine(g, 5, 31, 6, "N");
+  hLine(g, 5, 33, 5, "N");
   return sprite("desk_monitor", g);
 }
 
@@ -312,94 +391,151 @@ function deskMonitor(): PixelSprite {
 // ---------------------------------------------------------------------------
 
 function chair(): PixelSprite {
-  const g = gridFor("chair", 16);
-  drawShadow(g, 3, 14, 10);
-  // Star base + post.
-  hLine(g, 4, 13, 8, "o");
-  setPx(g, 4, 14, "o");
-  setPx(g, 11, 14, "o");
-  fillRect(g, 7, 11, 2, 2, "V");
-  // Seat pan.
-  outlineRect(g, 2, 6, 12, 6, "o");
-  fillRect(g, 3, 7, 10, 4, "i");
-  hLine(g, 3, 10, 10, "V");
-  // Backrest with highlight (seen from behind).
-  outlineRect(g, 3, 0, 10, 7, "o");
-  fillRect(g, 4, 1, 8, 5, "I");
-  hLine(g, 5, 1, 6, "j");
-  setPx(g, 4, 2, "j");
+  const g = gridFor("chair", 32);
+  drawShadow(g, 5, 29, 22);
+  // 5-star base: post, spokes, casters.
+  hLine(g, 5, 26, 9, "o");
+  hLine(g, 18, 26, 9, "o");
+  setPx(g, 12, 27, "o");
+  setPx(g, 11, 28, "o");
+  setPx(g, 19, 27, "o");
+  setPx(g, 20, 28, "o");
+  fillRect(g, 3, 26, 3, 3, "V");
+  fillRect(g, 26, 26, 3, 3, "V");
+  fillRect(g, 9, 28, 3, 3, "V");
+  fillRect(g, 20, 28, 3, 3, "V");
+  fillRect(g, 14, 20, 4, 6, "V");
+  vLine(g, 14, 20, 6, "v");
+  // Backrest seen from behind: top highlight band, bolsters, lumbar seam.
+  roundRect(g, 5, 0, 22, 14);
+  fillRound(g, 5, 0, 22, 14, "I");
+  fillRect(g, 8, 1, 16, 3, "j");
+  vLine(g, 6, 3, 9, "i");
+  vLine(g, 25, 3, 9, "i");
+  setPx(g, 9, 7, "i");
+  hLine(g, 10, 8, 12, "i");
+  setPx(g, 22, 7, "i");
+  // Seat pan with a lit rear edge and a darker front skirt.
+  roundRect(g, 3, 12, 26, 10);
+  fillRound(g, 3, 12, 26, 10, "i");
+  hLine(g, 6, 13, 20, "j");
+  fillRect(g, 4, 18, 24, 3, "V");
+  // Armrests hugging the seat sides.
+  outlineRect(g, 0, 8, 4, 11, "o");
+  fillRect(g, 1, 9, 2, 9, "v");
+  hLine(g, 1, 9, 2, "s");
+  outlineRect(g, 28, 8, 4, 11, "o");
+  fillRect(g, 29, 9, 2, 9, "v");
+  hLine(g, 29, 9, 2, "s");
   return sprite("chair", g);
 }
 
 function sofaH(): PixelSprite {
-  const g = gridFor("sofa_h", 22);
-  drawShadow(g, 2, 20, 28);
-  // Backrest.
-  outlineRect(g, 2, 0, 28, 8, "o");
-  trimCorners(g, 2, 0, 28, 8);
-  fillRect(g, 3, 1, 26, 6, "e");
-  hLine(g, 4, 1, 24, "f");
-  // Front base bar.
-  outlineRect(g, 4, 16, 24, 4, "o");
-  fillRect(g, 5, 17, 22, 2, "E");
-  // Seat cushions with a divot line.
-  outlineRect(g, 5, 7, 22, 10, "o");
-  fillRect(g, 6, 8, 20, 8, "f");
-  vLine(g, 16, 8, 7, "E");
-  hLine(g, 6, 14, 20, "e");
-  hLine(g, 6, 15, 20, "E");
-  // Armrests on top.
-  outlineRect(g, 0, 5, 6, 14, "o");
-  setPx(g, 0, 5, ".");
-  setPx(g, 0, 18, ".");
-  fillRect(g, 1, 6, 4, 12, "e");
-  hLine(g, 1, 6, 4, "f");
-  outlineRect(g, 26, 5, 6, 14, "o");
-  setPx(g, 31, 5, ".");
-  setPx(g, 31, 18, ".");
-  fillRect(g, 27, 6, 4, 12, "e");
-  hLine(g, 27, 6, 4, "f");
+  const g = gridFor("sofa_h", 44);
+  drawShadow(g, 4, 41, 56);
+  // Base bar with feet.
+  roundRect(g, 6, 28, 52, 11);
+  fillRound(g, 6, 28, 52, 11, "E");
+  hLine(g, 8, 29, 48, "e");
+  fillRect(g, 9, 39, 4, 3, "V");
+  fillRect(g, 51, 39, 4, 3, "V");
+  // Seat cushions: divot split, piping, shaded front roll.
+  roundRect(g, 9, 14, 46, 18);
+  fillRound(g, 9, 14, 46, 18, "f");
+  hLine(g, 11, 15, 42, "e");
+  vLine(g, 31, 16, 13, "E");
+  vLine(g, 32, 16, 13, "e");
+  fillRect(g, 11, 26, 42, 3, "e");
+  fillRect(g, 11, 29, 42, 2, "E");
+  // Backrest with a lit top band, divot, and bottom piping.
+  roundRect(g, 4, 0, 56, 16);
+  fillRound(g, 4, 0, 56, 16, "e");
+  fillRect(g, 6, 1, 52, 4, "f");
+  vLine(g, 31, 2, 12, "E");
+  vLine(g, 32, 2, 12, "e");
+  hLine(g, 6, 14, 52, "E");
+  // Armrests with lit caps and inner shading.
+  roundRect(g, 0, 10, 10, 25);
+  fillRound(g, 0, 10, 10, 25, "e");
+  fillRect(g, 2, 11, 6, 4, "f");
+  vLine(g, 8, 15, 16, "E");
+  fillRect(g, 1, 30, 8, 3, "E");
+  roundRect(g, 54, 10, 10, 25);
+  fillRound(g, 54, 10, 10, 25, "e");
+  fillRect(g, 56, 11, 6, 4, "f");
+  vLine(g, 55, 15, 16, "E");
+  fillRect(g, 55, 30, 8, 3, "E");
+  // Blue throw pillow on the right cushion.
+  fillRect(g, 37, 16, 10, 9, "b");
+  trimCorners(g, 37, 16, 10, 9);
+  hLine(g, 39, 18, 4, "n");
+  hLine(g, 38, 23, 8, "B");
   return sprite("sofa_h", g);
 }
 
 function sofaV(): PixelSprite {
-  const g = gridFor("sofa_v", 34);
-  drawShadow(g, 2, 32, 12);
-  // Backrest along the left edge (sofa faces right).
-  outlineRect(g, 0, 2, 7, 28, "o");
-  trimCorners(g, 0, 2, 7, 28);
-  fillRect(g, 1, 3, 5, 26, "e");
-  vLine(g, 1, 3, 26, "f");
-  // Seat cushions.
-  outlineRect(g, 6, 5, 10, 22, "o");
-  fillRect(g, 7, 6, 8, 20, "f");
-  hLine(g, 7, 16, 8, "E");
-  vLine(g, 14, 6, 20, "e");
-  // Armrests top and bottom.
-  outlineRect(g, 4, 0, 12, 6, "o");
-  setPx(g, 15, 0, ".");
-  fillRect(g, 5, 1, 10, 4, "e");
-  hLine(g, 5, 1, 10, "f");
-  outlineRect(g, 4, 26, 12, 6, "o");
-  setPx(g, 15, 31, ".");
-  setPx(g, 4, 31, ".");
-  fillRect(g, 5, 27, 10, 4, "e");
+  const g = gridFor("sofa_v", 68);
+  drawShadow(g, 4, 65, 24);
+  // Seat cushions (sofa faces right): split, shaded front edge.
+  roundRect(g, 9, 8, 21, 48);
+  fillRound(g, 9, 8, 21, 48, "f");
+  hLine(g, 11, 31, 17, "E");
+  hLine(g, 11, 32, 17, "e");
+  vLine(g, 26, 10, 44, "e");
+  vLine(g, 27, 10, 44, "e");
+  vLine(g, 28, 10, 44, "E");
+  // Backrest along the left edge with piping.
+  roundRect(g, 0, 2, 11, 60);
+  fillRound(g, 0, 2, 11, 60, "e");
+  fillRect(g, 2, 3, 7, 4, "f");
+  vLine(g, 9, 4, 56, "E");
+  // Armrests top and bottom with lit caps.
+  roundRect(g, 6, 0, 26, 11);
+  fillRound(g, 6, 0, 26, 11, "e");
+  fillRect(g, 8, 1, 22, 3, "f");
+  roundRect(g, 6, 53, 26, 11);
+  fillRound(g, 6, 53, 26, 11, "e");
+  fillRect(g, 8, 54, 22, 2, "f");
+  fillRect(g, 8, 60, 22, 2, "E");
+  // Blue throw pillow near the top seat.
+  fillRect(g, 12, 12, 9, 9, "b");
+  trimCorners(g, 12, 12, 9, 9);
+  hLine(g, 14, 14, 4, "n");
+  hLine(g, 13, 19, 7, "B");
+  // Feet.
+  fillRect(g, 8, 63, 3, 4, "V");
+  fillRect(g, 25, 63, 3, 4, "V");
   return sprite("sofa_v", g);
 }
 
 function coffeeTable(): PixelSprite {
-  const g = gridFor("coffee_table", 16);
-  drawShadow(g, 2, 14, 12);
-  // Legs.
-  fillRect(g, 3, 11, 2, 3, "W");
-  fillRect(g, 11, 11, 2, 3, "W");
-  // Light wood top with a magazine.
-  roundRect(g, 1, 2, 14, 9);
-  fillRect(g, 2, 3, 12, 5, "k");
-  fillRect(g, 2, 8, 12, 2, "w");
-  fillRect(g, 5, 4, 5, 3, "n");
-  hLine(g, 6, 5, 2, "b");
-  setPx(g, 9, 5, "p");
+  const g = gridFor("coffee_table", 32);
+  drawShadow(g, 3, 29, 26);
+  // Wooden legs.
+  fillRect(g, 5, 22, 3, 8, "W");
+  vLine(g, 5, 22, 8, "h");
+  fillRect(g, 24, 22, 3, 8, "W");
+  vLine(g, 24, 22, 8, "h");
+  // Light wood top with a front lip and grain dashes.
+  roundRect(g, 0, 4, 32, 20);
+  fillRound(g, 0, 4, 32, 20, "k");
+  fillRect(g, 1, 17, 30, 4, "w");
+  fillRect(g, 1, 21, 30, 2, "W");
+  hLine(g, 6, 9, 5, "w");
+  hLine(g, 20, 12, 5, "w");
+  hLine(g, 10, 14, 4, "w");
+  // Magazine with a title line.
+  fillRect(g, 7, 7, 11, 8, "n");
+  trimCorners(g, 7, 7, 11, 8);
+  hLine(g, 9, 9, 6, "b");
+  hLine(g, 9, 11, 7, "N");
+  hLine(g, 9, 13, 5, "N");
+  setPx(g, 16, 9, "p");
+  // Teal mug.
+  fillRect(g, 21, 8, 5, 5, "t");
+  hLine(g, 21, 8, 5, "T");
+  hLine(g, 22, 9, 3, "h");
+  vLine(g, 26, 9, 3, "T");
   return sprite("coffee_table", g);
 }
 
@@ -408,22 +544,49 @@ function coffeeTable(): PixelSprite {
 // ---------------------------------------------------------------------------
 
 function meetingTable(): PixelSprite {
-  const g = gridFor("meeting_table", 32);
-  roundRect(g, 1, 2, 46, 30);
-  fillRect(g, 2, 3, 44, 28, "w");
-  hLine(g, 3, 3, 42, "k");
+  const g = gridFor("meeting_table", 64);
+  drawShadow(g, 6, 61, 84);
+  // Big rounded slab with a lit top edge.
+  roundRect(g, 1, 0, 94, 61);
+  fillRound(g, 1, 0, 94, 61, "w");
+  hLine(g, 4, 1, 88, "k");
+  hLine(g, 3, 2, 90, "k");
+  // Soft diagonal sheen dashes near the lit corner.
+  for (let y = 4; y < 18; y += 1) hLine(g, 40 - y, y, 9, "k");
+  for (let y = 6; y < 14; y += 1) hLine(g, 54 - y, y, 4, "k");
+  // Wood grain dashes.
+  hLine(g, 20, 18, 6, "W");
+  hLine(g, 70, 20, 5, "W");
+  hLine(g, 10, 30, 5, "W");
+  hLine(g, 82, 32, 4, "W");
+  hLine(g, 30, 49, 6, "W");
+  hLine(g, 60, 48, 5, "W");
   // Apron / front edge.
-  fillRect(g, 2, 28, 44, 3, "W");
-  // Subtle placemats.
-  fillRect(g, 8, 6, 8, 4, "k");
-  fillRect(g, 32, 6, 8, 4, "k");
-  fillRect(g, 8, 18, 8, 4, "k");
-  fillRect(g, 32, 18, 8, 4, "k");
-  // Tiny centerpiece plant.
-  fillRect(g, 22, 12, 4, 2, "g");
-  setPx(g, 22, 12, "l");
-  hLine(g, 22, 14, 4, "2");
-  hLine(g, 22, 15, 4, "3");
+  fillRect(g, 2, 53, 92, 6, "W");
+  // Six rounded placemats.
+  for (const [mx, my] of [
+    [14, 7],
+    [40, 7],
+    [66, 7],
+    [14, 37],
+    [40, 37],
+    [66, 37],
+  ] as Array<[number, number]>) {
+    fillRect(g, mx, my, 16, 9, "0");
+    trimCorners(g, mx, my, 16, 9);
+    hLine(g, mx + 1, my + 8, 14, "k");
+  }
+  // Centerpiece plant in a terracotta pot.
+  fillRect(g, 43, 22, 10, 6, "g");
+  trimCorners(g, 43, 22, 10, 6);
+  hLine(g, 44, 22, 4, "l");
+  setPx(g, 43, 23, "l");
+  setPx(g, 51, 26, "G");
+  setPx(g, 52, 27, "G");
+  hLine(g, 42, 28, 12, "2");
+  fillRect(g, 43, 29, 10, 3, "2");
+  hLine(g, 44, 29, 5, "e");
+  hLine(g, 43, 31, 10, "3");
   return sprite("meeting_table", g);
 }
 
@@ -432,100 +595,156 @@ function meetingTable(): PixelSprite {
 // ---------------------------------------------------------------------------
 
 function plant(): PixelSprite {
-  const g = gridFor("plant", 22);
-  drawShadow(g, 4, 20, 8);
-  // Terracotta pot.
-  outlineRect(g, 4, 13, 8, 7, "o");
-  fillRect(g, 5, 14, 6, 4, "2");
-  hLine(g, 5, 18, 6, "3");
+  const g = gridFor("plant", 44);
+  drawShadow(g, 6, 41, 20);
+  // Layered foliage first so the pot rim overlaps the lowest leaves.
   drawFoliage(
     g,
     [
-      [7, 6, 5],
-      [5, 9, 4],
-      [10, 9, 4],
+      [16, 13, 10],
+      [9, 18, 7],
+      [23, 18, 7],
+      [16, 22, 7],
     ],
-    { light: 10, dark: 22, highlights: [[5, 4, 3, 2], [9, 7, 2, 2]] },
+    {
+      light: 22,
+      dark: 44,
+      highlights: [
+        [10, 8, 6, 3],
+        [18, 14, 4, 2],
+        [6, 16, 3, 2],
+      ],
+    },
   );
+  // Terracotta pot: outlined rim with a highlight, tapered shaded body.
+  outlineRect(g, 6, 25, 20, 5, "o");
+  trimCorners(g, 6, 25, 20, 5);
+  fillRect(g, 7, 26, 18, 3, "2");
+  hLine(g, 8, 26, 14, "e");
+  vLine(g, 8, 30, 11, "o");
+  vLine(g, 23, 30, 11, "o");
+  fillRect(g, 9, 30, 14, 11, "2");
+  fillRect(g, 20, 30, 3, 11, "3");
+  hLine(g, 9, 40, 14, "3");
+  hLine(g, 9, 41, 14, "o");
   return sprite("plant", g);
 }
 
 function plantTall(): PixelSprite {
-  const g = gridFor("plant_tall", 30);
-  drawShadow(g, 4, 28, 8);
-  // White pot.
-  outlineRect(g, 4, 20, 8, 8, "o");
-  fillRect(g, 5, 21, 6, 6, "d");
-  hLine(g, 5, 26, 6, "D");
+  const g = gridFor("plant_tall", 60);
+  drawShadow(g, 6, 57, 20);
   drawFoliage(
     g,
     [
-      [8, 5, 5],
-      [5, 10, 4],
-      [11, 10, 4],
-      [8, 16, 4],
+      [16, 10, 9],
+      [9, 19, 7],
+      [23, 19, 7],
+      [16, 26, 8],
+      [16, 36, 6],
     ],
-    { light: 10, dark: 24, highlights: [[6, 3, 3, 2], [4, 9, 2, 2], [10, 12, 2, 2]] },
+    {
+      light: 20,
+      dark: 50,
+      highlights: [
+        [11, 5, 6, 3],
+        [5, 16, 4, 2],
+        [19, 22, 4, 2],
+        [13, 32, 4, 2],
+      ],
+    },
   );
+  // Tall white pot with a rim and shaded side.
+  outlineRect(g, 6, 41, 20, 5, "o");
+  trimCorners(g, 6, 41, 20, 5);
+  fillRect(g, 7, 42, 18, 3, "d");
+  hLine(g, 8, 42, 14, "n");
+  vLine(g, 8, 46, 11, "o");
+  vLine(g, 23, 46, 11, "o");
+  fillRect(g, 9, 46, 14, 11, "d");
+  fillRect(g, 20, 46, 3, 11, "D");
+  hLine(g, 9, 56, 14, "D");
+  hLine(g, 9, 57, 14, "o");
   return sprite("plant_tall", g);
 }
 
 function tree(): PixelSprite {
-  const g = gridFor("tree", 40);
-  drawShadow(g, 6, 38, 20);
-  // Trunk (top tucks under the canopy).
-  outlineRect(g, 12, 22, 8, 16, "o");
-  fillRect(g, 14, 23, 5, 14, "h");
-  vLine(g, 13, 23, 14, "W");
-  // Big fluffy canopy: three heavily overlapping lobes.
+  const g = gridFor("tree", 80);
+  drawShadow(g, 14, 77, 36);
+  // Trunk with a shaded left side and a root flare.
+  vLine(g, 26, 40, 36, "o");
+  vLine(g, 37, 40, 36, "o");
+  fillRect(g, 27, 40, 10, 36, "h");
+  fillRect(g, 27, 40, 2, 36, "W");
+  vLine(g, 35, 42, 32, "k");
+  fillRect(g, 23, 72, 18, 4, "h");
+  fillRect(g, 23, 72, 3, 4, "W");
+  hLine(g, 23, 76, 18, "o");
+  vLine(g, 22, 73, 3, "o");
+  vLine(g, 41, 73, 3, "o");
+  // Big fluffy canopy: heavily overlapping lobes.
   drawFoliage(
     g,
     [
-      [15, 12, 11],
-      [9, 10, 8],
-      [22, 10, 8],
+      [32, 22, 20],
+      [16, 20, 13],
+      [48, 20, 13],
+      [32, 10, 13],
+      [10, 30, 9],
+      [54, 30, 9],
+      [24, 34, 10],
+      [42, 34, 10],
     ],
     {
-      light: 16,
-      dark: 34,
+      light: 40,
+      dark: 72,
       highlights: [
-        [8, 5, 4, 2],
-        [14, 3, 4, 2],
-        [5, 10, 3, 2],
-        [19, 6, 3, 2],
-        [12, 8, 2, 2],
+        [14, 8, 8, 3],
+        [26, 4, 8, 3],
+        [40, 10, 6, 3],
+        [8, 20, 5, 3],
+        [50, 16, 5, 3],
+        [20, 14, 4, 2],
+        [34, 20, 5, 2],
       ],
     },
   );
   return sprite("tree", g);
 }
 
-/** Small plus-shaped bloom with a contrasting center. */
+/** Chunky bloom: 2x2 center with four 2x2 petals. */
 function drawBloom(g: Grid, x: number, y: number, petal: string, center: string): void {
-  setPx(g, x, y - 1, petal);
-  setPx(g, x - 1, y, petal);
-  setPx(g, x + 1, y, petal);
-  setPx(g, x, y + 1, petal);
-  setPx(g, x, y, center);
+  fillRect(g, x, y - 2, 2, 2, petal);
+  fillRect(g, x, y + 2, 2, 2, petal);
+  fillRect(g, x - 2, y, 2, 2, petal);
+  fillRect(g, x + 2, y, 2, 2, petal);
+  fillRect(g, x, y, 2, 2, center);
 }
 
 function flower(): PixelSprite {
-  const g = gridFor("flower", 16);
-  hLine(g, 3, 15, 10, "z");
+  const g = gridFor("flower", 32);
+  hLine(g, 4, 30, 24, "z");
+  hLine(g, 6, 31, 20, "z");
   // Wooden planter with soil.
-  outlineRect(g, 1, 9, 14, 6, "o");
-  fillRect(g, 2, 10, 12, 3, "w");
-  hLine(g, 2, 10, 12, "3");
-  hLine(g, 2, 13, 12, "W");
-  // Stems, leaves, blooms.
-  vLine(g, 4, 7, 3, "g");
-  vLine(g, 8, 6, 4, "g");
-  vLine(g, 12, 7, 3, "g");
-  setPx(g, 5, 8, "l");
-  setPx(g, 11, 8, "l");
-  drawBloom(g, 4, 5, "p", "y");
-  drawBloom(g, 8, 3, "y", "a");
-  drawBloom(g, 12, 5, "p", "y");
+  outlineRect(g, 2, 20, 28, 10, "o");
+  trimCorners(g, 2, 20, 28, 10);
+  fillRect(g, 3, 21, 26, 8, "w");
+  fillRect(g, 4, 21, 24, 2, "3");
+  fillRect(g, 3, 26, 26, 3, "W");
+  // Stems + leaves.
+  vLine(g, 7, 13, 8, "g");
+  vLine(g, 15, 10, 11, "g");
+  vLine(g, 23, 13, 8, "g");
+  setPx(g, 9, 16, "l");
+  setPx(g, 10, 15, "l");
+  setPx(g, 13, 14, "l");
+  setPx(g, 21, 16, "l");
+  setPx(g, 22, 15, "l");
+  // Blooms + small buds.
+  drawBloom(g, 6, 9, "p", "y");
+  drawBloom(g, 14, 5, "y", "a");
+  drawBloom(g, 22, 9, "u", "y");
+  fillRect(g, 11, 12, 2, 2, "p");
+  fillRect(g, 19, 12, 2, 2, "r");
   return sprite("flower", g);
 }
 
@@ -534,35 +753,52 @@ function flower(): PixelSprite {
 // ---------------------------------------------------------------------------
 
 function bookshelf(): PixelSprite {
-  const g = gridFor("bookshelf", 30);
-  drawShadow(g, 2, 28, 28);
-  // Gray-blue case.
-  outlineRect(g, 0, 0, 32, 28, "o");
-  fillRect(g, 1, 1, 30, 26, "C");
-  fillRect(g, 1, 1, 30, 2, "j");
-  // Two shelf openings.
-  fillRect(g, 2, 4, 28, 9, "V");
-  hLine(g, 2, 13, 28, "F");
-  fillRect(g, 2, 15, 28, 9, "V");
-  hLine(g, 2, 24, 28, "F");
-  // Colorful book spines with varied heights.
-  const topColors = ["r", "b", "y", "1", "u", "p", "a", "t", "r"];
-  const topHeights = [6, 8, 5, 7, 6, 8, 5, 7, 6];
-  for (let i = 0; i < 9; i += 1) {
-    fillRect(g, 3 + i * 3, 13 - topHeights[i], 2, topHeights[i], topColors[i]);
-  }
-  const lowColors = ["t", "p", "1", "y", "b", "u", "r", "a"];
-  const lowHeights = [7, 5, 8, 6, 7, 5, 6, 8];
-  for (let i = 0; i < 8; i += 1) {
-    fillRect(g, 3 + i * 3, 24 - lowHeights[i], 2, lowHeights[i], lowColors[i]);
-  }
-  // Tiny plant at the end of the lower shelf.
-  fillRect(g, 27, 21, 2, 3, "2");
-  setPx(g, 27, 19, "g");
-  setPx(g, 28, 19, "l");
-  setPx(g, 28, 20, "g");
+  const g = gridFor("bookshelf", 60);
+  drawShadow(g, 3, 57, 58);
+  // Gray-blue case with a lit top face and shaded side.
+  roundRect(g, 0, 8, 64, 46);
+  fillRound(g, 0, 8, 64, 46, "C");
+  fillRect(g, 2, 9, 60, 3, "j");
+  fillRect(g, 61, 12, 2, 40, "F");
+  // Two shelf openings with board edges.
+  fillRect(g, 4, 13, 56, 15, "V");
+  hLine(g, 4, 28, 56, "j");
+  hLine(g, 4, 29, 56, "F");
+  fillRect(g, 4, 30, 56, 15, "V");
+  hLine(g, 4, 45, 56, "j");
+  hLine(g, 4, 46, 56, "F");
   // Plinth.
-  fillRect(g, 1, 25, 30, 2, "F");
+  fillRect(g, 2, 47, 60, 5, "F");
+  hLine(g, 2, 52, 60, "V");
+  // Top shelf: varied book spines, one leaning book, a steel bookend.
+  const topColors = ["r", "b", "y", "1", "u", "p", "a", "t", "6", "q"];
+  const topHeights = [11, 13, 9, 12, 10, 14, 9, 12, 11, 10];
+  for (let i = 0; i < 10; i += 1) {
+    fillRect(g, 6 + i * 4, 28 - topHeights[i], 3, topHeights[i], topColors[i]);
+    if (i % 3 === 0) setPx(g, 7 + i * 4, 24, "n");
+  }
+  for (let k = 0; k < 12; k += 1) hLine(g, 47 + (k >> 2), 16 + k, 4, "8");
+  fillRect(g, 55, 20, 2, 8, "s");
+  vLine(g, 56, 20, 8, "S");
+  // Lower shelf: spines plus a flat stack.
+  const lowColors = ["t", "p", "1", "y", "b", "u", "r", "a"];
+  const lowHeights = [12, 9, 13, 10, 12, 9, 11, 13];
+  for (let i = 0; i < 8; i += 1) {
+    fillRect(g, 6 + i * 4, 45 - lowHeights[i], 3, lowHeights[i], lowColors[i]);
+    if (i % 3 === 1) setPx(g, 7 + i * 4, 41, "n");
+  }
+  fillRect(g, 41, 42, 14, 3, "6");
+  fillRect(g, 42, 39, 12, 3, "y");
+  fillRect(g, 43, 36, 10, 3, "p");
+  // Small potted plant on top of the case.
+  hLine(g, 46, 3, 10, "2");
+  fillRect(g, 47, 4, 8, 3, "2");
+  hLine(g, 47, 6, 8, "3");
+  fillRect(g, 46, 0, 10, 3, "g");
+  trimCorners(g, 46, 0, 10, 3);
+  setPx(g, 47, 0, "l");
+  setPx(g, 49, 1, "l");
+  setPx(g, 54, 2, "G");
   return sprite("bookshelf", g);
 }
 
@@ -571,117 +807,209 @@ function bookshelf(): PixelSprite {
 // ---------------------------------------------------------------------------
 
 function kitchenCounter(): PixelSprite {
-  const g = gridFor("kitchen_counter", 25);
-  drawShadow(g, 2, 23, 28);
-  // Faucet.
-  vLine(g, 7, 1, 3, "S");
-  setPx(g, 8, 1, "S");
-  // Steel top with sink + cutting board.
-  outlineRect(g, 0, 4, 32, 6, "o");
-  fillRect(g, 1, 5, 30, 4, "s");
-  hLine(g, 1, 8, 30, "S");
-  fillRect(g, 4, 5, 8, 3, "S");
-  fillRect(g, 5, 6, 6, 2, "F");
-  fillRect(g, 20, 5, 7, 3, "w");
-  hLine(g, 21, 6, 5, "k");
-  setPx(g, 25, 5, "r");
-  // Sage cabinets.
-  outlineRect(g, 0, 10, 32, 13, "o");
-  fillRect(g, 1, 11, 30, 11, "4");
-  vLine(g, 15, 11, 11, "5");
-  vLine(g, 13, 14, 3, "S");
-  vLine(g, 18, 14, 3, "S");
-  hLine(g, 1, 21, 30, "5");
+  const g = gridFor("kitchen_counter", 50);
+  drawShadow(g, 3, 47, 58);
+  // Gooseneck faucet with a handle.
+  fillRect(g, 14, 4, 2, 7, "s");
+  hLine(g, 14, 3, 5, "s");
+  vLine(g, 18, 4, 2, "S");
+  setPx(g, 18, 7, "q");
+  fillRect(g, 11, 5, 2, 2, "S");
+  // Counter block: steel top, lip, sage cabinet faces, kick.
+  roundRect(g, 0, 10, 64, 36);
+  fillRound(g, 0, 10, 64, 36, "s");
+  hLine(g, 2, 11, 60, "n");
+  fillRect(g, 1, 18, 62, 2, "S");
+  fillRect(g, 1, 20, 62, 20, "4");
+  vLine(g, 32, 22, 15, "5");
+  outlineRect(g, 6, 22, 22, 15, "5");
+  outlineRect(g, 36, 22, 22, 15, "5");
+  vLine(g, 25, 25, 6, "S");
+  vLine(g, 39, 25, 6, "S");
+  fillRect(g, 1, 40, 62, 2, "5");
+  fillRect(g, 1, 42, 62, 3, "F");
+  // Sink: rim, shaded basin, water glint, drain.
+  fillRect(g, 6, 11, 20, 7, "S");
+  fillRect(g, 8, 12, 16, 5, "F");
+  hLine(g, 9, 13, 6, "q");
+  hLine(g, 8, 16, 16, "V");
+  fillRect(g, 15, 15, 2, 1, "x");
+  // Cutting board with a knife and a tomato.
+  fillRect(g, 36, 12, 16, 6, "w");
+  trimCorners(g, 36, 12, 16, 6);
+  fillRect(g, 38, 13, 12, 2, "k");
+  hLine(g, 39, 16, 6, "s");
+  hLine(g, 45, 16, 3, "h");
+  fillRect(g, 50, 13, 2, 2, "r");
+  setPx(g, 50, 12, "x");
   return sprite("kitchen_counter", g);
 }
 
 function fridge(): PixelSprite {
-  const g = gridFor("fridge", 30);
-  drawShadow(g, 3, 28, 10);
-  roundRect(g, 2, 0, 12, 28);
-  fillRect(g, 3, 1, 10, 26, "d");
-  vLine(g, 12, 1, 26, "D");
-  hLine(g, 4, 1, 6, "n");
-  // Freezer seam + handles.
-  hLine(g, 3, 9, 10, "D");
-  vLine(g, 4, 3, 4, "S");
-  vLine(g, 4, 11, 7, "S");
-  hLine(g, 3, 26, 10, "D");
+  const g = gridFor("fridge", 60);
+  drawShadow(g, 4, 57, 24);
+  // Tall white body with a shaded right side and top sheen.
+  roundRect(g, 3, 0, 26, 54);
+  fillRound(g, 3, 0, 26, 54, "d");
+  fillRect(g, 26, 2, 2, 50, "D");
+  hLine(g, 5, 1, 18, "n");
+  hLine(g, 5, 2, 8, "n");
+  // Freezer / fridge door seam.
+  hLine(g, 4, 18, 24, "D");
+  hLine(g, 4, 19, 24, "S");
+  // Door handles with a lit edge.
+  fillRect(g, 6, 4, 3, 11, "s");
+  vLine(g, 6, 4, 11, "n");
+  hLine(g, 6, 14, 3, "S");
+  fillRect(g, 6, 22, 3, 16, "s");
+  vLine(g, 6, 22, 16, "n");
+  hLine(g, 6, 37, 3, "S");
+  // Water dispenser recess with a cup.
+  outlineRect(g, 14, 24, 10, 8, "S");
+  fillRect(g, 15, 25, 8, 6, "M");
+  fillRect(g, 17, 27, 3, 3, "n");
+  setPx(g, 21, 25, "L");
+  // Vent lines + feet.
+  hLine(g, 6, 48, 20, "S");
+  hLine(g, 6, 50, 20, "S");
+  fillRect(g, 6, 54, 4, 4, "S");
+  fillRect(g, 22, 54, 4, 4, "S");
   return sprite("fridge", g);
 }
 
 function coffeeMachine(): PixelSprite {
-  const g = gridFor("coffee_machine", 26);
-  drawShadow(g, 3, 24, 10);
-  roundRect(g, 2, 2, 12, 22);
-  fillRect(g, 3, 3, 10, 20, "v");
-  hLine(g, 3, 3, 10, "j");
-  // Display + red brew light.
-  fillRect(g, 5, 5, 4, 2, "M");
-  setPx(g, 6, 5, "c");
-  setPx(g, 11, 5, "r");
-  // Brew cavity with mug + pouring coffee.
-  fillRect(g, 4, 9, 8, 8, "V");
-  hLine(g, 7, 9, 2, "S");
-  vLine(g, 7, 10, 3, "h");
-  fillRect(g, 6, 13, 3, 3, "n");
-  setPx(g, 9, 14, "n");
-  // Drip tray + base.
-  fillRect(g, 4, 17, 8, 2, "S");
-  hLine(g, 5, 21, 6, "V");
-  hLine(g, 3, 22, 10, "V");
+  const g = gridFor("coffee_machine", 52);
+  drawShadow(g, 4, 49, 24);
+  // Slate body with a lit top and shaded side.
+  roundRect(g, 3, 2, 26, 46);
+  fillRound(g, 3, 2, 26, 46, "v");
+  hLine(g, 5, 3, 22, "j");
+  fillRect(g, 26, 4, 2, 42, "V");
+  // Display with text and a red brew light.
+  fillRect(g, 7, 6, 10, 5, "M");
+  hLine(g, 8, 7, 5, "c");
+  hLine(g, 8, 9, 3, "n");
+  setPx(g, 15, 7, "L");
+  fillRect(g, 21, 6, 2, 2, "r");
+  // Brew cavity: spout, drip stream, glass carafe with coffee.
+  fillRect(g, 6, 14, 20, 19, "V");
+  fillRect(g, 13, 15, 6, 3, "S");
+  fillRect(g, 15, 18, 2, 1, "x");
+  vLine(g, 15, 19, 5, "h");
+  vLine(g, 16, 19, 5, "h");
+  outlineRect(g, 10, 24, 12, 8, "o");
+  trimCorners(g, 10, 24, 12, 8);
+  fillRect(g, 11, 25, 10, 3, "A");
+  fillRect(g, 11, 28, 10, 3, "h");
+  vLine(g, 22, 26, 4, "o");
+  // Drip tray with slots.
+  fillRect(g, 6, 34, 20, 3, "S");
+  hLine(g, 8, 35, 16, "x");
+  // Button row.
+  fillRect(g, 7, 40, 2, 2, "r");
+  fillRect(g, 11, 40, 2, 2, "y");
+  fillRect(g, 15, 40, 2, 2, "1");
+  // Base band + feet.
+  fillRect(g, 4, 43, 24, 4, "V");
+  fillRect(g, 6, 48, 4, 2, "S");
+  fillRect(g, 22, 48, 4, 2, "S");
   return sprite("coffee_machine", g);
 }
 
 function waterCooler(): PixelSprite {
-  const g = gridFor("water_cooler", 26);
-  drawShadow(g, 3, 24, 10);
-  // Blue bottle.
-  outlineRect(g, 4, 0, 8, 8, "o");
-  trimCorners(g, 4, 0, 8, 8);
-  fillRect(g, 5, 1, 6, 6, "q");
-  vLine(g, 6, 2, 3, "n");
-  hLine(g, 5, 6, 6, "Q");
-  // White body with taps + recess.
-  outlineRect(g, 3, 8, 10, 14, "o");
-  fillRect(g, 4, 9, 8, 12, "d");
-  fillRect(g, 6, 12, 4, 4, "D");
-  setPx(g, 5, 12, "b");
-  setPx(g, 10, 12, "r");
-  fillRect(g, 4, 19, 8, 2, "D");
-  // Feet.
-  fillRect(g, 5, 22, 2, 2, "S");
-  fillRect(g, 9, 22, 2, 2, "S");
+  const g = gridFor("water_cooler", 52);
+  drawShadow(g, 5, 49, 22);
+  // Translucent bottle with water and a shine.
+  roundRect(g, 7, 0, 18, 15);
+  fillRound(g, 7, 0, 18, 15, "A");
+  fillRect(g, 8, 6, 16, 7, "q");
+  hLine(g, 8, 6, 16, "Q");
+  vLine(g, 10, 2, 10, "n");
+  fillRect(g, 12, 15, 8, 2, "S");
+  // White body with a shaded side and lit top.
+  roundRect(g, 6, 17, 20, 28);
+  fillRound(g, 6, 17, 20, 28, "d");
+  fillRect(g, 23, 18, 2, 25, "D");
+  hLine(g, 8, 18, 14, "n");
+  // Cup sleeve on the left.
+  outlineRect(g, 1, 19, 5, 12, "o");
+  fillRect(g, 2, 20, 3, 10, "s");
+  for (let cy = 21; cy <= 29; cy += 2) hLine(g, 2, cy, 3, "S");
+  // Taps + drip recess with two cups.
+  fillRect(g, 9, 26, 3, 3, "b");
+  setPx(g, 10, 29, "x");
+  fillRect(g, 20, 26, 3, 3, "r");
+  setPx(g, 21, 29, "x");
+  fillRect(g, 12, 31, 8, 4, "D");
+  hLine(g, 12, 34, 8, "S");
+  fillRect(g, 13, 32, 2, 2, "n");
+  fillRect(g, 17, 32, 2, 2, "n");
+  // Vents + feet.
+  hLine(g, 9, 39, 14, "S");
+  hLine(g, 9, 41, 14, "S");
+  fillRect(g, 8, 45, 4, 5, "S");
+  fillRect(g, 20, 45, 4, 5, "S");
   return sprite("water_cooler", g);
 }
 
 function vendingMachine(): PixelSprite {
-  const g = gridFor("vending_machine", 31);
-  drawShadow(g, 3, 29, 10);
-  roundRect(g, 2, 0, 12, 29);
-  fillRect(g, 3, 1, 10, 27, "b");
-  vLine(g, 12, 2, 26, "B");
-  // Glass window with can rows.
-  outlineRect(g, 4, 3, 8, 14, "o");
-  fillRect(g, 5, 4, 6, 12, "M");
-  hLine(g, 5, 7, 6, "F");
-  hLine(g, 5, 11, 6, "F");
-  hLine(g, 5, 15, 6, "F");
-  fillRect(g, 5, 5, 2, 2, "r");
-  fillRect(g, 8, 5, 2, 2, "y");
-  fillRect(g, 5, 9, 2, 2, "1");
-  fillRect(g, 8, 9, 2, 2, "p");
-  fillRect(g, 5, 13, 2, 2, "a");
-  fillRect(g, 8, 13, 2, 2, "c");
-  setPx(g, 10, 4, "n");
-  setPx(g, 9, 5, "n");
-  // Coin panel + dispenser flap.
-  fillRect(g, 9, 18, 3, 4, "v");
-  setPx(g, 10, 19, "x");
-  setPx(g, 10, 21, "L");
-  fillRect(g, 4, 23, 8, 3, "v");
-  hLine(g, 5, 24, 6, "x");
-  hLine(g, 3, 27, 10, "B");
+  const g = gridFor("vending_machine", 62);
+  drawShadow(g, 4, 59, 24);
+  // Blue cabinet with a shaded side and top sheen.
+  roundRect(g, 2, 0, 28, 58);
+  fillRound(g, 2, 0, 28, 58, "b");
+  fillRect(g, 26, 2, 2, 54, "B");
+  hLine(g, 4, 1, 22, "n");
+  // Header band with brand dashes.
+  fillRect(g, 4, 2, 24, 4, "B");
+  hLine(g, 7, 3, 4, "n");
+  hLine(g, 13, 3, 3, "n");
+  hLine(g, 18, 3, 4, "n");
+  // Glass window: two shelves of colorful cans behind a reflection.
+  outlineRect(g, 4, 7, 17, 32, "o");
+  fillRect(g, 5, 8, 15, 30, "M");
+  hLine(g, 5, 18, 15, "F");
+  hLine(g, 5, 28, 15, "F");
+  const canColors: Array<[number, number, string]> = [
+    [6, 12, "r"],
+    [10, 12, "y"],
+    [14, 12, "1"],
+    [6, 22, "p"],
+    [10, 22, "a"],
+    [14, 22, "c"],
+  ];
+  for (const [cx, cy, ch] of canColors) {
+    fillRect(g, cx, cy, 3, 6, ch);
+    setPx(g, cx, cy, "n");
+  }
+  // Diagonal glass reflection streaks.
+  for (let k = 0; k < 14; k += 1) {
+    const rx = 6 + k;
+    const ry = 9 + k;
+    if (rx >= 5 && rx <= 19 && ry >= 8 && ry <= 37) {
+      setPx(g, rx, ry, "A");
+      if (rx + 1 <= 19) setPx(g, rx + 1, ry, "A");
+    }
+  }
+  for (let k = 0; k < 8; k += 1) setPx(g, 12 + k, 26 + k, "A");
+  // Coin panel: screen, keypad, coin slot, LED.
+  fillRect(g, 22, 9, 5, 12, "v");
+  fillRect(g, 23, 10, 3, 2, "M");
+  setPx(g, 23, 14, "x");
+  setPx(g, 25, 14, "x");
+  setPx(g, 23, 16, "x");
+  setPx(g, 25, 16, "x");
+  vLine(g, 24, 18, 2, "x");
+  setPx(g, 24, 8, "L");
+  // Dispenser flap.
+  fillRect(g, 5, 44, 16, 7, "v");
+  hLine(g, 5, 44, 16, "V");
+  fillRect(g, 7, 46, 12, 3, "x");
+  // Bottom band, vents, feet.
+  fillRect(g, 3, 52, 26, 3, "B");
+  hLine(g, 6, 55, 20, "S");
+  fillRect(g, 5, 56, 4, 4, "V");
+  fillRect(g, 23, 56, 4, 4, "V");
   return sprite("vending_machine", g);
 }
 
@@ -690,108 +1018,166 @@ function vendingMachine(): PixelSprite {
 // ---------------------------------------------------------------------------
 
 function pingPongTable(): PixelSprite {
-  const g = gridFor("ping_pong_table", 32);
-  drawShadow(g, 3, 30, 42);
-  // Indigo table with a soft edge.
-  roundRect(g, 1, 0, 46, 30);
-  fillRect(g, 2, 1, 44, 28, "6");
-  fillRect(g, 2, 27, 44, 2, "7");
-  // White boundary + centerline.
-  outlineRect(g, 3, 2, 42, 24, "n");
-  hLine(g, 4, 14, 40, "n");
-  // Net across the middle.
-  vLine(g, 23, 1, 28, "n");
-  vLine(g, 24, 1, 28, "S");
-  fillRect(g, 23, 0, 2, 1, "x");
-  fillRect(g, 23, 29, 2, 1, "x");
-  // Paddles + ball.
-  fillRect(g, 9, 6, 3, 3, "r");
-  setPx(g, 11, 8, "9");
-  setPx(g, 12, 9, "w");
-  setPx(g, 13, 10, "w");
-  fillRect(g, 35, 20, 3, 3, "b");
-  setPx(g, 35, 22, "B");
-  setPx(g, 34, 23, "w");
-  setPx(g, 33, 24, "w");
-  setPx(g, 30, 8, "n");
+  const g = gridFor("ping_pong_table", 64);
+  drawShadow(g, 6, 61, 84);
+  // Indigo top with a lit edge and a darker front face.
+  roundRect(g, 1, 0, 94, 58);
+  fillRound(g, 1, 0, 94, 58, "6");
+  hLine(g, 4, 1, 88, "J");
+  hLine(g, 3, 2, 90, "J");
+  fillRect(g, 2, 52, 92, 5, "7");
+  // White boundary + doubles centerline.
+  outlineRect(g, 6, 5, 84, 44, "n");
+  hLine(g, 7, 26, 82, "n");
+  hLine(g, 7, 27, 82, "n");
+  // Net with posts, mesh, and a soft cast shadow.
+  fillRect(g, 45, 1, 6, 4, "V");
+  fillRect(g, 45, 50, 6, 4, "V");
+  fillRect(g, 46, 5, 4, 45, "n");
+  for (let ny = 5; ny < 50; ny += 1) {
+    for (let nx = 46; nx < 50; nx += 1) {
+      if ((nx + ny) % 2 === 0) setPx(g, nx, ny, "S");
+    }
+  }
+  vLine(g, 51, 6, 44, "7");
+  // Red paddle with a wooden handle.
+  fillRect(g, 17, 10, 6, 6, "r");
+  trimCorners(g, 17, 10, 6, 6);
+  hLine(g, 18, 15, 4, "9");
+  setPx(g, 22, 14, "9");
+  setPx(g, 23, 16, "w");
+  setPx(g, 24, 16, "w");
+  setPx(g, 24, 17, "w");
+  setPx(g, 25, 17, "w");
+  setPx(g, 25, 18, "w");
+  setPx(g, 26, 18, "w");
+  // Blue paddle mirrored on the far side.
+  fillRect(g, 70, 38, 6, 6, "b");
+  trimCorners(g, 70, 38, 6, 6);
+  hLine(g, 71, 43, 4, "B");
+  setPx(g, 70, 42, "B");
+  setPx(g, 69, 44, "w");
+  setPx(g, 68, 44, "w");
+  setPx(g, 68, 45, "w");
+  setPx(g, 67, 45, "w");
+  setPx(g, 67, 46, "w");
+  setPx(g, 66, 46, "w");
+  // Ball with a tiny cast shadow.
+  fillRect(g, 58, 14, 3, 3, "n");
+  trimCorners(g, 58, 14, 3, 3);
+  hLine(g, 58, 18, 3, "7");
   return sprite("ping_pong_table", g);
 }
 
 function arcade(): PixelSprite {
-  const g = gridFor("arcade", 29);
-  drawShadow(g, 3, 27, 10);
-  roundRect(g, 2, 0, 12, 27);
-  fillRect(g, 3, 1, 10, 25, "u");
-  // Marquee.
-  fillRect(g, 3, 1, 10, 2, "p");
-  setPx(g, 5, 2, "y");
-  setPx(g, 7, 2, "n");
-  setPx(g, 9, 2, "y");
-  // Bright screen with tiny game pixels.
-  outlineRect(g, 4, 4, 8, 8, "o");
-  fillRect(g, 5, 5, 6, 6, "M");
-  setPx(g, 5, 5, "y");
-  setPx(g, 6, 6, "1");
-  setPx(g, 8, 6, "1");
-  setPx(g, 10, 6, "1");
-  setPx(g, 7, 8, "n");
-  setPx(g, 7, 9, "c");
-  hLine(g, 6, 10, 3, "c");
-  // Control deck: joystick + buttons.
-  fillRect(g, 4, 13, 8, 3, "j");
-  setPx(g, 6, 12, "r");
-  setPx(g, 6, 13, "x");
-  setPx(g, 9, 14, "y");
-  setPx(g, 11, 14, "b");
-  // Front panel decal + vents.
-  fillRect(g, 6, 19, 4, 4, "p");
-  hLine(g, 5, 24, 6, "V");
-  hLine(g, 3, 25, 10, "V");
+  const g = gridFor("arcade", 58);
+  drawShadow(g, 4, 55, 24);
+  // Purple cabinet with a shaded side.
+  roundRect(g, 2, 0, 28, 54);
+  fillRound(g, 2, 0, 28, 54, "u");
+  fillRect(g, 26, 2, 2, 50, "X");
+  // Marquee with lights and a glow line.
+  fillRect(g, 3, 1, 26, 6, "p");
+  hLine(g, 9, 3, 4, "n");
+  setPx(g, 15, 3, "n");
+  hLine(g, 18, 3, 4, "n");
+  setPx(g, 6, 4, "y");
+  setPx(g, 25, 4, "y");
+  hLine(g, 4, 7, 24, "Y");
+  // Screen with a tiny invaders scene.
+  outlineRect(g, 4, 9, 24, 18, "o");
+  fillRect(g, 5, 10, 22, 16, "m");
+  fillRect(g, 7, 12, 18, 12, "M");
+  for (let i = 0; i < 3; i += 1) fillRect(g, 9 + i * 5, 13, 3, 2, "1");
+  for (let i = 0; i < 3; i += 1) fillRect(g, 9 + i * 5, 16, 3, 2, "p");
+  setPx(g, 17, 19, "n");
+  fillRect(g, 15, 21, 4, 2, "c");
+  setPx(g, 16, 20, "c");
+  setPx(g, 17, 20, "c");
+  // Control deck: joystick with a red ball, two buttons.
+  fillRect(g, 4, 27, 24, 6, "j");
+  hLine(g, 4, 27, 24, "s");
+  hLine(g, 4, 32, 24, "S");
+  fillRect(g, 10, 25, 2, 3, "x");
+  fillRect(g, 9, 22, 3, 3, "r");
+  trimCorners(g, 9, 22, 3, 3);
+  fillRect(g, 18, 28, 3, 2, "y");
+  fillRect(g, 23, 28, 3, 2, "b");
+  // Front decal with a tiny alien.
+  fillRect(g, 10, 36, 12, 8, "p");
+  hLine(g, 14, 38, 4, "n");
+  setPx(g, 13, 39, "n");
+  setPx(g, 18, 39, "n");
+  hLine(g, 13, 40, 6, "n");
+  // Vents, base, feet.
+  hLine(g, 6, 46, 20, "X");
+  hLine(g, 6, 48, 20, "X");
+  fillRect(g, 3, 50, 26, 3, "X");
+  fillRect(g, 5, 53, 4, 3, "V");
+  fillRect(g, 23, 53, 4, 3, "V");
   return sprite("arcade", g);
 }
 
 function jukebox(): PixelSprite {
-  const g = gridFor("jukebox", 30);
-  drawShadow(g, 3, 28, 10);
-  // Rounded dome top.
-  hLine(g, 5, 0, 6, "o");
-  setPx(g, 4, 1, "o");
-  setPx(g, 11, 1, "o");
-  fillRect(g, 5, 1, 6, 1, "p");
-  setPx(g, 3, 2, "o");
-  setPx(g, 12, 2, "o");
-  setPx(g, 4, 2, "p");
-  setPx(g, 11, 2, "p");
-  fillRect(g, 5, 2, 6, 1, "Y");
-  // Body.
-  vLine(g, 2, 3, 25, "o");
-  vLine(g, 13, 3, 25, "o");
-  fillRect(g, 3, 3, 10, 24, "w");
-  hLine(g, 2, 27, 12, "o");
-  // Glow arch.
-  vLine(g, 3, 3, 6, "p");
-  vLine(g, 12, 3, 6, "p");
-  vLine(g, 4, 3, 6, "Y");
-  vLine(g, 11, 3, 6, "Y");
-  // Record window.
-  fillRect(g, 6, 4, 4, 4, "M");
-  fillRect(g, 7, 5, 2, 2, "x");
-  setPx(g, 6, 4, "n");
-  // Song list + colorful buttons.
-  fillRect(g, 4, 10, 8, 3, "n");
-  hLine(g, 5, 11, 6, "N");
-  setPx(g, 5, 13, "r");
-  setPx(g, 7, 13, "y");
-  setPx(g, 9, 13, "1");
-  setPx(g, 11, 13, "b");
+  const g = gridFor("jukebox", 60);
+  drawShadow(g, 4, 57, 24);
+  // Rounded dome from circle bands: outline, pink glow ring, warm ring, wood.
+  const domeCx = 15.5;
+  const domeCy = 16;
+  for (let y = 0; y < 16; y += 1) {
+    for (let x = 0; x < 32; x += 1) {
+      const d = Math.sqrt((x - domeCx) * (x - domeCx) + (y - domeCy) * (y - domeCy));
+      if (d > 14.5) continue;
+      if (d > 13.2) setPx(g, x, y, "o");
+      else if (d > 11.2) setPx(g, x, y, "p");
+      else if (d > 9.2) setPx(g, x, y, "Y");
+      else setPx(g, x, y, "w");
+    }
+  }
+  // Body below the dome with glow columns continuing the arch.
+  vLine(g, 2, 16, 38, "o");
+  vLine(g, 29, 16, 38, "o");
+  fillRect(g, 3, 16, 26, 38, "w");
+  fillRect(g, 4, 16, 2, 14, "p");
+  fillRect(g, 6, 16, 2, 14, "Y");
+  fillRect(g, 26, 16, 2, 14, "p");
+  fillRect(g, 24, 16, 2, 14, "Y");
+  setPx(g, 5, 20, "n");
+  setPx(g, 26, 24, "n");
+  // Record window with a spinning vinyl.
+  outlineRect(g, 9, 8, 14, 10, "o");
+  fillRect(g, 10, 9, 12, 8, "M");
+  fillRect(g, 13, 10, 6, 6, "x");
+  trimCorners(g, 13, 10, 6, 6);
+  fillRect(g, 15, 12, 2, 2, "r");
+  setPx(g, 14, 10, "n");
+  // Song list card with entries.
+  fillRect(g, 8, 20, 16, 8, "n");
+  vLine(g, 16, 21, 6, "N");
+  hLine(g, 10, 22, 5, "N");
+  hLine(g, 18, 22, 5, "N");
+  hLine(g, 10, 24, 4, "N");
+  hLine(g, 18, 24, 5, "N");
+  hLine(g, 10, 26, 5, "N");
+  hLine(g, 18, 26, 4, "N");
+  // Colorful button row.
+  fillRect(g, 8, 30, 3, 2, "r");
+  fillRect(g, 12, 30, 3, 2, "y");
+  fillRect(g, 16, 30, 3, 2, "1");
+  fillRect(g, 20, 30, 3, 2, "b");
+  fillRect(g, 24, 30, 3, 2, "u");
   // Speaker grill.
-  fillRect(g, 4, 15, 8, 10, "h");
-  hLine(g, 5, 17, 6, "x");
-  hLine(g, 5, 20, 6, "x");
-  hLine(g, 5, 23, 6, "x");
-  // Base.
-  hLine(g, 3, 25, 10, "W");
-  hLine(g, 3, 26, 10, "W");
+  outlineRect(g, 7, 34, 18, 12, "W");
+  fillRect(g, 8, 35, 16, 10, "h");
+  hLine(g, 9, 37, 14, "x");
+  hLine(g, 9, 39, 14, "x");
+  hLine(g, 9, 41, 14, "x");
+  hLine(g, 9, 43, 14, "x");
+  // Base + feet.
+  fillRect(g, 3, 48, 26, 6, "W");
+  hLine(g, 3, 54, 26, "o");
+  fillRect(g, 5, 55, 4, 3, "V");
+  fillRect(g, 23, 55, 4, 3, "V");
   return sprite("jukebox", g);
 }
 
@@ -799,72 +1185,98 @@ function jukebox(): PixelSprite {
 // Boards
 // ---------------------------------------------------------------------------
 
-/** White board face on slate legs with a ground shadow. */
+/** White board face on slate legs with a marker tray and ground shadow. */
 function drawBoardFrame(g: Grid): void {
-  drawShadow(g, 3, 28, 26);
-  fillRect(g, 6, 21, 2, 7, "v");
-  fillRect(g, 24, 21, 2, 7, "v");
-  hLine(g, 5, 27, 4, "v");
-  hLine(g, 23, 27, 4, "v");
-  outlineRect(g, 1, 0, 30, 22, "o");
-  fillRect(g, 2, 1, 28, 20, "n");
+  drawShadow(g, 5, 57, 54);
+  // Legs with feet.
+  fillRect(g, 12, 44, 4, 13, "v");
+  vLine(g, 15, 44, 13, "V");
+  fillRect(g, 48, 44, 4, 13, "v");
+  vLine(g, 51, 44, 13, "V");
+  fillRect(g, 9, 55, 10, 3, "V");
+  fillRect(g, 45, 55, 10, 3, "V");
+  // Marker tray.
+  fillRect(g, 16, 45, 32, 2, "s");
+  hLine(g, 16, 47, 32, "S");
+  // Board face with a soft inner shade.
+  roundRect(g, 2, 0, 60, 44);
+  fillRound(g, 2, 0, 60, 44, "n");
+  hLine(g, 4, 1, 56, "N");
+  vLine(g, 60, 2, 40, "N");
+}
+
+/** Sticky note with a shaded fold edge and scribble dashes. */
+function drawSticky(g: Grid, x: number, y: number, ch: string): void {
+  fillRect(g, x, y, 7, 7, ch);
+  hLine(g, x + 1, y + 2, 4, "S");
+  hLine(g, x + 1, y + 4, 3, "S");
+  setPx(g, x + 6, y + 6, "N");
 }
 
 function kanbanBoard(): PixelSprite {
-  const g = gridFor("kanban_board", 30);
+  const g = gridFor("kanban_board", 60);
   drawBoardFrame(g);
-  // Column dividers + header rule.
-  hLine(g, 2, 4, 28, "N");
-  vLine(g, 11, 1, 20, "N");
-  vLine(g, 21, 1, 20, "N");
-  hLine(g, 4, 2, 5, "S");
-  hLine(g, 13, 2, 6, "S");
-  hLine(g, 23, 2, 6, "S");
-  // Sticky notes.
-  const notes: Array<[number, number, string]> = [
-    [3, 6, "y"],
-    [7, 7, "p"],
-    [3, 11, "b"],
-    [6, 15, "y"],
-    [13, 6, "1"],
-    [16, 10, "y"],
-    [13, 14, "u"],
-    [23, 6, "b"],
-    [26, 10, "p"],
-    [23, 15, "1"],
-  ];
-  for (const [x, y, ch] of notes) fillRect(g, x, y, 3, 3, ch);
+  // Column dividers + labeled headers.
+  vLine(g, 22, 2, 40, "N");
+  vLine(g, 42, 2, 40, "N");
+  fillRect(g, 6, 3, 13, 4, "b");
+  hLine(g, 8, 4, 9, "n");
+  fillRect(g, 26, 3, 13, 4, "y");
+  hLine(g, 28, 4, 9, "S");
+  fillRect(g, 46, 3, 13, 4, "1");
+  hLine(g, 48, 4, 9, "S");
+  // Sticky notes per column.
+  drawSticky(g, 5, 10, "y");
+  drawSticky(g, 13, 13, "p");
+  drawSticky(g, 6, 19, "b");
+  drawSticky(g, 13, 25, "y");
+  drawSticky(g, 5, 32, "1");
+  drawSticky(g, 25, 10, "1");
+  drawSticky(g, 33, 14, "y");
+  drawSticky(g, 26, 20, "u");
+  drawSticky(g, 33, 27, "p");
+  drawSticky(g, 45, 11, "b");
+  drawSticky(g, 52, 16, "p");
+  drawSticky(g, 45, 22, "1");
   return sprite("kanban_board", g);
 }
 
 function whiteboard(): PixelSprite {
-  const g = gridFor("whiteboard", 30);
+  const g = gridFor("whiteboard", 60);
   drawBoardFrame(g);
-  // Marker scribbles.
-  hLine(g, 4, 3, 12, "b");
-  hLine(g, 4, 5, 16, "S");
-  hLine(g, 4, 7, 10, "S");
-  setPx(g, 3, 5, "r");
-  setPx(g, 3, 7, "r");
-  // Bar chart.
-  outlineRect(g, 19, 3, 9, 8, "S");
-  fillRect(g, 20, 8, 1, 2, "t");
-  fillRect(g, 22, 6, 1, 4, "b");
-  fillRect(g, 24, 7, 1, 3, "r");
-  fillRect(g, 26, 5, 1, 5, "1");
-  // Green arrow.
-  hLine(g, 4, 12, 8, "1");
-  setPx(g, 11, 11, "1");
-  setPx(g, 12, 12, "1");
-  setPx(g, 11, 13, "1");
-  // Note line + pink sticky.
-  hLine(g, 4, 16, 11, "m");
-  fillRect(g, 25, 14, 3, 3, "p");
-  // Marker tray with markers.
-  hLine(g, 3, 22, 26, "s");
-  setPx(g, 6, 21, "r");
-  setPx(g, 8, 21, "b");
-  setPx(g, 10, 21, "1");
+  // Title + bullet scribbles.
+  fillRect(g, 6, 4, 16, 2, "b");
+  setPx(g, 4, 9, "r");
+  hLine(g, 6, 9, 20, "S");
+  setPx(g, 4, 12, "r");
+  hLine(g, 6, 12, 16, "S");
+  setPx(g, 4, 15, "r");
+  hLine(g, 6, 15, 18, "S");
+  // Bar chart with axes.
+  vLine(g, 36, 6, 16, "S");
+  hLine(g, 36, 21, 22, "S");
+  fillRect(g, 38, 15, 3, 6, "t");
+  fillRect(g, 43, 11, 3, 10, "b");
+  fillRect(g, 48, 16, 3, 5, "r");
+  fillRect(g, 53, 8, 3, 13, "1");
+  // Rising green arrow.
+  for (let k = 0; k < 10; k += 1) setPx(g, 6 + k, 30 - k, "1");
+  setPx(g, 15, 20, "1");
+  setPx(g, 14, 20, "1");
+  setPx(g, 15, 22, "1");
+  // Extra note lines + pink sticky.
+  hLine(g, 24, 32, 12, "S");
+  hLine(g, 24, 35, 9, "S");
+  drawSticky(g, 51, 28, "p");
+  // Corner magnets.
+  fillRect(g, 4, 2, 2, 2, "r");
+  fillRect(g, 57, 2, 2, 2, "b");
+  fillRect(g, 4, 39, 2, 2, "y");
+  fillRect(g, 57, 39, 2, 2, "1");
+  // Markers resting on the tray.
+  fillRect(g, 20, 43, 6, 2, "r");
+  fillRect(g, 28, 43, 6, 2, "b");
+  fillRect(g, 36, 43, 6, 2, "1");
   return sprite("whiteboard", g);
 }
 
@@ -872,44 +1284,80 @@ function whiteboard(): PixelSprite {
 // Booths
 // ---------------------------------------------------------------------------
 
-/** Tall booth: rounded casing, glass pane, sign icon plate, base + shadow. */
+/** Tall booth: rounded casing, roof sign, glass door, base; icons drawn by caller. */
 function drawBooth(g: Grid, body: string, shade: string): void {
-  drawShadow(g, 3, 38, 10);
-  roundRect(g, 2, 0, 12, 38);
-  fillRect(g, 3, 1, 10, 36, body);
-  fillRect(g, 3, 1, 10, 3, shade);
-  // Glass pane with a shine.
-  outlineRect(g, 4, 5, 8, 17, "o");
-  fillRect(g, 5, 6, 6, 15, "q");
-  vLine(g, 6, 7, 5, "n");
-  // Icon plate + base.
-  fillRect(g, 5, 24, 6, 6, shade);
-  fillRect(g, 3, 34, 10, 3, shade);
+  drawShadow(g, 4, 77, 24);
+  // Casing with a shaded side and a band under the roof.
+  roundRect(g, 2, 8, 28, 66);
+  fillRound(g, 2, 8, 28, 66, body);
+  fillRect(g, 26, 10, 2, 62, shade);
+  fillRect(g, 3, 9, 26, 3, shade);
+  // Roof sign plate.
+  roundRect(g, 4, 0, 24, 9);
+  fillRound(g, 4, 0, 24, 9, shade);
+  // Glass door: frame, pale glass, tinted lower half, mid rail.
+  outlineRect(g, 6, 14, 20, 48, "o");
+  fillRect(g, 7, 15, 18, 46, "A");
+  fillRect(g, 7, 38, 18, 23, "q");
+  hLine(g, 6, 37, 20, "o");
+  // Door handle.
+  fillRect(g, 22, 40, 2, 7, "s");
+  vLine(g, 23, 40, 7, "S");
+  // Base band with vents and feet.
+  fillRect(g, 3, 66, 26, 6, shade);
+  hLine(g, 6, 68, 20, "V");
+  hLine(g, 6, 70, 20, "V");
+  fillRect(g, 5, 74, 5, 4, "V");
+  fillRect(g, 22, 74, 5, 4, "V");
+}
+
+/** Diagonal reflection streaks over booth glass. */
+function drawBoothReflection(g: Grid): void {
+  for (let k = 0; k < 13; k += 1) {
+    setPx(g, 9 + k, 16 + k, "n");
+    setPx(g, 10 + k, 16 + k, "n");
+  }
+  for (let k = 0; k < 7; k += 1) setPx(g, 8 + k, 42 + k, "n");
 }
 
 function phoneBooth(): PixelSprite {
-  const g = gridFor("phone_booth", 40);
+  const g = gridFor("phone_booth", 80);
   drawBooth(g, "t", "T");
-  // Handset icon on the roof band and the plate.
-  setPx(g, 5, 2, "n");
-  setPx(g, 10, 2, "n");
-  hLine(g, 6, 3, 4, "n");
-  setPx(g, 6, 26, "n");
-  setPx(g, 9, 26, "n");
-  hLine(g, 6, 27, 4, "n");
+  // White handset icon on the roof sign.
+  hLine(g, 10, 3, 12, "n");
+  fillRect(g, 9, 4, 3, 3, "n");
+  fillRect(g, 20, 4, 3, 3, "n");
+  // Interior hint: wall phone with a handset and keypad.
+  fillRect(g, 10, 22, 8, 10, "v");
+  vLine(g, 11, 23, 6, "n");
+  setPx(g, 14, 24, "x");
+  setPx(g, 16, 24, "x");
+  setPx(g, 14, 26, "x");
+  setPx(g, 16, 26, "x");
+  // Interior shelf line behind the glass.
+  hLine(g, 8, 44, 12, "T");
+  drawBoothReflection(g);
   return sprite("phone_booth", g);
 }
 
 function smsBooth(): PixelSprite {
-  const g = gridFor("sms_booth", 40);
+  const g = gridFor("sms_booth", 80);
   drawBooth(g, "8", "9");
-  // Speech bubble icons.
-  fillRect(g, 6, 2, 4, 2, "n");
-  setPx(g, 6, 4, "n");
-  fillRect(g, 5, 25, 6, 4, "n");
-  setPx(g, 6, 29, "n");
-  setPx(g, 6, 26, "9");
-  setPx(g, 8, 26, "9");
+  // White speech bubble icon with dots and a tail.
+  fillRect(g, 10, 2, 12, 5, "n");
+  trimCorners(g, 10, 2, 12, 5);
+  setPx(g, 12, 4, "9");
+  setPx(g, 15, 4, "9");
+  setPx(g, 18, 4, "9");
+  setPx(g, 12, 7, "n");
+  setPx(g, 11, 7, "n");
+  // Interior hint: glowing message screen.
+  fillRect(g, 10, 22, 10, 8, "v");
+  fillRect(g, 11, 23, 8, 6, "c");
+  hLine(g, 12, 24, 5, "n");
+  hLine(g, 12, 26, 4, "n");
+  hLine(g, 8, 44, 12, "9");
+  drawBoothReflection(g);
   return sprite("sms_booth", g);
 }
 
@@ -918,55 +1366,69 @@ function smsBooth(): PixelSprite {
 // ---------------------------------------------------------------------------
 
 function treadmill(): PixelSprite {
-  const g = gridFor("treadmill", 32);
-  // Console (top-down).
-  roundRect(g, 2, 0, 12, 6);
-  fillRect(g, 3, 1, 10, 4, "m");
-  fillRect(g, 5, 2, 6, 2, "c");
-  setPx(g, 6, 2, "n");
-  setPx(g, 11, 2, "r");
-  setPx(g, 11, 3, "y");
-  // Side rails.
-  vLine(g, 1, 5, 26, "o");
-  vLine(g, 2, 5, 26, "s");
-  vLine(g, 14, 5, 26, "o");
-  vLine(g, 13, 5, 26, "s");
-  // Gray-blue belt with tread stripes.
-  fillRect(g, 3, 6, 10, 24, "v");
-  hLine(g, 3, 6, 10, "V");
-  for (let y = 8; y < 30; y += 4) hLine(g, 3, y, 10, "V");
-  hLine(g, 3, 30, 10, "v");
-  hLine(g, 1, 31, 14, "o");
+  const g = gridFor("treadmill", 64);
+  drawShadow(g, 5, 61, 22);
+  // Console with a display and buttons.
+  roundRect(g, 4, 0, 24, 9);
+  fillRound(g, 4, 0, 24, 9, "m");
+  fillRect(g, 8, 2, 12, 4, "c");
+  hLine(g, 9, 3, 4, "n");
+  setPx(g, 17, 3, "r");
+  fillRect(g, 22, 3, 2, 2, "r");
+  fillRect(g, 25, 3, 2, 2, "y");
+  // Side rails running the full deck.
+  vLine(g, 2, 8, 52, "o");
+  fillRect(g, 3, 8, 2, 52, "s");
+  vLine(g, 29, 8, 52, "o");
+  fillRect(g, 27, 8, 2, 52, "s");
+  // Deck frame + belt with tread stripes.
+  fillRect(g, 5, 10, 22, 51, "V");
+  fillRect(g, 7, 12, 18, 46, "v");
+  hLine(g, 7, 12, 18, "j");
+  for (let y = 17; y < 58; y += 6) hLine(g, 7, y, 18, "V");
+  // Rear roller line.
+  hLine(g, 7, 56, 18, "S");
   return sprite("treadmill", g);
 }
 
-/** Dumbbell: two colored plates and a steel bar. */
+/** Dumbbell: two outlined colored plates joined by a steel bar. */
 function drawDumbbell(g: Grid, x: number, y: number, ch: string): void {
-  fillRect(g, x, y, 2, 4, ch);
-  hLine(g, x + 2, y + 1, 2, "s");
-  hLine(g, x + 2, y + 2, 2, "S");
-  fillRect(g, x + 4, y, 2, 4, ch);
+  outlineRect(g, x, y, 5, 10, "o");
+  fillRect(g, x + 1, y + 1, 3, 8, ch);
+  setPx(g, x + 1, y + 1, "n");
+  fillRect(g, x + 5, y + 4, 5, 2, "s");
+  hLine(g, x + 5, y + 6, 5, "S");
+  outlineRect(g, x + 10, y, 5, 10, "o");
+  fillRect(g, x + 11, y + 1, 3, 8, ch);
+  setPx(g, x + 11, y + 1, "n");
 }
 
 function dumbbellRack(): PixelSprite {
-  const g = gridFor("dumbbell_rack", 22);
-  drawShadow(g, 2, 20, 28);
-  // Slate posts.
-  vLine(g, 1, 3, 17, "v");
-  vLine(g, 2, 3, 17, "V");
-  vLine(g, 29, 3, 17, "V");
-  vLine(g, 30, 3, 17, "v");
-  // Two shelf bars.
-  hLine(g, 3, 9, 26, "v");
-  hLine(g, 3, 10, 26, "V");
-  hLine(g, 3, 16, 26, "v");
-  hLine(g, 3, 17, 26, "V");
-  // Weights.
-  drawDumbbell(g, 4, 5, "r");
-  drawDumbbell(g, 13, 5, "b");
-  drawDumbbell(g, 22, 5, "y");
-  drawDumbbell(g, 8, 12, "1");
-  drawDumbbell(g, 18, 12, "u");
+  const g = gridFor("dumbbell_rack", 44);
+  drawShadow(g, 3, 41, 58);
+  // Slate side posts.
+  vLine(g, 1, 4, 36, "o");
+  fillRect(g, 2, 4, 4, 36, "v");
+  vLine(g, 5, 4, 36, "V");
+  vLine(g, 62, 4, 36, "o");
+  fillRect(g, 58, 4, 4, 36, "v");
+  vLine(g, 58, 4, 36, "V");
+  // Two shelf tiers.
+  fillRect(g, 5, 16, 54, 4, "v");
+  hLine(g, 5, 16, 54, "s");
+  hLine(g, 5, 19, 54, "V");
+  fillRect(g, 5, 30, 54, 4, "v");
+  hLine(g, 5, 30, 54, "s");
+  hLine(g, 5, 33, 54, "V");
+  // Feet.
+  fillRect(g, 1, 38, 6, 4, "V");
+  fillRect(g, 57, 38, 6, 4, "V");
+  // Color-coded weights on both tiers.
+  drawDumbbell(g, 7, 6, "r");
+  drawDumbbell(g, 25, 6, "b");
+  drawDumbbell(g, 43, 6, "y");
+  drawDumbbell(g, 15, 20, "1");
+  drawDumbbell(g, 33, 20, "u");
   return sprite("dumbbell_rack", g);
 }
 
@@ -975,71 +1437,114 @@ function dumbbellRack(): PixelSprite {
 // ---------------------------------------------------------------------------
 
 function serverRack(): PixelSprite {
-  const g = gridFor("server_rack", 30);
-  drawShadow(g, 3, 28, 10);
-  outlineRect(g, 2, 0, 12, 28, "o");
-  fillRect(g, 3, 1, 10, 26, "v");
-  hLine(g, 3, 1, 10, "j");
-  // Rack units with vents and green + amber LEDs.
+  const g = gridFor("server_rack", 72);
+  drawShadow(g, 4, 69, 24);
+  // Cabinet with a lit top edge and shaded side.
+  roundRect(g, 2, 0, 28, 66);
+  fillRound(g, 2, 0, 28, 66, "v");
+  hLine(g, 4, 1, 24, "j");
+  fillRect(g, 26, 2, 2, 62, "V");
+  // Four rack units: vents, LED clusters, drive slots.
   for (let i = 0; i < 4; i += 1) {
-    const y = 3 + i * 6;
-    fillRect(g, 4, y, 8, 4, "V");
-    hLine(g, 5, y + 2, 4, "x");
-    setPx(g, 10, y + 1, "L");
-    setPx(g, 11, y + 1, i % 2 === 0 ? "a" : "L");
+    const uy = 4 + i * 13;
+    fillRect(g, 4, uy, 24, 10, "V");
+    hLine(g, 4, uy, 24, "S");
+    hLine(g, 6, uy + 3, 10, "x");
+    hLine(g, 6, uy + 5, 10, "x");
+    hLine(g, 6, uy + 7, 10, "x");
+    setPx(g, 20, uy + 3, "L");
+    setPx(g, 22, uy + 3, "L");
+    setPx(g, 24, uy + 3, "L");
+    setPx(g, 20, uy + 5, "a");
+    setPx(g, 22, uy + 5, "a");
+    setPx(g, 24, uy + 5, i === 2 ? "r" : "L");
+    hLine(g, 18, uy + 8, 8, "S");
   }
-  hLine(g, 3, 26, 10, "V");
+  // Cable hints in the gaps between units.
+  for (const cy of [15, 28, 41]) {
+    setPx(g, 23, cy, "y");
+    setPx(g, 24, cy + 1, "y");
+    setPx(g, 20, cy, "c");
+    setPx(g, 21, cy + 1, "c");
+  }
+  // Base band with vents + feet.
+  fillRect(g, 4, 56, 24, 6, "V");
+  hLine(g, 6, 58, 20, "x");
+  fillRect(g, 5, 66, 4, 4, "V");
+  fillRect(g, 23, 66, 4, 4, "V");
   return sprite("server_rack", g);
 }
 
 function tvStand(): PixelSprite {
-  const g = gridFor("tv_stand", 26);
-  drawShadow(g, 2, 24, 28);
-  // Wood console.
-  roundRect(g, 1, 13, 30, 10);
-  fillRect(g, 2, 14, 28, 8, "w");
-  hLine(g, 2, 14, 28, "k");
-  vLine(g, 11, 15, 6, "W");
-  vLine(g, 21, 15, 6, "W");
-  setPx(g, 9, 17, "W");
-  setPx(g, 23, 17, "W");
-  hLine(g, 2, 21, 28, "W");
-  fillRect(g, 3, 23, 2, 1, "W");
-  fillRect(g, 27, 23, 2, 1, "W");
-  // TV with a colorful sunset scene.
-  outlineRect(g, 4, 0, 24, 12, "o");
-  fillRect(g, 5, 1, 22, 10, "m");
-  fillRect(g, 6, 2, 20, 4, "c");
-  fillRect(g, 21, 3, 3, 2, "y");
-  fillRect(g, 6, 6, 20, 4, "1");
-  fillRect(g, 6, 8, 20, 2, "g");
-  hLine(g, 8, 12, 3, "m");
-  hLine(g, 21, 12, 3, "m");
+  const g = gridFor("tv_stand", 52);
+  drawShadow(g, 3, 49, 58);
+  // Wood console with doors, knobs, and feet.
+  roundRect(g, 1, 30, 62, 17);
+  fillRound(g, 1, 30, 62, 17, "w");
+  fillRect(g, 3, 31, 58, 3, "k");
+  outlineRect(g, 8, 35, 20, 9, "W");
+  outlineRect(g, 36, 35, 20, 9, "W");
+  fillRect(g, 24, 38, 2, 2, "k");
+  fillRect(g, 38, 38, 2, 2, "k");
+  fillRect(g, 2, 44, 60, 2, "W");
+  fillRect(g, 4, 47, 4, 3, "W");
+  fillRect(g, 56, 47, 4, 3, "W");
+  // TV with a colorful landscape scene.
+  outlineRect(g, 8, 0, 48, 24, "o");
+  fillRect(g, 9, 1, 46, 22, "m");
+  fillRect(g, 11, 3, 42, 10, "c");
+  fillRect(g, 42, 5, 6, 4, "y");
+  trimCorners(g, 42, 5, 6, 4);
+  hLine(g, 16, 6, 7, "n");
+  hLine(g, 18, 7, 5, "n");
+  fillRect(g, 11, 13, 42, 4, "l");
+  fillRect(g, 11, 17, 42, 4, "g");
+  fillRect(g, 22, 15, 4, 4, "G");
+  // Stand neck + soundbar with a grill.
+  fillRect(g, 29, 24, 6, 3, "m");
+  fillRect(g, 14, 27, 36, 3, "v");
+  for (let sx = 16; sx <= 45; sx += 3) setPx(g, sx, 28, "x");
+  setPx(g, 47, 28, "L");
   return sprite("tv_stand", g);
 }
 
 function atm(): PixelSprite {
-  const g = gridFor("atm", 26);
-  drawShadow(g, 3, 24, 10);
-  roundRect(g, 2, 0, 12, 24);
-  fillRect(g, 3, 1, 10, 22, "s");
-  vLine(g, 12, 2, 21, "S");
-  fillRect(g, 3, 1, 10, 2, "t");
-  // Small green screen.
-  outlineRect(g, 4, 4, 8, 6, "o");
-  fillRect(g, 5, 5, 6, 4, "M");
-  hLine(g, 6, 6, 3, "1");
-  hLine(g, 6, 8, 2, "1");
-  // Keypad, card slot, cash tray.
-  for (const y of [12, 14]) {
-    setPx(g, 5, y, "x");
-    setPx(g, 7, y, "x");
-    setPx(g, 9, y, "x");
+  const g = gridFor("atm", 52);
+  drawShadow(g, 4, 49, 24);
+  // Steel kiosk with a teal header.
+  roundRect(g, 2, 0, 28, 46);
+  fillRound(g, 2, 0, 28, 46, "s");
+  fillRect(g, 26, 2, 2, 42, "S");
+  fillRect(g, 3, 1, 26, 5, "t");
+  hLine(g, 8, 3, 4, "n");
+  vLine(g, 15, 2, 3, "n");
+  hLine(g, 18, 3, 5, "n");
+  // Green screen with text lines.
+  outlineRect(g, 6, 8, 20, 13, "o");
+  fillRect(g, 7, 9, 18, 11, "M");
+  hLine(g, 9, 11, 8, "1");
+  hLine(g, 9, 13, 12, "1");
+  hLine(g, 9, 15, 6, "1");
+  hLine(g, 9, 17, 8, "c");
+  // Keypad grid.
+  for (let kr = 0; kr < 4; kr += 1) {
+    for (let kc = 0; kc < 3; kc += 1) {
+      fillRect(g, 7 + kc * 4, 24 + kr * 3, 3, 2, "x");
+    }
   }
-  hLine(g, 5, 17, 6, "x");
-  fillRect(g, 5, 19, 6, 2, "V");
-  hLine(g, 6, 20, 4, "x");
-  hLine(g, 3, 22, 10, "S");
+  // Card slot with an LED + receipt slot.
+  setPx(g, 24, 22, "L");
+  fillRect(g, 21, 24, 7, 2, "V");
+  hLine(g, 22, 24, 5, "x");
+  fillRect(g, 21, 29, 7, 2, "V");
+  hLine(g, 22, 29, 5, "x");
+  // Cash tray.
+  fillRect(g, 6, 37, 20, 5, "V");
+  fillRect(g, 8, 39, 16, 2, "x");
+  // Base + feet.
+  fillRect(g, 3, 42, 26, 3, "S");
+  fillRect(g, 5, 46, 4, 4, "V");
+  fillRect(g, 23, 46, 4, 4, "V");
   return sprite("atm", g);
 }
 
@@ -1048,95 +1553,152 @@ function atm(): PixelSprite {
 // ---------------------------------------------------------------------------
 
 function rug(): PixelSprite {
-  const g = gridFor("rug", 32);
-  // Round cream rug with a terracotta ring (hard threshold, no AA).
-  const cx = 15.5;
-  const cy = 15.5;
-  const radius = 16;
-  for (let y = 0; y < 32; y += 1) {
-    for (let x = 0; x < 32; x += 1) {
+  const g = gridFor("rug", 64);
+  // Round cream rug with a double terracotta ring (hard threshold, no AA).
+  const cx = 31.5;
+  const cy = 31.5;
+  const radius = 32;
+  for (let y = 0; y < 64; y += 1) {
+    for (let x = 0; x < 64; x += 1) {
       const nx = (x - cx) / radius;
       const ny = (y - cy) / radius;
       const rr = nx * nx + ny * ny;
       if (rr > 1) continue;
-      if (rr > 0.8) setPx(g, x, y, "R");
-      else if (rr > 0.36) setPx(g, x, y, "0");
-      else if (rr > 0.22) setPx(g, x, y, "R");
+      if (rr > 0.88) setPx(g, x, y, "R");
+      else if (rr > 0.78) setPx(g, x, y, "0");
+      else if (rr > 0.68) setPx(g, x, y, "R");
+      else if (rr > 0.24) setPx(g, x, y, "0");
+      else if (rr > 0.14) setPx(g, x, y, "R");
       else setPx(g, x, y, "0");
     }
   }
-  // Small center motif.
-  fillRect(g, 15, 15, 2, 2, "R");
+  // Center medallion diamond.
+  for (let y = 0; y < 64; y += 1) {
+    for (let x = 0; x < 64; x += 1) {
+      if (Math.abs(x - cx) + Math.abs(y - cy) < 5) setPx(g, x, y, "R");
+    }
+  }
+  // Eight small motif crosses around the field.
+  for (let k = 0; k < 8; k += 1) {
+    const ang = (k * Math.PI) / 4;
+    const mx = Math.round(cx + 15 * Math.cos(ang));
+    const my = Math.round(cy + 15 * Math.sin(ang));
+    setPx(g, mx, my - 1, "R");
+    setPx(g, mx - 1, my, "R");
+    setPx(g, mx, my, "R");
+    setPx(g, mx + 1, my, "R");
+    setPx(g, mx, my + 1, "R");
+  }
   return sprite("rug", g);
 }
 
 function lamp(): PixelSprite {
-  const g = gridFor("lamp", 30);
-  drawShadow(g, 4, 28, 8);
-  // Warm halo.
-  fillRect(g, 3, 0, 10, 9, "Y");
-  trimCorners(g, 3, 0, 10, 9);
-  // Shade (trapezoid).
-  hLine(g, 6, 1, 4, "o");
-  setPx(g, 5, 2, "o");
-  fillRect(g, 6, 2, 4, 1, "y");
-  setPx(g, 10, 2, "o");
-  setPx(g, 5, 3, "o");
-  fillRect(g, 6, 3, 4, 1, "y");
-  setPx(g, 10, 3, "o");
-  setPx(g, 4, 4, "o");
-  fillRect(g, 5, 4, 6, 1, "y");
-  setPx(g, 11, 4, "o");
-  setPx(g, 4, 5, "o");
-  fillRect(g, 5, 5, 6, 1, "a");
-  setPx(g, 11, 5, "o");
-  hLine(g, 4, 6, 8, "o");
-  // Pole + base.
-  vLine(g, 7, 7, 18, "o");
-  vLine(g, 8, 7, 18, "v");
-  hLine(g, 6, 25, 4, "v");
-  hLine(g, 5, 26, 6, "v");
-  hLine(g, 4, 27, 8, "V");
+  const g = gridFor("lamp", 60);
+  drawShadow(g, 8, 57, 16);
+  // Translucent warm halo painted first so the shade covers its center.
+  for (let y = 0; y < 22; y += 1) {
+    for (let x = 3; x < 29; x += 1) {
+      if ((x - 16) * (x - 16) + (y - 9) * (y - 9) <= 144) setPx(g, x, y, "K");
+    }
+  }
+  // Trapezoid shade: lit yellow top, amber base, glowing mouth.
+  hLine(g, 11, 2, 10, "o");
+  for (let r = 0; r < 10; r += 1) {
+    const half = 5 + Math.floor(r / 2);
+    const left = 15 - half;
+    const right = 16 + half;
+    const row = 3 + r;
+    setPx(g, left, row, "o");
+    setPx(g, right, row, "o");
+    const body = r < 6 ? "y" : "a";
+    hLine(g, left + 1, row, right - left - 1, body);
+  }
+  hLine(g, 7, 12, 18, "Y");
+  hLine(g, 7, 13, 18, "o");
+  setPx(g, 15, 1, "o");
+  setPx(g, 16, 1, "o");
+  // Pole with a highlight and shade.
+  vLine(g, 15, 14, 36, "o");
+  vLine(g, 16, 14, 36, "v");
+  vLine(g, 17, 14, 36, "V");
+  // Domed base.
+  hLine(g, 13, 50, 6, "v");
+  hLine(g, 11, 51, 10, "v");
+  fillRect(g, 9, 52, 14, 2, "v");
+  fillRect(g, 8, 54, 16, 2, "V");
+  hLine(g, 8, 56, 16, "o");
   return sprite("lamp", g);
 }
 
-/** Small orange fish; dir 1 faces right, -1 faces left. */
-function drawFish(g: Grid, x: number, y: number, dir: 1 | -1): void {
-  fillRect(g, x, y, 3, 2, "a");
-  const tailX = dir === 1 ? x - 1 : x + 3;
-  setPx(g, tailX, y, "8");
-  setPx(g, tailX, y + 1, "8");
-  setPx(g, dir === 1 ? x + 2 : x, y, "x");
+/** Small fish: colored body, contrasting tail; dir 1 faces right, -1 left. */
+function drawFish(
+  g: Grid,
+  x: number,
+  y: number,
+  dir: 1 | -1,
+  body: string,
+  tail: string,
+): void {
+  fillRect(g, x, y, 5, 3, body);
+  trimCorners(g, x, y, 5, 3);
+  setPx(g, x + 2, y - 1, tail);
+  const tailX = dir === 1 ? x - 2 : x + 5;
+  fillRect(g, tailX, y, 2, 3, tail);
+  setPx(g, dir === 1 ? x + 3 : x + 1, y + 1, "x");
 }
 
 function aquarium(): PixelSprite {
-  const g = gridFor("aquarium", 26);
-  drawShadow(g, 2, 24, 28);
-  // Tank.
-  outlineRect(g, 1, 0, 30, 17, "o");
-  hLine(g, 2, 1, 28, "s");
-  fillRect(g, 2, 2, 28, 14, "q");
-  fillRect(g, 2, 11, 28, 5, "Q");
-  hLine(g, 2, 15, 28, "S");
-  // Plants.
-  vLine(g, 4, 9, 6, "g");
-  setPx(g, 3, 10, "l");
-  setPx(g, 5, 12, "l");
-  vLine(g, 27, 8, 7, "g");
-  setPx(g, 26, 9, "l");
-  setPx(g, 28, 12, "G");
-  // Fish + bubbles.
-  drawFish(g, 8, 5, 1);
-  drawFish(g, 19, 9, -1);
-  setPx(g, 14, 4, "n");
-  setPx(g, 15, 7, "n");
-  setPx(g, 13, 10, "n");
-  setPx(g, 24, 4, "n");
-  // Slate stand.
-  outlineRect(g, 1, 17, 30, 7, "o");
-  fillRect(g, 2, 18, 28, 5, "v");
-  vLine(g, 15, 18, 5, "V");
-  hLine(g, 2, 22, 28, "V");
+  const g = gridFor("aquarium", 52);
+  drawShadow(g, 3, 49, 58);
+  // Tank with a steel rim.
+  outlineRect(g, 2, 0, 60, 36, "o");
+  fillRect(g, 3, 1, 58, 3, "s");
+  hLine(g, 4, 3, 56, "S");
+  // Water gradient: pale surface, mid blue, deep bottom.
+  fillRect(g, 3, 4, 58, 5, "A");
+  fillRect(g, 3, 9, 58, 14, "q");
+  fillRect(g, 3, 23, 58, 8, "Q");
+  // Gravel bed.
+  fillRect(g, 3, 31, 58, 4, "S");
+  for (let x = 4; x < 61; x += 3) setPx(g, x, 31, "2");
+  for (let x = 5; x < 61; x += 4) setPx(g, x, 33, "h");
+  hLine(g, 3, 34, 58, "F");
+  // Wavy seaweed strands + a leafy bush.
+  for (let k = 0; k < 14; k += 1) {
+    setPx(g, 10 + ((k >> 2) % 2), 30 - k, "g");
+  }
+  setPx(g, 9, 18, "l");
+  setPx(g, 12, 23, "l");
+  for (let k = 0; k < 9; k += 1) {
+    setPx(g, 15 + ((k >> 1) % 2), 30 - k, "G");
+  }
+  fillRect(g, 47, 24, 9, 7, "G");
+  trimCorners(g, 47, 24, 9, 7);
+  setPx(g, 48, 24, "g");
+  setPx(g, 50, 25, "g");
+  setPx(g, 49, 27, "l");
+  setPx(g, 53, 26, "g");
+  // Three fish.
+  drawFish(g, 20, 12, 1, "a", "8");
+  drawFish(g, 38, 17, -1, "y", "a");
+  drawFish(g, 27, 24, 1, "p", "u");
+  // Bubbles rising near the bush.
+  setPx(g, 52, 6, "n");
+  setPx(g, 54, 10, "n");
+  setPx(g, 51, 14, "n");
+  setPx(g, 53, 18, "n");
+  fillRect(g, 52, 21, 2, 2, "n");
+  trimCorners(g, 52, 21, 2, 2);
+  // Slate stand with doors + feet.
+  roundRect(g, 1, 36, 62, 12);
+  fillRound(g, 1, 36, 62, 12, "v");
+  hLine(g, 3, 37, 58, "j");
+  vLine(g, 31, 39, 7, "V");
+  fillRect(g, 27, 41, 2, 2, "S");
+  fillRect(g, 34, 41, 2, 2, "S");
+  fillRect(g, 2, 45, 60, 2, "V");
+  fillRect(g, 4, 47, 5, 3, "V");
+  fillRect(g, 55, 47, 5, 3, "V");
   return sprite("aquarium", g);
 }
 

--- a/src/features/pixel-office/art/grid.ts
+++ b/src/features/pixel-office/art/grid.ts
@@ -1,0 +1,67 @@
+// Internal mutable char-grid helpers used to compose sprites in code.
+// Not part of the public art API (not re-exported from index.ts).
+
+export type Grid = string[][];
+
+/** Creates a w x h grid filled with the given char (transparent by default). */
+export function makeGrid(width: number, height: number, fill = "."): Grid {
+  const grid: Grid = [];
+  for (let y = 0; y < height; y += 1) {
+    grid.push(new Array<string>(width).fill(fill));
+  }
+  return grid;
+}
+
+/** Sets one cell; out-of-bounds writes are silently ignored. */
+export function setPx(grid: Grid, x: number, y: number, ch: string): void {
+  if (y < 0 || y >= grid.length) return;
+  const row = grid[y];
+  if (x < 0 || x >= row.length) return;
+  row[x] = ch;
+}
+
+/** Fills a solid rectangle. */
+export function fillRect(
+  grid: Grid,
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+  ch: string,
+): void {
+  for (let yy = y; yy < y + h; yy += 1) {
+    for (let xx = x; xx < x + w; xx += 1) {
+      setPx(grid, xx, yy, ch);
+    }
+  }
+}
+
+/** Draws only the 1px border of a rectangle. */
+export function outlineRect(
+  grid: Grid,
+  x: number,
+  y: number,
+  w: number,
+  h: number,
+  ch: string,
+): void {
+  hLine(grid, x, y, w, ch);
+  hLine(grid, x, y + h - 1, w, ch);
+  vLine(grid, x, y, h, ch);
+  vLine(grid, x + w - 1, y, h, ch);
+}
+
+/** Horizontal line of length len starting at (x, y). */
+export function hLine(grid: Grid, x: number, y: number, len: number, ch: string): void {
+  for (let xx = x; xx < x + len; xx += 1) setPx(grid, xx, y, ch);
+}
+
+/** Vertical line of length len starting at (x, y). */
+export function vLine(grid: Grid, x: number, y: number, len: number, ch: string): void {
+  for (let yy = y; yy < y + len; yy += 1) setPx(grid, x, yy, ch);
+}
+
+/** Joins the grid into sprite rows. */
+export function gridRows(grid: Grid): string[] {
+  return grid.map((row) => row.join(""));
+}

--- a/src/features/pixel-office/art/index.ts
+++ b/src/features/pixel-office/art/index.ts
@@ -1,0 +1,5 @@
+export * from "./palette";
+export { makeSprite, paintSpriteToContext, spriteHeight, spriteWidth } from "./sprite";
+export { buildGroundTileSprites } from "./tiles";
+export { buildFurnitureSprites } from "./furniture";
+export { buildCharacterFrames, mirrorSprite, JANITOR_LOOK } from "./characters";

--- a/src/features/pixel-office/art/palette.ts
+++ b/src/features/pixel-office/art/palette.ts
@@ -1,0 +1,100 @@
+// Named color constants for the Gather-style pixel office look.
+// All values are "#rrggbb" (or "#rrggbbaa" for translucent shadows).
+
+// ---------------------------------------------------------------------------
+// Ground tiles.
+// ---------------------------------------------------------------------------
+
+export const GRASS_BASE = "#7bc850";
+export const GRASS_BLADE = "#63ad3f";
+export const GRASS_ALT_BASE = "#76c24d";
+export const GRASS_DARK_BASE = "#63ad3f";
+export const GRASS_DARK_BLADE = "#529636";
+
+export const PATH_BASE = "#d9c79a";
+export const PATH_SPECKLE = "#c9b283";
+
+export const FLOOR_CREAM = "#f2e6cf";
+export const FLOOR_CREAM_LINE = "#e6d6b8";
+export const FLOOR_WHITE = "#f7f5f0";
+export const FLOOR_WHITE_LINE = "#eae7df";
+export const FLOOR_WOOD = "#d8a86e";
+export const FLOOR_WOOD_SEAM = "#c39257";
+
+export const CARPET_PURPLE = "#a9a3d6";
+export const CARPET_PURPLE_DOT = "#9a93cb";
+export const CARPET_BLUE = "#8fb7d9";
+export const CARPET_BLUE_DOT = "#7fa6c9";
+
+export const KITCHEN_TILE_LIGHT = "#e8e2d4";
+export const KITCHEN_TILE_DARK = "#dcd4c2";
+
+export const GYM_MAT = "#b8c9d9";
+export const GYM_MAT_LINE = "#a5b8ca";
+
+export const SERVER_FLOOR = "#4a5568";
+export const SERVER_FLOOR_GRID = "#3d4759";
+
+export const WALL_TOP = "#3d4258";
+export const WALL_FACE = "#565d7a";
+export const WALL_EDGE = "#6b7394";
+
+// ---------------------------------------------------------------------------
+// Furniture.
+// ---------------------------------------------------------------------------
+
+export const OUTLINE = "#2b2b3a";
+export const NEAR_BLACK = "#1d1f28";
+
+export const FURN_WOOD = "#a06a3c";
+export const FURN_WOOD_DARK = "#7d5230";
+export const FURN_WOOD_LIGHT = "#b8824f";
+
+export const DESK_WHITE = "#f5f2ec";
+export const DESK_WHITE_SHADE = "#ddd8ce";
+
+export const MONITOR_DARK = "#2a2e3d";
+export const SCREEN_ON = "#7ec8e3";
+export const SCREEN_OFF = "#3a3f52";
+
+export const PAPER_WHITE = "#f9f8f4";
+export const PAPER_SHADE = "#d9d9d2";
+
+export const STEEL = "#aab2c0";
+export const STEEL_DARK = "#7d8595";
+
+export const LEAF_GREEN = "#4f9e43";
+export const LEAF_GREEN_DARK = "#3c7d33";
+export const LEAF_GREEN_LIGHT = "#6dbb5a";
+
+export const ACCENT_RED = "#c94f43";
+export const ACCENT_RED_DARK = "#9c382f";
+export const SOFA_ORANGE = "#e08a4e";
+export const SOFA_ORANGE_DARK = "#b96a35";
+export const SOFA_ORANGE_LIGHT = "#f0a86a";
+export const ACCENT_YELLOW = "#e8c832";
+export const WARM_GLOW = "#f7e9b6";
+export const ACCENT_AMBER = "#e3a23c";
+export const ACCENT_BLUE = "#5a8fd9";
+export const ACCENT_BLUE_DARK = "#3f6cab";
+export const WATER_AQUA = "#79c2e8";
+export const WATER_AQUA_DARK = "#5497c4";
+export const ACCENT_TEAL = "#4fb8b0";
+export const ACCENT_TEAL_DARK = "#37918a";
+export const ACCENT_PURPLE = "#8f7fd0";
+export const ACCENT_MAGENTA = "#d95fb0";
+export const RUG_RED = "#b56a5a";
+export const RUG_RED_DARK = "#9c5548";
+export const LED_GREEN = "#5fdc7a";
+export const SOFT_SHADOW = "#00000030";
+
+// ---------------------------------------------------------------------------
+// Characters.
+// ---------------------------------------------------------------------------
+
+export const CHAR_OUTLINE = "#262833";
+export const CHAR_SHOE = "#2f3140";
+export const CHAR_EYE = "#23252e";
+export const CHAR_WHITE = "#ffffff";
+export const CAP_YELLOW = "#e8c832";
+export const FALLBACK_SHIRT = "#4a90d9";

--- a/src/features/pixel-office/art/palette.ts
+++ b/src/features/pixel-office/art/palette.ts
@@ -9,22 +9,31 @@
 
 export const GRASS_BASE = "#b5dc9c";
 export const GRASS_MOTTLE = "#c3e5ab";
+export const GRASS_MOTTLE_DEEP = "#aad48f";
 export const GRASS_BLADE = "#9ccb80";
 export const GRASS_FLOWER = "#f7f3e9";
+export const GRASS_FLOWER_PINK = "#f3cdd8";
+export const GRASS_FLOWER_CENTER = "#f0d98c";
 export const GRASS_ALT_BASE = "#b3da99";
 export const GRASS_DARK_BASE = "#a2cf88";
 export const GRASS_DARK_MOTTLE = "#aed695";
+export const GRASS_DARK_MOTTLE_DEEP = "#97c67c";
 export const GRASS_DARK_BLADE = "#90bf75";
 
 export const PATH_BASE = "#e3ddd0";
 export const PATH_SPECKLE = "#d7d0c0";
+export const PATH_PEBBLE_LIGHT = "#ece7db";
 
 export const FLOOR_CREAM = "#f4efe4";
-export const FLOOR_CREAM_CHECK = "#f2ece0";
+export const FLOOR_CREAM_CHECK = "#f3ede1";
 export const FLOOR_CREAM_LINE = "#ebe4d5";
 export const FLOOR_WHITE = "#f8f7f3";
-export const FLOOR_WHITE_LINE = "#f5f3ee";
+export const FLOOR_WHITE_LINE = "#f6f5f0";
+export const FLOOR_WHITE_SPECK = "#efede6";
+
 export const FLOOR_WOOD = "#ecd9c3";
+export const FLOOR_WOOD_TONE = "#e9d4bc";
+export const FLOOR_WOOD_LIGHT = "#f0dfcb";
 export const FLOOR_WOOD_SEAM = "#dfc9ae";
 export const FLOOR_WOOD_GRAIN = "#e5d1b8";
 
@@ -35,22 +44,32 @@ export const CARPET_BLUE_DOT = "#9dbcdc";
 
 export const KITCHEN_TILE_LIGHT = "#e4e6dd";
 export const KITCHEN_TILE_DARK = "#d8dbd0";
+export const KITCHEN_TILE_LIGHT_BEVEL = "#eef0e8";
+export const KITCHEN_TILE_DARK_BEVEL = "#e2e5da";
 
 export const GYM_MAT = "#c4d2e0";
 export const GYM_MAT_LINE = "#b3c3d4";
+export const GYM_MAT_SEAM = "#bccbd9";
 
 export const SERVER_FLOOR = "#5b6478";
 export const SERVER_FLOOR_GRID = "#4e576a";
+export const SERVER_FLOOR_LIGHT = "#677085";
+export const SERVER_FLOOR_VENT = "#454e60";
 
 export const WALL_TOP = "#6e7687";
+export const WALL_TOP_SHEEN = "#767e8e";
 export const WALL_FACE = "#8b93a4";
 export const WALL_EDGE = "#9aa2b2";
 export const WALL_SEAM = "#7e8697";
+export const WALL_SEAM_HIGHLIGHT = "#959dad";
 export const WALL_BASEBOARD = "#626a7a";
+export const WALL_FLOOR_SHADOW = "#565e6e";
 
 export const WINDOW_GLASS = "#bfe2f4";
+export const WINDOW_SKY_TOP = "#cfeaf8";
 export const WINDOW_SHEEN = "#e8f6fd";
 export const WINDOW_FRAME = "#f2f4f6";
+export const WINDOW_SILL_SHADOW = "#d9dde2";
 
 // ---------------------------------------------------------------------------
 // Furniture.

--- a/src/features/pixel-office/art/palette.ts
+++ b/src/features/pixel-office/art/palette.ts
@@ -3,41 +3,54 @@
 
 // ---------------------------------------------------------------------------
 // Ground tiles.
+// Soft pastel Gather-style palette: light desaturated bases with
+// low-contrast texture accents so large floor areas read calm, not busy.
 // ---------------------------------------------------------------------------
 
-export const GRASS_BASE = "#7bc850";
-export const GRASS_BLADE = "#63ad3f";
-export const GRASS_ALT_BASE = "#76c24d";
-export const GRASS_DARK_BASE = "#63ad3f";
-export const GRASS_DARK_BLADE = "#529636";
+export const GRASS_BASE = "#b5dc9c";
+export const GRASS_MOTTLE = "#c3e5ab";
+export const GRASS_BLADE = "#9ccb80";
+export const GRASS_FLOWER = "#f7f3e9";
+export const GRASS_ALT_BASE = "#b3da99";
+export const GRASS_DARK_BASE = "#a2cf88";
+export const GRASS_DARK_MOTTLE = "#aed695";
+export const GRASS_DARK_BLADE = "#90bf75";
 
-export const PATH_BASE = "#d9c79a";
-export const PATH_SPECKLE = "#c9b283";
+export const PATH_BASE = "#e3ddd0";
+export const PATH_SPECKLE = "#d7d0c0";
 
-export const FLOOR_CREAM = "#f2e6cf";
-export const FLOOR_CREAM_LINE = "#e6d6b8";
-export const FLOOR_WHITE = "#f7f5f0";
-export const FLOOR_WHITE_LINE = "#eae7df";
-export const FLOOR_WOOD = "#d8a86e";
-export const FLOOR_WOOD_SEAM = "#c39257";
+export const FLOOR_CREAM = "#f4efe4";
+export const FLOOR_CREAM_CHECK = "#f2ece0";
+export const FLOOR_CREAM_LINE = "#ebe4d5";
+export const FLOOR_WHITE = "#f8f7f3";
+export const FLOOR_WHITE_LINE = "#f5f3ee";
+export const FLOOR_WOOD = "#ecd9c3";
+export const FLOOR_WOOD_SEAM = "#dfc9ae";
+export const FLOOR_WOOD_GRAIN = "#e5d1b8";
 
-export const CARPET_PURPLE = "#a9a3d6";
-export const CARPET_PURPLE_DOT = "#9a93cb";
-export const CARPET_BLUE = "#8fb7d9";
-export const CARPET_BLUE_DOT = "#7fa6c9";
+export const CARPET_PURPLE = "#b7b1e2";
+export const CARPET_PURPLE_DOT = "#aca5da";
+export const CARPET_BLUE = "#a9c8e6";
+export const CARPET_BLUE_DOT = "#9dbcdc";
 
-export const KITCHEN_TILE_LIGHT = "#e8e2d4";
-export const KITCHEN_TILE_DARK = "#dcd4c2";
+export const KITCHEN_TILE_LIGHT = "#e4e6dd";
+export const KITCHEN_TILE_DARK = "#d8dbd0";
 
-export const GYM_MAT = "#b8c9d9";
-export const GYM_MAT_LINE = "#a5b8ca";
+export const GYM_MAT = "#c4d2e0";
+export const GYM_MAT_LINE = "#b3c3d4";
 
-export const SERVER_FLOOR = "#4a5568";
-export const SERVER_FLOOR_GRID = "#3d4759";
+export const SERVER_FLOOR = "#5b6478";
+export const SERVER_FLOOR_GRID = "#4e576a";
 
-export const WALL_TOP = "#3d4258";
-export const WALL_FACE = "#565d7a";
-export const WALL_EDGE = "#6b7394";
+export const WALL_TOP = "#6e7687";
+export const WALL_FACE = "#8b93a4";
+export const WALL_EDGE = "#9aa2b2";
+export const WALL_SEAM = "#7e8697";
+export const WALL_BASEBOARD = "#626a7a";
+
+export const WINDOW_GLASS = "#bfe2f4";
+export const WINDOW_SHEEN = "#e8f6fd";
+export const WINDOW_FRAME = "#f2f4f6";
 
 // ---------------------------------------------------------------------------
 // Furniture.

--- a/src/features/pixel-office/art/sprite.ts
+++ b/src/features/pixel-office/art/sprite.ts
@@ -1,0 +1,83 @@
+import type { PixelSprite } from "../types";
+
+const TRANSPARENT_CHARS = new Set([".", " "]);
+
+/** Width of a sprite in pixels (longest row wins; short rows are padded). */
+export function spriteWidth(sprite: PixelSprite): number {
+  let max = 0;
+  for (const row of sprite.rows) {
+    if (row.length > max) max = row.length;
+  }
+  return max;
+}
+
+/** Height of a sprite in pixels (row count). */
+export function spriteHeight(sprite: PixelSprite): number {
+  return sprite.rows.length;
+}
+
+/**
+ * Paints a sprite onto a 2D canvas context at 1 canvas pixel per cell.
+ * Adjacent same-color cells in a row are merged into a single fillRect for
+ * speed. "." and " " cells are transparent.
+ */
+export function paintSpriteToContext(
+  sprite: PixelSprite,
+  ctx: CanvasRenderingContext2D,
+  dx: number,
+  dy: number,
+): void {
+  const { rows, palette } = sprite;
+  for (let y = 0; y < rows.length; y += 1) {
+    const row = rows[y];
+    let x = 0;
+    while (x < row.length) {
+      const ch = row[x];
+      if (TRANSPARENT_CHARS.has(ch)) {
+        x += 1;
+        continue;
+      }
+      const color = palette[ch];
+      if (!color) {
+        x += 1;
+        continue;
+      }
+      // Extend the run across every following cell that resolves to the same color.
+      let end = x + 1;
+      while (end < row.length) {
+        const nextCh = row[end];
+        if (TRANSPARENT_CHARS.has(nextCh) || palette[nextCh] !== color) break;
+        end += 1;
+      }
+      ctx.fillStyle = color;
+      ctx.fillRect(dx + x, dy + y, end - x, 1);
+      x = end;
+    }
+  }
+}
+
+/**
+ * Builds a PixelSprite while validating that every non-transparent char in
+ * the rows exists in the palette. Throws with the list of missing chars.
+ */
+export function makeSprite(
+  key: string,
+  palette: Record<string, string>,
+  rows: string[],
+): PixelSprite {
+  const missing = new Set<string>();
+  for (const row of rows) {
+    for (const ch of row) {
+      if (TRANSPARENT_CHARS.has(ch)) continue;
+      if (!(ch in palette)) missing.add(ch);
+    }
+  }
+  if (missing.size > 0) {
+    throw new Error(
+      `Sprite "${key}" uses chars missing from its palette: ${[...missing]
+        .map((c) => JSON.stringify(c))
+        .join(", ")}`,
+    );
+  }
+  return { key, rows, palette };
+}

--- a/src/features/pixel-office/art/tiles.ts
+++ b/src/features/pixel-office/art/tiles.ts
@@ -1,0 +1,190 @@
+import type { PixelSprite } from "../types";
+import {
+  CARPET_BLUE,
+  CARPET_BLUE_DOT,
+  CARPET_PURPLE,
+  CARPET_PURPLE_DOT,
+  FLOOR_CREAM,
+  FLOOR_CREAM_LINE,
+  FLOOR_WHITE,
+  FLOOR_WHITE_LINE,
+  FLOOR_WOOD,
+  FLOOR_WOOD_SEAM,
+  GRASS_ALT_BASE,
+  GRASS_BASE,
+  GRASS_BLADE,
+  GRASS_DARK_BASE,
+  GRASS_DARK_BLADE,
+  GYM_MAT,
+  GYM_MAT_LINE,
+  KITCHEN_TILE_DARK,
+  KITCHEN_TILE_LIGHT,
+  PATH_BASE,
+  PATH_SPECKLE,
+  SERVER_FLOOR,
+  SERVER_FLOOR_GRID,
+  WALL_EDGE,
+  WALL_FACE,
+  WALL_TOP,
+} from "./palette";
+import { fillRect, gridRows, hLine, makeGrid, outlineRect, setPx, vLine, type Grid } from "./grid";
+import { makeSprite } from "./sprite";
+
+const T = 16;
+
+/** Small L-shaped grass blade cluster. */
+function bladeCluster(grid: Grid, x: number, y: number, ch: string): void {
+  setPx(grid, x, y, ch);
+  setPx(grid, x + 1, y, ch);
+  setPx(grid, x, y + 1, ch);
+  setPx(grid, x + 2, y + 1, ch);
+}
+
+function grassTile(key: string, base: string, blade: string, alt: boolean): PixelSprite {
+  const g = makeGrid(T, T, "g");
+  const spots: Array<[number, number]> = alt
+    ? [
+        [1, 2],
+        [9, 5],
+        [4, 11],
+        [12, 12],
+      ]
+    : [
+        [3, 3],
+        [11, 2],
+        [6, 8],
+        [1, 12],
+        [12, 10],
+      ];
+  for (const [x, y] of spots) bladeCluster(g, x, y, "d");
+  return makeSprite(key, { g: base, d: blade }, gridRows(g));
+}
+
+function pathTile(): PixelSprite {
+  const g = makeGrid(T, T, "g");
+  const speckles: Array<[number, number]> = [
+    [2, 3],
+    [3, 3],
+    [9, 1],
+    [13, 6],
+    [5, 9],
+    [6, 9],
+    [11, 12],
+    [1, 14],
+  ];
+  for (const [x, y] of speckles) setPx(g, x, y, "d");
+  return makeSprite("tile_path", { g: PATH_BASE, d: PATH_SPECKLE }, gridRows(g));
+}
+
+/** Floor with a subtle 1px grid line along the right and bottom edges. */
+function gridFloorTile(key: string, base: string, line: string): PixelSprite {
+  const g = makeGrid(T, T, "f");
+  vLine(g, T - 1, 0, T, "l");
+  hLine(g, 0, T - 1, T, "l");
+  return makeSprite(key, { f: base, l: line }, gridRows(g));
+}
+
+/** Alt floor variant: no grid line, just a couple of faint specks. */
+function altFloorTile(key: string, base: string, line: string): PixelSprite {
+  const g = makeGrid(T, T, "f");
+  vLine(g, T - 1, 0, T, "l");
+  hLine(g, 0, T - 1, T, "l");
+  setPx(g, 4, 5, "l");
+  setPx(g, 10, 11, "l");
+  return makeSprite(key, { f: base, l: line }, gridRows(g));
+}
+
+function woodTile(key: string, alt: boolean): PixelSprite {
+  const g = makeGrid(T, T, "w");
+  // Horizontal plank seams every 4 rows.
+  for (const y of [3, 7, 11, 15]) hLine(g, 0, y, T, "s");
+  // Staggered vertical joints between planks.
+  const joints: Array<[number, number]> = alt
+    ? [
+        [11, 0],
+        [3, 4],
+        [13, 8],
+        [7, 12],
+      ]
+    : [
+        [5, 0],
+        [12, 4],
+        [2, 8],
+        [9, 12],
+      ];
+  for (const [x, y] of joints) vLine(g, x, y, 3, "s");
+  return makeSprite(key, { w: FLOOR_WOOD, s: FLOOR_WOOD_SEAM }, gridRows(g));
+}
+
+function carpetTile(key: string, base: string, dot: string): PixelSprite {
+  const g = makeGrid(T, T, "c");
+  // Sparse checker of texture dots.
+  for (let y = 2; y < T; y += 4) {
+    for (let x = 2; x < T; x += 4) {
+      setPx(g, x + ((y / 4) % 2 === 0 ? 0 : 2), y, "d");
+    }
+  }
+  return makeSprite(key, { c: base, d: dot }, gridRows(g));
+}
+
+function kitchenTile(): PixelSprite {
+  const g = makeGrid(T, T, "a");
+  // 8x8 checkerboard quadrants.
+  fillRect(g, 8, 0, 8, 8, "b");
+  fillRect(g, 0, 8, 8, 8, "b");
+  return makeSprite(
+    "tile_kitchen_tile",
+    { a: KITCHEN_TILE_LIGHT, b: KITCHEN_TILE_DARK },
+    gridRows(g),
+  );
+}
+
+function gymMatTile(): PixelSprite {
+  const g = makeGrid(T, T, "m");
+  outlineRect(g, 0, 0, T, T, "l");
+  return makeSprite("tile_gym_mat", { m: GYM_MAT, l: GYM_MAT_LINE }, gridRows(g));
+}
+
+function serverFloorTile(): PixelSprite {
+  const g = makeGrid(T, T, "f");
+  vLine(g, T - 1, 0, T, "l");
+  hLine(g, 0, T - 1, T, "l");
+  setPx(g, 7, 7, "l");
+  return makeSprite("tile_server_floor", { f: SERVER_FLOOR, l: SERVER_FLOOR_GRID }, gridRows(g));
+}
+
+/** Gather-style wall: dark top surface, lighter front face, bright top edge. */
+function wallTile(): PixelSprite {
+  const g = makeGrid(T, T, "f");
+  fillRect(g, 0, 0, T, 6, "t");
+  hLine(g, 0, 6, T, "e");
+  return makeSprite(
+    "tile_wall",
+    { t: WALL_TOP, e: WALL_EDGE, f: WALL_FACE },
+    gridRows(g),
+  );
+}
+
+/**
+ * Builds one 16x16 sprite per paintable ground tile (all PixelGroundTile
+ * values except "void"), plus _alt variants for large-area tiles.
+ */
+export function buildGroundTileSprites(): PixelSprite[] {
+  return [
+    grassTile("tile_grass", GRASS_BASE, GRASS_BLADE, false),
+    grassTile("tile_grass_alt", GRASS_ALT_BASE, GRASS_BLADE, true),
+    grassTile("tile_grass_dark", GRASS_DARK_BASE, GRASS_DARK_BLADE, false),
+    pathTile(),
+    gridFloorTile("tile_floor_cream", FLOOR_CREAM, FLOOR_CREAM_LINE),
+    altFloorTile("tile_floor_cream_alt", FLOOR_CREAM, FLOOR_CREAM_LINE),
+    gridFloorTile("tile_floor_white", FLOOR_WHITE, FLOOR_WHITE_LINE),
+    woodTile("tile_floor_wood", false),
+    woodTile("tile_floor_wood_alt", true),
+    carpetTile("tile_carpet_purple", CARPET_PURPLE, CARPET_PURPLE_DOT),
+    carpetTile("tile_carpet_blue", CARPET_BLUE, CARPET_BLUE_DOT),
+    kitchenTile(),
+    gymMatTile(),
+    serverFloorTile(),
+    wallTile(),
+  ];
+}

--- a/src/features/pixel-office/art/tiles.ts
+++ b/src/features/pixel-office/art/tiles.ts
@@ -5,16 +5,21 @@ import {
   CARPET_PURPLE,
   CARPET_PURPLE_DOT,
   FLOOR_CREAM,
+  FLOOR_CREAM_CHECK,
   FLOOR_CREAM_LINE,
   FLOOR_WHITE,
   FLOOR_WHITE_LINE,
   FLOOR_WOOD,
+  FLOOR_WOOD_GRAIN,
   FLOOR_WOOD_SEAM,
   GRASS_ALT_BASE,
   GRASS_BASE,
   GRASS_BLADE,
   GRASS_DARK_BASE,
   GRASS_DARK_BLADE,
+  GRASS_DARK_MOTTLE,
+  GRASS_FLOWER,
+  GRASS_MOTTLE,
   GYM_MAT,
   GYM_MAT_LINE,
   KITCHEN_TILE_DARK,
@@ -23,88 +28,116 @@ import {
   PATH_SPECKLE,
   SERVER_FLOOR,
   SERVER_FLOOR_GRID,
+  WALL_BASEBOARD,
   WALL_EDGE,
   WALL_FACE,
+  WALL_SEAM,
   WALL_TOP,
+  WINDOW_FRAME,
+  WINDOW_GLASS,
+  WINDOW_SHEEN,
 } from "./palette";
 import { fillRect, gridRows, hLine, makeGrid, outlineRect, setPx, vLine, type Grid } from "./grid";
 import { makeSprite } from "./sprite";
 
 const T = 16;
 
-/** Small L-shaped grass blade cluster. */
-function bladeCluster(grid: Grid, x: number, y: number, ch: string): void {
+/** Small soft mottle patch: a 2x2-ish blob of a lighter shade. */
+function mottlePatch(grid: Grid, x: number, y: number, ch: string): void {
   setPx(grid, x, y, ch);
   setPx(grid, x + 1, y, ch);
   setPx(grid, x, y + 1, ch);
+  setPx(grid, x + 1, y + 1, ch);
   setPx(grid, x + 2, y + 1, ch);
 }
 
-function grassTile(key: string, base: string, blade: string, alt: boolean): PixelSprite {
+type GrassColors = {
+  base: string;
+  mottle: string;
+  blade: string;
+};
+
+/**
+ * Pastel grass: light desaturated base with lighter mottled patches, a few
+ * 1px blade specks, and (optionally) one near-white flower speck.
+ */
+function grassTile(
+  key: string,
+  colors: GrassColors,
+  layout: {
+    mottles: Array<[number, number]>;
+    blades: Array<[number, number]>;
+    flower: [number, number] | null;
+  },
+): PixelSprite {
   const g = makeGrid(T, T, "g");
-  const spots: Array<[number, number]> = alt
-    ? [
-        [1, 2],
-        [9, 5],
-        [4, 11],
-        [12, 12],
-      ]
-    : [
-        [3, 3],
-        [11, 2],
-        [6, 8],
-        [1, 12],
-        [12, 10],
-      ];
-  for (const [x, y] of spots) bladeCluster(g, x, y, "d");
-  return makeSprite(key, { g: base, d: blade }, gridRows(g));
+  for (const [x, y] of layout.mottles) mottlePatch(g, x, y, "m");
+  for (const [x, y] of layout.blades) setPx(g, x, y, "b");
+  const palette: Record<string, string> = {
+    g: colors.base,
+    m: colors.mottle,
+    b: colors.blade,
+  };
+  if (layout.flower) {
+    setPx(g, layout.flower[0], layout.flower[1], "f");
+    palette.f = GRASS_FLOWER;
+  }
+  return makeSprite(key, palette, gridRows(g));
 }
 
+/** Light warm gray path with sparse, low-contrast pebble specks. */
 function pathTile(): PixelSprite {
   const g = makeGrid(T, T, "g");
-  const speckles: Array<[number, number]> = [
-    [2, 3],
-    [3, 3],
-    [9, 1],
-    [13, 6],
-    [5, 9],
-    [6, 9],
-    [11, 12],
-    [1, 14],
+  const pebbles: Array<[number, number]> = [
+    [3, 2],
+    [4, 2],
+    [10, 4],
+    [13, 8],
+    [6, 10],
+    [7, 10],
+    [2, 13],
+    [11, 13],
   ];
-  for (const [x, y] of speckles) setPx(g, x, y, "d");
+  for (const [x, y] of pebbles) setPx(g, x, y, "d");
   return makeSprite("tile_path", { g: PATH_BASE, d: PATH_SPECKLE }, gridRows(g));
 }
 
-/** Floor with a subtle 1px grid line along the right and bottom edges. */
-function gridFloorTile(key: string, base: string, line: string): PixelSprite {
-  const g = makeGrid(T, T, "f");
-  vLine(g, T - 1, 0, T, "l");
-  hLine(g, 0, T - 1, T, "l");
-  return makeSprite(key, { f: base, l: line }, gridRows(g));
+/** Ultra-subtle 8px checker floor (two quadrants per tile edge). */
+function checkerFloorTile(key: string, base: string, check: string): PixelSprite {
+  const g = makeGrid(T, T, "a");
+  fillRect(g, 8, 0, 8, 8, "b");
+  fillRect(g, 0, 8, 8, 8, "b");
+  return makeSprite(key, { a: base, b: check }, gridRows(g));
 }
 
-/** Alt floor variant: no grid line, just a couple of faint specks. */
-function altFloorTile(key: string, base: string, line: string): PixelSprite {
-  const g = makeGrid(T, T, "f");
-  vLine(g, T - 1, 0, T, "l");
-  hLine(g, 0, T - 1, T, "l");
-  setPx(g, 4, 5, "l");
-  setPx(g, 10, 11, "l");
-  return makeSprite(key, { f: base, l: line }, gridRows(g));
+/** Alt cream floor: same checker plus a faint 2x2 dot decal. */
+function creamAltFloorTile(): PixelSprite {
+  const g = makeGrid(T, T, "a");
+  fillRect(g, 8, 0, 8, 8, "b");
+  fillRect(g, 0, 8, 8, 8, "b");
+  fillRect(g, 4, 4, 2, 2, "d");
+  return makeSprite(
+    "tile_floor_cream_alt",
+    { a: FLOOR_CREAM, b: FLOOR_CREAM_CHECK, d: FLOOR_CREAM_LINE },
+    gridRows(g),
+  );
 }
 
+/**
+ * Light pink-beige wood: horizontal plank seams every 4 rows, staggered
+ * vertical joints, sparse 2px grain ticks. Alt offsets the seam rows so
+ * adjacent tiles do not tile visibly.
+ */
 function woodTile(key: string, alt: boolean): PixelSprite {
   const g = makeGrid(T, T, "w");
-  // Horizontal plank seams every 4 rows.
-  for (const y of [3, 7, 11, 15]) hLine(g, 0, y, T, "s");
-  // Staggered vertical joints between planks.
+  const seamRows = alt ? [1, 5, 9, 13] : [3, 7, 11, 15];
+  for (const y of seamRows) hLine(g, 0, y, T, "s");
   const joints: Array<[number, number]> = alt
     ? [
-        [11, 0],
-        [3, 4],
-        [13, 8],
-        [7, 12],
+        [10, 2],
+        [4, 6],
+        [13, 10],
+        [6, 14],
       ]
     : [
         [5, 0],
@@ -113,23 +146,41 @@ function woodTile(key: string, alt: boolean): PixelSprite {
         [9, 12],
       ];
   for (const [x, y] of joints) vLine(g, x, y, 3, "s");
-  return makeSprite(key, { w: FLOOR_WOOD, s: FLOOR_WOOD_SEAM }, gridRows(g));
+  const grain: Array<[number, number]> = alt
+    ? [
+        [2, 3],
+        [12, 7],
+        [7, 11],
+      ]
+    : [
+        [8, 1],
+        [3, 5],
+        [13, 9],
+        [6, 13],
+      ];
+  for (const [x, y] of grain) hLine(g, x, y, 2, "t");
+  return makeSprite(
+    key,
+    { w: FLOOR_WOOD, s: FLOOR_WOOD_SEAM, t: FLOOR_WOOD_GRAIN },
+    gridRows(g),
+  );
 }
 
+/** Soft carpet with a sparse offset-dot weave texture. */
 function carpetTile(key: string, base: string, dot: string): PixelSprite {
   const g = makeGrid(T, T, "c");
-  // Sparse checker of texture dots.
   for (let y = 2; y < T; y += 4) {
+    const offset = Math.floor(y / 4) % 2 === 0 ? 0 : 2;
     for (let x = 2; x < T; x += 4) {
-      setPx(g, x + ((y / 4) % 2 === 0 ? 0 : 2), y, "d");
+      setPx(g, x + offset, y, "d");
     }
   }
   return makeSprite(key, { c: base, d: dot }, gridRows(g));
 }
 
+/** Soft sage 8px checker for the kitchen. */
 function kitchenTile(): PixelSprite {
   const g = makeGrid(T, T, "a");
-  // 8x8 checkerboard quadrants.
   fillRect(g, 8, 0, 8, 8, "b");
   fillRect(g, 0, 8, 8, 8, "b");
   return makeSprite(
@@ -139,12 +190,14 @@ function kitchenTile(): PixelSprite {
   );
 }
 
+/** Blue-gray gym mat with a 1px seam border. */
 function gymMatTile(): PixelSprite {
   const g = makeGrid(T, T, "m");
   outlineRect(g, 0, 0, T, T, "l");
   return makeSprite("tile_gym_mat", { m: GYM_MAT, l: GYM_MAT_LINE }, gridRows(g));
 }
 
+/** Medium slate raised floor with a grid line on the right/bottom edges. */
 function serverFloorTile(): PixelSprite {
   const g = makeGrid(T, T, "f");
   vLine(g, T - 1, 0, T, "l");
@@ -153,14 +206,60 @@ function serverFloorTile(): PixelSprite {
   return makeSprite("tile_server_floor", { f: SERVER_FLOOR, l: SERVER_FLOOR_GRID }, gridRows(g));
 }
 
-/** Gather-style wall: dark top surface, lighter front face, bright top edge. */
+// Wall layout shared by tile_wall and tile_wall_window:
+// row 0        = 1px light top edge
+// rows 1..5    = top surface
+// rows 6..14   = front face
+// row 15       = 1px darker baseboard
+const WALL_FACE_TOP = 6;
+
+/** Paints the shared light-gray wall frame (edge, top surface, face, baseboard). */
+function paintWallFrame(g: Grid): void {
+  hLine(g, 0, 0, T, "e");
+  fillRect(g, 0, 1, T, WALL_FACE_TOP - 1, "t");
+  fillRect(g, 0, WALL_FACE_TOP, T, T - WALL_FACE_TOP - 1, "f");
+  hLine(g, 0, T - 1, T, "b");
+}
+
+const WALL_FRAME_PALETTE: Record<string, string> = {
+  e: WALL_EDGE,
+  t: WALL_TOP,
+  f: WALL_FACE,
+  s: WALL_SEAM,
+  b: WALL_BASEBOARD,
+};
+
+/**
+ * Gather-style light paneled wall: light top edge, gray top surface, lighter
+ * face with subtle vertical panel seams every 5px, and a darker baseboard.
+ */
 function wallTile(): PixelSprite {
   const g = makeGrid(T, T, "f");
-  fillRect(g, 0, 0, T, 6, "t");
-  hLine(g, 0, 6, T, "e");
+  paintWallFrame(g);
+  for (const x of [5, 10]) vLine(g, x, WALL_FACE_TOP, T - WALL_FACE_TOP - 1, "s");
+  return makeSprite("tile_wall", WALL_FRAME_PALETTE, gridRows(g));
+}
+
+/**
+ * Wall with a window: same frame as tile_wall, but most of the face is a
+ * sky-blue glass pane with a white diagonal sheen inside a 1px light frame.
+ */
+function wallWindowTile(): PixelSprite {
+  const g = makeGrid(T, T, "f");
+  paintWallFrame(g);
+  // 1px light frame around the pane, inset from the tile edges.
+  outlineRect(g, 1, WALL_FACE_TOP, T - 2, T - WALL_FACE_TOP - 1, "r");
+  fillRect(g, 2, WALL_FACE_TOP + 1, T - 4, T - WALL_FACE_TOP - 3, "p");
+  // Two-pixel-wide diagonal sheen across the pane.
+  for (let i = 0; i < 6; i += 1) {
+    const y = WALL_FACE_TOP + 1 + i;
+    const x = 11 - i;
+    setPx(g, x, y, "h");
+    setPx(g, x + 1, y, "h");
+  }
   return makeSprite(
-    "tile_wall",
-    { t: WALL_TOP, e: WALL_EDGE, f: WALL_FACE },
+    "tile_wall_window",
+    { ...WALL_FRAME_PALETTE, r: WINDOW_FRAME, p: WINDOW_GLASS, h: WINDOW_SHEEN },
     gridRows(g),
   );
 }
@@ -171,13 +270,67 @@ function wallTile(): PixelSprite {
  */
 export function buildGroundTileSprites(): PixelSprite[] {
   return [
-    grassTile("tile_grass", GRASS_BASE, GRASS_BLADE, false),
-    grassTile("tile_grass_alt", GRASS_ALT_BASE, GRASS_BLADE, true),
-    grassTile("tile_grass_dark", GRASS_DARK_BASE, GRASS_DARK_BLADE, false),
+    grassTile(
+      "tile_grass",
+      { base: GRASS_BASE, mottle: GRASS_MOTTLE, blade: GRASS_BLADE },
+      {
+        mottles: [
+          [2, 2],
+          [10, 4],
+          [5, 9],
+          [12, 12],
+        ],
+        blades: [
+          [7, 1],
+          [1, 7],
+          [14, 8],
+          [8, 14],
+        ],
+        flower: [13, 2],
+      },
+    ),
+    grassTile(
+      "tile_grass_alt",
+      { base: GRASS_ALT_BASE, mottle: GRASS_MOTTLE, blade: GRASS_BLADE },
+      {
+        mottles: [
+          [6, 1],
+          [1, 6],
+          [11, 8],
+          [4, 12],
+        ],
+        blades: [
+          [12, 3],
+          [8, 6],
+          [2, 10],
+          [14, 14],
+        ],
+        flower: [3, 3],
+      },
+    ),
+    grassTile(
+      "tile_grass_dark",
+      { base: GRASS_DARK_BASE, mottle: GRASS_DARK_MOTTLE, blade: GRASS_DARK_BLADE },
+      {
+        mottles: [
+          [3, 3],
+          [11, 2],
+          [6, 8],
+          [1, 12],
+          [12, 11],
+        ],
+        blades: [
+          [8, 5],
+          [14, 7],
+          [4, 14],
+        ],
+        flower: null,
+      },
+    ),
     pathTile(),
-    gridFloorTile("tile_floor_cream", FLOOR_CREAM, FLOOR_CREAM_LINE),
-    altFloorTile("tile_floor_cream_alt", FLOOR_CREAM, FLOOR_CREAM_LINE),
-    gridFloorTile("tile_floor_white", FLOOR_WHITE, FLOOR_WHITE_LINE),
+    checkerFloorTile("tile_floor_cream", FLOOR_CREAM, FLOOR_CREAM_CHECK),
+    creamAltFloorTile(),
+    checkerFloorTile("tile_floor_white", FLOOR_WHITE, FLOOR_WHITE_LINE),
     woodTile("tile_floor_wood", false),
     woodTile("tile_floor_wood_alt", true),
     carpetTile("tile_carpet_purple", CARPET_PURPLE, CARPET_PURPLE_DOT),
@@ -186,5 +339,6 @@ export function buildGroundTileSprites(): PixelSprite[] {
     gymMatTile(),
     serverFloorTile(),
     wallTile(),
+    wallWindowTile(),
   ];
 }

--- a/src/features/pixel-office/art/tiles.ts
+++ b/src/features/pixel-office/art/tiles.ts
@@ -9,328 +9,674 @@ import {
   FLOOR_CREAM_LINE,
   FLOOR_WHITE,
   FLOOR_WHITE_LINE,
+  FLOOR_WHITE_SPECK,
   FLOOR_WOOD,
   FLOOR_WOOD_GRAIN,
+  FLOOR_WOOD_LIGHT,
   FLOOR_WOOD_SEAM,
+  FLOOR_WOOD_TONE,
   GRASS_ALT_BASE,
   GRASS_BASE,
   GRASS_BLADE,
   GRASS_DARK_BASE,
   GRASS_DARK_BLADE,
   GRASS_DARK_MOTTLE,
+  GRASS_DARK_MOTTLE_DEEP,
   GRASS_FLOWER,
+  GRASS_FLOWER_CENTER,
+  GRASS_FLOWER_PINK,
   GRASS_MOTTLE,
+  GRASS_MOTTLE_DEEP,
   GYM_MAT,
   GYM_MAT_LINE,
+  GYM_MAT_SEAM,
   KITCHEN_TILE_DARK,
+  KITCHEN_TILE_DARK_BEVEL,
   KITCHEN_TILE_LIGHT,
+  KITCHEN_TILE_LIGHT_BEVEL,
   PATH_BASE,
+  PATH_PEBBLE_LIGHT,
   PATH_SPECKLE,
   SERVER_FLOOR,
   SERVER_FLOOR_GRID,
+  SERVER_FLOOR_LIGHT,
+  SERVER_FLOOR_VENT,
   WALL_BASEBOARD,
   WALL_EDGE,
   WALL_FACE,
+  WALL_FLOOR_SHADOW,
   WALL_SEAM,
+  WALL_SEAM_HIGHLIGHT,
   WALL_TOP,
+  WALL_TOP_SHEEN,
   WINDOW_FRAME,
   WINDOW_GLASS,
   WINDOW_SHEEN,
+  WINDOW_SILL_SHADOW,
+  WINDOW_SKY_TOP,
 } from "./palette";
-import { fillRect, gridRows, hLine, makeGrid, outlineRect, setPx, vLine, type Grid } from "./grid";
+import { fillRect, gridRows, hLine, makeGrid, setPx, vLine, type Grid } from "./grid";
 import { makeSprite } from "./sprite";
 
-const T = 16;
+const T = 32;
 
-/** Small soft mottle patch: a 2x2-ish blob of a lighter shade. */
-function mottlePatch(grid: Grid, x: number, y: number, ch: string): void {
-  setPx(grid, x, y, ch);
-  setPx(grid, x + 1, y, ch);
-  setPx(grid, x, y + 1, ch);
-  setPx(grid, x + 1, y + 1, ch);
-  setPx(grid, x + 2, y + 1, ch);
+// ---------------------------------------------------------------------------
+// Grass.
+// ---------------------------------------------------------------------------
+
+type BlobShape = ReadonlyArray<readonly [number, number]>;
+
+// Irregular blob silhouettes (relative offsets) so mottles read as organic
+// patches instead of stamped rectangles.
+const BLOB_ROUND: BlobShape = [
+  [1, 0],
+  [2, 0],
+  [0, 1],
+  [1, 1],
+  [2, 1],
+  [3, 1],
+  [0, 2],
+  [1, 2],
+  [2, 2],
+  [3, 2],
+  [1, 3],
+  [2, 3],
+];
+
+const BLOB_WIDE: BlobShape = [
+  [1, 0],
+  [2, 0],
+  [3, 0],
+  [0, 1],
+  [1, 1],
+  [2, 1],
+  [3, 1],
+  [4, 1],
+  [2, 2],
+  [3, 2],
+];
+
+const BLOB_SMALL: BlobShape = [
+  [0, 0],
+  [1, 0],
+  [0, 1],
+  [1, 1],
+  [2, 1],
+];
+
+/** Paints one blob shape at (x, y). */
+function paintBlob(grid: Grid, x: number, y: number, shape: BlobShape, ch: string): void {
+  for (const [dx, dy] of shape) setPx(grid, x + dx, y + dy, ch);
+}
+
+/** Tiny 3x3 plus-shaped flower: four petals around a warm center pixel. */
+function paintFlower(grid: Grid, x: number, y: number, petalCh: string): void {
+  setPx(grid, x, y - 1, petalCh);
+  setPx(grid, x - 1, y, petalCh);
+  setPx(grid, x + 1, y, petalCh);
+  setPx(grid, x, y + 1, petalCh);
+  setPx(grid, x, y, "q");
 }
 
 type GrassColors = {
   base: string;
   mottle: string;
+  mottleDeep: string;
   blade: string;
 };
 
+type GrassLayout = {
+  /** Lighter organic patches: [x, y, shape]. */
+  mottles: Array<[number, number, BlobShape]>;
+  /** Slightly deeper patches for depth: [x, y, shape]. */
+  deepMottles: Array<[number, number, BlobShape]>;
+  /** 2px-tall blade sprigs (top pixel coordinate). */
+  blades: Array<[number, number]>;
+  /** Optional flowers: [x, y, petal char ("p" white or "k" pink)]. */
+  flowers: Array<[number, number, "p" | "k"]>;
+};
+
 /**
- * Pastel grass: light desaturated base with lighter mottled patches, a few
- * 1px blade specks, and (optionally) one near-white flower speck.
+ * Pastel grass: uniform base (so edges tile seamlessly) with scattered
+ * organic mottle blobs in two close shades, sparse 2px blades, and an
+ * occasional tiny flower.
  */
-function grassTile(
-  key: string,
-  colors: GrassColors,
-  layout: {
-    mottles: Array<[number, number]>;
-    blades: Array<[number, number]>;
-    flower: [number, number] | null;
-  },
-): PixelSprite {
+function grassTile(key: string, colors: GrassColors, layout: GrassLayout): PixelSprite {
   const g = makeGrid(T, T, "g");
-  for (const [x, y] of layout.mottles) mottlePatch(g, x, y, "m");
-  for (const [x, y] of layout.blades) setPx(g, x, y, "b");
-  const palette: Record<string, string> = {
-    g: colors.base,
-    m: colors.mottle,
-    b: colors.blade,
-  };
-  if (layout.flower) {
-    setPx(g, layout.flower[0], layout.flower[1], "f");
-    palette.f = GRASS_FLOWER;
+  for (const [x, y, shape] of layout.mottles) paintBlob(g, x, y, shape, "m");
+  for (const [x, y, shape] of layout.deepMottles) paintBlob(g, x, y, shape, "n");
+  for (const [x, y] of layout.blades) {
+    setPx(g, x, y, "b");
+    setPx(g, x, y + 1, "b");
   }
-  return makeSprite(key, palette, gridRows(g));
-}
-
-/** Light warm gray path with sparse, low-contrast pebble specks. */
-function pathTile(): PixelSprite {
-  const g = makeGrid(T, T, "g");
-  const pebbles: Array<[number, number]> = [
-    [3, 2],
-    [4, 2],
-    [10, 4],
-    [13, 8],
-    [6, 10],
-    [7, 10],
-    [2, 13],
-    [11, 13],
-  ];
-  for (const [x, y] of pebbles) setPx(g, x, y, "d");
-  return makeSprite("tile_path", { g: PATH_BASE, d: PATH_SPECKLE }, gridRows(g));
-}
-
-/** Ultra-subtle 8px checker floor (two quadrants per tile edge). */
-function checkerFloorTile(key: string, base: string, check: string): PixelSprite {
-  const g = makeGrid(T, T, "a");
-  fillRect(g, 8, 0, 8, 8, "b");
-  fillRect(g, 0, 8, 8, 8, "b");
-  return makeSprite(key, { a: base, b: check }, gridRows(g));
-}
-
-/** Alt cream floor: same checker plus a faint 2x2 dot decal. */
-function creamAltFloorTile(): PixelSprite {
-  const g = makeGrid(T, T, "a");
-  fillRect(g, 8, 0, 8, 8, "b");
-  fillRect(g, 0, 8, 8, 8, "b");
-  fillRect(g, 4, 4, 2, 2, "d");
+  for (const [x, y, petal] of layout.flowers) paintFlower(g, x, y, petal);
   return makeSprite(
-    "tile_floor_cream_alt",
-    { a: FLOOR_CREAM, b: FLOOR_CREAM_CHECK, d: FLOOR_CREAM_LINE },
+    key,
+    {
+      g: colors.base,
+      m: colors.mottle,
+      n: colors.mottleDeep,
+      b: colors.blade,
+      p: GRASS_FLOWER,
+      k: GRASS_FLOWER_PINK,
+      q: GRASS_FLOWER_CENTER,
+    },
     gridRows(g),
   );
 }
 
+// ---------------------------------------------------------------------------
+// Path.
+// ---------------------------------------------------------------------------
+
 /**
- * Light pink-beige wood: horizontal plank seams every 4 rows, staggered
- * vertical joints, sparse 2px grain ticks. Alt offsets the seam rows so
- * adjacent tiles do not tile visibly.
+ * Light warm gray path with sparse low-contrast pebbles: small 2-3px
+ * clusters in two close tones plus a few single-pixel specks.
+ */
+function pathTile(): PixelSprite {
+  const g = makeGrid(T, T, "g");
+  // Darker pebble clusters (2px pairs and 3px L-shapes).
+  const darkPairs: Array<[number, number]> = [
+    [5, 4],
+    [21, 3],
+    [12, 9],
+    [27, 13],
+    [3, 18],
+    [16, 21],
+    [24, 26],
+    [8, 28],
+  ];
+  for (const [x, y] of darkPairs) {
+    setPx(g, x, y, "d");
+    setPx(g, x + 1, y, "d");
+  }
+  const darkCorners: Array<[number, number]> = [
+    [13, 10],
+    [4, 19],
+    [25, 27],
+  ];
+  for (const [x, y] of darkCorners) setPx(g, x, y, "d");
+  // Lighter pebbles for variety.
+  const lightPairs: Array<[number, number]> = [
+    [10, 2],
+    [26, 7],
+    [7, 13],
+    [19, 15],
+    [29, 20],
+    [13, 25],
+    [2, 26],
+  ];
+  for (const [x, y] of lightPairs) {
+    setPx(g, x, y, "l");
+    setPx(g, x + 1, y, "l");
+  }
+  // Single-pixel specks.
+  const specks: Array<[number, number]> = [
+    [17, 6],
+    [1, 9],
+    [23, 11],
+    [10, 18],
+    [30, 24],
+    [20, 30],
+  ];
+  for (const [x, y] of specks) setPx(g, x, y, "d");
+  return makeSprite(
+    "tile_path",
+    { g: PATH_BASE, d: PATH_SPECKLE, l: PATH_PEBBLE_LIGHT },
+    gridRows(g),
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Cream / white office floors.
+// ---------------------------------------------------------------------------
+
+/**
+ * Near-uniform floor: ultra-subtle 16px checker (two quadrants per edge)
+ * plus rare 1px specks. Contrast is kept so low it does not read as a
+ * pattern when zoomed out.
+ */
+function subtleFloorTile(
+  key: string,
+  base: string,
+  check: string,
+  speck: string,
+  specks: Array<[number, number]>,
+  decal: [number, number] | null,
+): PixelSprite {
+  const g = makeGrid(T, T, "a");
+  fillRect(g, 16, 0, 16, 16, "b");
+  fillRect(g, 0, 16, 16, 16, "b");
+  for (const [x, y] of specks) setPx(g, x, y, "d");
+  if (decal) fillRect(g, decal[0], decal[1], 2, 2, "d");
+  return makeSprite(key, { a: base, b: check, d: speck }, gridRows(g));
+}
+
+// ---------------------------------------------------------------------------
+// Wood.
+// ---------------------------------------------------------------------------
+
+/**
+ * Light pink-beige wood: two 16px plank rows per tile with a subtle tone
+ * shift between the upper and lower plank, a 1px lighter bevel along each
+ * plank's top edge, seam lines at each plank's bottom edge, one staggered
+ * butt joint per plank, and sparse 2-3px grain ticks. Band tones are shared
+ * by both variants so planks run continuously across tile boundaries; the
+ * alt variant only moves the joints and grain to break up repetition.
  */
 function woodTile(key: string, alt: boolean): PixelSprite {
   const g = makeGrid(T, T, "w");
-  const seamRows = alt ? [1, 5, 9, 13] : [3, 7, 11, 15];
-  for (const y of seamRows) hLine(g, 0, y, T, "s");
-  const joints: Array<[number, number]> = alt
+  // Lower plank band rows 16..30 in the second tone.
+  fillRect(g, 0, 16, T, 15, "v");
+  // 1px lighter bevel along the top edge of each plank.
+  hLine(g, 0, 0, T, "l");
+  hLine(g, 0, 16, T, "l");
+  // Plank seams at the bottom edge of each band (rows 15 and 31) so the
+  // pattern wraps cleanly to the next tile below.
+  hLine(g, 0, 15, T, "s");
+  hLine(g, 0, 31, T, "s");
+  // One staggered butt joint per plank band.
+  vLine(g, alt ? 26 : 10, 0, 15, "s");
+  vLine(g, alt ? 6 : 22, 16, 15, "s");
+  // Sparse short grain ticks, kept clear of joints and seams.
+  const grain: Array<[number, number, number]> = alt
     ? [
-        [10, 2],
-        [4, 6],
-        [13, 10],
-        [6, 14],
+        [4, 3, 3],
+        [16, 7, 2],
+        [30, 11, 2],
+        [12, 19, 3],
+        [22, 24, 2],
+        [2, 28, 2],
       ]
     : [
-        [5, 0],
-        [12, 4],
-        [2, 8],
-        [9, 12],
+        [4, 4, 3],
+        [19, 8, 2],
+        [28, 2, 2],
+        [13, 12, 3],
+        [7, 20, 2],
+        [24, 25, 3],
+        [15, 29, 2],
+        [2, 23, 2],
       ];
-  for (const [x, y] of joints) vLine(g, x, y, 3, "s");
-  const grain: Array<[number, number]> = alt
-    ? [
-        [2, 3],
-        [12, 7],
-        [7, 11],
-      ]
-    : [
-        [8, 1],
-        [3, 5],
-        [13, 9],
-        [6, 13],
-      ];
-  for (const [x, y] of grain) hLine(g, x, y, 2, "t");
+  for (const [x, y, len] of grain) hLine(g, x, y, len, "t");
   return makeSprite(
     key,
-    { w: FLOOR_WOOD, s: FLOOR_WOOD_SEAM, t: FLOOR_WOOD_GRAIN },
+    {
+      w: FLOOR_WOOD,
+      v: FLOOR_WOOD_TONE,
+      l: FLOOR_WOOD_LIGHT,
+      s: FLOOR_WOOD_SEAM,
+      t: FLOOR_WOOD_GRAIN,
+    },
     gridRows(g),
   );
 }
 
-/** Soft carpet with a sparse offset-dot weave texture. */
-function carpetTile(key: string, base: string, dot: string): PixelSprite {
+// ---------------------------------------------------------------------------
+// Carpets.
+// ---------------------------------------------------------------------------
+
+/**
+ * Soft two-tone basket weave: 4x4 thread blocks alternate between
+ * horizontal and vertical 1px threads. The 8px pattern period divides the
+ * tile size so the carpet stays fully seamless.
+ */
+function carpetTile(key: string, base: string, weave: string): PixelSprite {
   const g = makeGrid(T, T, "c");
-  for (let y = 2; y < T; y += 4) {
-    const offset = Math.floor(y / 4) % 2 === 0 ? 0 : 2;
-    for (let x = 2; x < T; x += 4) {
-      setPx(g, x + offset, y, "d");
+  for (let y = 0; y < T; y += 1) {
+    for (let x = 0; x < T; x += 1) {
+      const horizontalBlock = (Math.floor(x / 4) + Math.floor(y / 4)) % 2 === 0;
+      const thread = horizontalBlock ? y % 4 : x % 4;
+      if (thread === 1 || thread === 3) setPx(g, x, y, "d");
     }
   }
-  return makeSprite(key, { c: base, d: dot }, gridRows(g));
+  return makeSprite(key, { c: base, d: weave }, gridRows(g));
 }
 
-/** Soft sage 8px checker for the kitchen. */
+// ---------------------------------------------------------------------------
+// Kitchen.
+// ---------------------------------------------------------------------------
+
+/**
+ * Soft sage 16px checker (four cells per tile) with a slight bevel: each
+ * cell gets a 1px lighter top edge so the tiles read gently raised.
+ */
 function kitchenTile(): PixelSprite {
   const g = makeGrid(T, T, "a");
-  fillRect(g, 8, 0, 8, 8, "b");
-  fillRect(g, 0, 8, 8, 8, "b");
+  fillRect(g, 16, 0, 16, 16, "b");
+  fillRect(g, 0, 16, 16, 16, "b");
+  hLine(g, 0, 0, 16, "p");
+  hLine(g, 16, 0, 16, "q");
+  hLine(g, 0, 16, 16, "q");
+  hLine(g, 16, 16, 16, "p");
   return makeSprite(
     "tile_kitchen_tile",
-    { a: KITCHEN_TILE_LIGHT, b: KITCHEN_TILE_DARK },
+    {
+      a: KITCHEN_TILE_LIGHT,
+      b: KITCHEN_TILE_DARK,
+      p: KITCHEN_TILE_LIGHT_BEVEL,
+      q: KITCHEN_TILE_DARK_BEVEL,
+    },
     gridRows(g),
   );
 }
 
-/** Blue-gray gym mat with a 1px seam border. */
+// ---------------------------------------------------------------------------
+// Gym mat.
+// ---------------------------------------------------------------------------
+
+/**
+ * Blue-gray gym mat: inset border with trimmed ends plus diagonal corner
+ * pixels for rounded-corner hints, and softer cross seams that quarter
+ * the mat.
+ */
 function gymMatTile(): PixelSprite {
   const g = makeGrid(T, T, "m");
-  outlineRect(g, 0, 0, T, T, "l");
-  return makeSprite("tile_gym_mat", { m: GYM_MAT, l: GYM_MAT_LINE }, gridRows(g));
+  // Softer cross seams first so the border paints over their ends.
+  vLine(g, 16, 2, 28, "e");
+  hLine(g, 2, 16, 28, "e");
+  // Border inset 1px from the tile edge, ends trimmed at the corners.
+  hLine(g, 3, 1, 26, "l");
+  hLine(g, 3, 30, 26, "l");
+  vLine(g, 1, 3, 26, "l");
+  vLine(g, 30, 3, 26, "l");
+  // Rounded corner hints.
+  setPx(g, 2, 2, "l");
+  setPx(g, 29, 2, "l");
+  setPx(g, 2, 29, "l");
+  setPx(g, 29, 29, "l");
+  return makeSprite(
+    "tile_gym_mat",
+    { m: GYM_MAT, l: GYM_MAT_LINE, e: GYM_MAT_SEAM },
+    gridRows(g),
+  );
 }
 
-/** Medium slate raised floor with a grid line on the right/bottom edges. */
+// ---------------------------------------------------------------------------
+// Server floor.
+// ---------------------------------------------------------------------------
+
+/**
+ * Slate raised-floor panel: lighter top/left edges against darker
+ * right/bottom grid lines, corner screw dots, and a cluster of tiny vent
+ * slots. Adjacent tiles form a continuous panel grid.
+ */
 function serverFloorTile(): PixelSprite {
   const g = makeGrid(T, T, "f");
+  hLine(g, 0, 0, T, "h");
+  vLine(g, 0, 0, T, "h");
   vLine(g, T - 1, 0, T, "l");
   hLine(g, 0, T - 1, T, "l");
-  setPx(g, 7, 7, "l");
-  return makeSprite("tile_server_floor", { f: SERVER_FLOOR, l: SERVER_FLOOR_GRID }, gridRows(g));
+  // Corner screws.
+  setPx(g, 3, 3, "l");
+  setPx(g, 28, 3, "l");
+  setPx(g, 3, 28, "l");
+  setPx(g, 28, 28, "l");
+  // Three tiny vent slots, offset from center.
+  for (const y of [12, 15, 18]) hLine(g, 20, y, 5, "v");
+  return makeSprite(
+    "tile_server_floor",
+    { f: SERVER_FLOOR, l: SERVER_FLOOR_GRID, h: SERVER_FLOOR_LIGHT, v: SERVER_FLOOR_VENT },
+    gridRows(g),
+  );
 }
 
-// Wall layout shared by tile_wall and tile_wall_window:
-// row 0        = 1px light top edge
-// rows 1..5    = top surface
-// rows 6..14   = front face
-// row 15       = 1px darker baseboard
-const WALL_FACE_TOP = 6;
+// ---------------------------------------------------------------------------
+// Walls.
+// ---------------------------------------------------------------------------
 
-/** Paints the shared light-gray wall frame (edge, top surface, face, baseboard). */
+// Shared wall layout for tile_wall and tile_wall_window:
+// rows 0..1   = 2px bright top edge.
+// rows 2..13  = top surface (~12px) with a soft horizontal sheen band.
+// row 14      = 1px contact shadow under the ledge.
+// rows 15..28 = front face (panel seams live here).
+// rows 29..30 = 2px baseboard.
+// row 31      = 1px shadow line at the floor junction.
+const WALL_LEDGE_SHADOW_ROW = 14;
+const WALL_FACE_TOP = 15;
+const WALL_BASEBOARD_TOP = 29;
+const WALL_FACE_ROWS = WALL_BASEBOARD_TOP - WALL_FACE_TOP;
+
+/** Paints the shared wall frame (edge, top surface, face, baseboard). */
 function paintWallFrame(g: Grid): void {
-  hLine(g, 0, 0, T, "e");
-  fillRect(g, 0, 1, T, WALL_FACE_TOP - 1, "t");
-  fillRect(g, 0, WALL_FACE_TOP, T, T - WALL_FACE_TOP - 1, "f");
-  hLine(g, 0, T - 1, T, "b");
+  fillRect(g, 0, 0, T, 2, "e");
+  fillRect(g, 0, 2, T, WALL_LEDGE_SHADOW_ROW - 2, "t");
+  // Subtle horizontal sheen band across the top surface.
+  fillRect(g, 0, 5, T, 2, "n");
+  hLine(g, 0, WALL_LEDGE_SHADOW_ROW, T, "s");
+  fillRect(g, 0, WALL_FACE_TOP, T, WALL_FACE_ROWS, "f");
+  fillRect(g, 0, WALL_BASEBOARD_TOP, T, 2, "b");
+  hLine(g, 0, T - 1, T, "d");
 }
 
 const WALL_FRAME_PALETTE: Record<string, string> = {
   e: WALL_EDGE,
   t: WALL_TOP,
+  n: WALL_TOP_SHEEN,
   f: WALL_FACE,
   s: WALL_SEAM,
+  h: WALL_SEAM_HIGHLIGHT,
   b: WALL_BASEBOARD,
+  d: WALL_FLOOR_SHADOW,
 };
 
 /**
- * Gather-style light paneled wall: light top edge, gray top surface, lighter
- * face with subtle vertical panel seams every 5px, and a darker baseboard.
+ * Gather-style paneled wall: bright top edge, top surface with a soft
+ * sheen, front face with vertical panel seams every 8px (each seam followed
+ * by a 1px highlight; the x=0 highlight pairs with the neighbor's x=31 seam
+ * so rows of wall tiles chain seamlessly), and a shadowed baseboard.
  */
 function wallTile(): PixelSprite {
   const g = makeGrid(T, T, "f");
   paintWallFrame(g);
-  for (const x of [5, 10]) vLine(g, x, WALL_FACE_TOP, T - WALL_FACE_TOP - 1, "s");
+  for (const x of [7, 15, 23, 31]) vLine(g, x, WALL_FACE_TOP, WALL_FACE_ROWS, "s");
+  for (const x of [0, 8, 16, 24]) vLine(g, x, WALL_FACE_TOP, WALL_FACE_ROWS, "h");
   return makeSprite("tile_wall", WALL_FRAME_PALETTE, gridRows(g));
 }
 
 /**
- * Wall with a window: same frame as tile_wall, but most of the face is a
- * sky-blue glass pane with a white diagonal sheen inside a 1px light frame.
+ * Wall with a window: same frame as tile_wall, plus a large glass pane in a
+ * 2px white frame with a sill, a center mullion splitting the glass into
+ * two panels, a slight two-blue sky gradient, and a 2px diagonal sheen band
+ * in each panel.
  */
 function wallWindowTile(): PixelSprite {
   const g = makeGrid(T, T, "f");
   paintWallFrame(g);
-  // 1px light frame around the pane, inset from the tile edges.
-  outlineRect(g, 1, WALL_FACE_TOP, T - 2, T - WALL_FACE_TOP - 1, "r");
-  fillRect(g, 2, WALL_FACE_TOP + 1, T - 4, T - WALL_FACE_TOP - 3, "p");
-  // Two-pixel-wide diagonal sheen across the pane.
-  for (let i = 0; i < 6; i += 1) {
-    const y = WALL_FACE_TOP + 1 + i;
-    const x = 11 - i;
-    setPx(g, x, y, "h");
-    setPx(g, x + 1, y, "h");
+  // Keep the outer face seam/highlight so adjacent wall tiles chain.
+  vLine(g, 31, WALL_FACE_TOP, WALL_FACE_ROWS, "s");
+  vLine(g, 0, WALL_FACE_TOP, WALL_FACE_ROWS, "h");
+  // 2px white frame block, then the glass inset inside it.
+  fillRect(g, 3, 14, 26, 13, "r");
+  fillRect(g, 5, 16, 22, 9, "p");
+  // Slight sky gradient: lighter blue on the upper glass rows.
+  fillRect(g, 5, 16, 22, 4, "y");
+  // Diagonal sheen band (2px wide) in each of the two panels.
+  for (const panelX of [5, 17]) {
+    for (let i = 0; i < 9; i += 1) {
+      const y = 16 + i;
+      const x = panelX + 8 - i;
+      setPx(g, x, y, "z");
+      if (x + 1 <= panelX + 9) setPx(g, x + 1, y, "z");
+    }
   }
+  // Center mullion splitting the glass into two panels.
+  fillRect(g, 15, 16, 2, 9, "r");
+  // Sill: 1px wider than the frame, with a shadow line beneath.
+  hLine(g, 2, 27, 28, "r");
+  hLine(g, 2, 28, 28, "i");
   return makeSprite(
     "tile_wall_window",
-    { ...WALL_FRAME_PALETTE, r: WINDOW_FRAME, p: WINDOW_GLASS, h: WINDOW_SHEEN },
+    {
+      ...WALL_FRAME_PALETTE,
+      r: WINDOW_FRAME,
+      p: WINDOW_GLASS,
+      y: WINDOW_SKY_TOP,
+      z: WINDOW_SHEEN,
+      i: WINDOW_SILL_SHADOW,
+    },
     gridRows(g),
   );
 }
 
+// ---------------------------------------------------------------------------
+// Exports.
+// ---------------------------------------------------------------------------
+
 /**
- * Builds one 16x16 sprite per paintable ground tile (all PixelGroundTile
+ * Builds one 32x32 sprite per paintable ground tile (all PixelGroundTile
  * values except "void"), plus _alt variants for large-area tiles.
  */
 export function buildGroundTileSprites(): PixelSprite[] {
   return [
     grassTile(
       "tile_grass",
-      { base: GRASS_BASE, mottle: GRASS_MOTTLE, blade: GRASS_BLADE },
+      {
+        base: GRASS_BASE,
+        mottle: GRASS_MOTTLE,
+        mottleDeep: GRASS_MOTTLE_DEEP,
+        blade: GRASS_BLADE,
+      },
       {
         mottles: [
-          [2, 2],
-          [10, 4],
-          [5, 9],
-          [12, 12],
+          [3, 2, BLOB_ROUND],
+          [18, 4, BLOB_WIDE],
+          [9, 12, BLOB_SMALL],
+          [24, 15, BLOB_ROUND],
+          [4, 22, BLOB_WIDE],
+          [16, 26, BLOB_SMALL],
+        ],
+        deepMottles: [
+          [13, 7, BLOB_SMALL],
+          [2, 16, BLOB_SMALL],
+          [21, 21, BLOB_SMALL],
+          [27, 27, BLOB_SMALL],
         ],
         blades: [
-          [7, 1],
-          [1, 7],
-          [14, 8],
-          [8, 14],
+          [8, 6],
+          [26, 9],
+          [4, 13],
+          [14, 19],
+          [29, 18],
+          [10, 28],
+          [22, 28],
+          [1, 26],
         ],
-        flower: [13, 2],
+        flowers: [[27, 3, "p"]],
       },
     ),
     grassTile(
       "tile_grass_alt",
-      { base: GRASS_ALT_BASE, mottle: GRASS_MOTTLE, blade: GRASS_BLADE },
+      {
+        base: GRASS_ALT_BASE,
+        mottle: GRASS_MOTTLE,
+        mottleDeep: GRASS_MOTTLE_DEEP,
+        blade: GRASS_BLADE,
+      },
       {
         mottles: [
-          [6, 1],
-          [1, 6],
-          [11, 8],
-          [4, 12],
+          [12, 1, BLOB_WIDE],
+          [2, 7, BLOB_ROUND],
+          [22, 9, BLOB_SMALL],
+          [15, 15, BLOB_ROUND],
+          [26, 20, BLOB_WIDE],
+          [6, 27, BLOB_SMALL],
+        ],
+        deepMottles: [
+          [24, 2, BLOB_SMALL],
+          [8, 14, BLOB_SMALL],
+          [1, 21, BLOB_SMALL],
+          [18, 24, BLOB_SMALL],
         ],
         blades: [
-          [12, 3],
-          [8, 6],
-          [2, 10],
-          [14, 14],
+          [19, 5],
+          [6, 4],
+          [29, 13],
+          [11, 20],
+          [2, 15],
+          [24, 27],
+          [14, 29],
+          [30, 26],
         ],
-        flower: [3, 3],
+        flowers: [[4, 18, "k"]],
       },
     ),
     grassTile(
       "tile_grass_dark",
-      { base: GRASS_DARK_BASE, mottle: GRASS_DARK_MOTTLE, blade: GRASS_DARK_BLADE },
+      {
+        base: GRASS_DARK_BASE,
+        mottle: GRASS_DARK_MOTTLE,
+        mottleDeep: GRASS_DARK_MOTTLE_DEEP,
+        blade: GRASS_DARK_BLADE,
+      },
       {
         mottles: [
-          [3, 3],
-          [11, 2],
-          [6, 8],
-          [1, 12],
-          [12, 11],
+          [6, 3, BLOB_ROUND],
+          [21, 2, BLOB_SMALL],
+          [13, 10, BLOB_WIDE],
+          [2, 18, BLOB_SMALL],
+          [24, 17, BLOB_ROUND],
+          [10, 25, BLOB_WIDE],
+        ],
+        deepMottles: [
+          [17, 5, BLOB_SMALL],
+          [27, 10, BLOB_SMALL],
+          [5, 12, BLOB_SMALL],
+          [20, 27, BLOB_SMALL],
+          [1, 28, BLOB_SMALL],
         ],
         blades: [
-          [8, 5],
-          [14, 7],
-          [4, 14],
+          [11, 6],
+          [28, 5],
+          [3, 8],
+          [16, 18],
+          [30, 22],
+          [6, 22],
+          [25, 24],
         ],
-        flower: null,
+        flowers: [],
       },
     ),
     pathTile(),
-    checkerFloorTile("tile_floor_cream", FLOOR_CREAM, FLOOR_CREAM_CHECK),
-    creamAltFloorTile(),
-    checkerFloorTile("tile_floor_white", FLOOR_WHITE, FLOOR_WHITE_LINE),
+    subtleFloorTile(
+      "tile_floor_cream",
+      FLOOR_CREAM,
+      FLOOR_CREAM_CHECK,
+      FLOOR_CREAM_LINE,
+      [
+        [6, 5],
+        [23, 10],
+        [12, 20],
+        [28, 27],
+      ],
+      null,
+    ),
+    subtleFloorTile(
+      "tile_floor_cream_alt",
+      FLOOR_CREAM,
+      FLOOR_CREAM_CHECK,
+      FLOOR_CREAM_LINE,
+      [
+        [18, 3],
+        [4, 14],
+        [26, 18],
+        [10, 29],
+      ],
+      [14, 14],
+    ),
+    subtleFloorTile(
+      "tile_floor_white",
+      FLOOR_WHITE,
+      FLOOR_WHITE_LINE,
+      FLOOR_WHITE_SPECK,
+      [
+        [9, 7],
+        [25, 13],
+        [5, 24],
+        [19, 28],
+      ],
+      null,
+    ),
     woodTile("tile_floor_wood", false),
     woodTile("tile_floor_wood_alt", true),
     carpetTile("tile_carpet_purple", CARPET_PURPLE, CARPET_PURPLE_DOT),

--- a/src/features/pixel-office/buildPixelInputs.ts
+++ b/src/features/pixel-office/buildPixelInputs.ts
@@ -30,10 +30,19 @@ export const buildPixelAgentInputs = (params: {
                 : animationState.jukeboxHoldByAgentId[id]
                   ? "jukebox"
                   : null;
+    // Mirror the 3D scene's desk latch: stay in "working" through desk
+    // directives and for a short stretch after the last run activity, so
+    // agents visibly reach their desk and sit even for quick runs.
+    const workingLatched =
+      agent.status === "working" ||
+      Boolean(animationState?.deskHoldByAgentId[id]) ||
+      (animationState?.workingUntilByAgentId[id] ?? 0) > nowMs;
+    const status =
+      agent.status === "error" ? "error" : workingLatched ? "working" : agent.status;
     return {
       id,
       name: agent.name,
-      status: agent.status,
+      status,
       color: agent.color,
       streaming: Boolean(animationState?.streamingByAgentId[id]),
       thinking: Boolean(animationState?.thinkingByAgentId[id]),

--- a/src/features/pixel-office/buildPixelInputs.ts
+++ b/src/features/pixel-office/buildPixelInputs.ts
@@ -1,0 +1,50 @@
+// Maps live Hermes office state (roster + animation holds) into the pixel
+// simulation's input shape. Pure so it stays unit-testable.
+
+import type { OfficeAgent } from "@/features/retro-office/core/types";
+import type { OfficeAnimationState } from "@/lib/office/eventTriggers";
+import type { PixelAgentInput } from "@/features/pixel-office/types";
+
+export const buildPixelAgentInputs = (params: {
+  agents: OfficeAgent[];
+  animationState: OfficeAnimationState | null;
+  nowMs: number;
+}): PixelAgentInput[] => {
+  const { agents, animationState, nowMs } = params;
+  return agents.map((agent) => {
+    const id = agent.id;
+    const hold: PixelAgentInput["hold"] = !animationState
+      ? null
+      : animationState.phoneBoothHoldByAgentId[id]
+        ? "phone_booth"
+        : animationState.smsBoothHoldByAgentId[id]
+          ? "sms_booth"
+          : animationState.gymHoldByAgentId[id] ||
+              animationState.skillGymHoldByAgentId[id] ||
+              (animationState.manualGymUntilByAgentId[id] ?? 0) > nowMs
+            ? "gym"
+            : animationState.qaHoldByAgentId[id]
+              ? "qa_lab"
+              : animationState.githubHoldByAgentId[id]
+                ? "github_desk"
+                : animationState.jukeboxHoldByAgentId[id]
+                  ? "jukebox"
+                  : null;
+    return {
+      id,
+      name: agent.name,
+      status: agent.status,
+      color: agent.color,
+      streaming: Boolean(animationState?.streamingByAgentId[id]),
+      thinking: Boolean(animationState?.thinkingByAgentId[id]),
+      awaitingApproval: Boolean(animationState?.awaitingApprovalByAgentId[id]),
+      dancing: (animationState?.danceUntilByAgentId[id] ?? 0) > nowMs,
+      hold,
+      standup: Boolean(animationState?.pendingStandupRequest),
+    };
+  });
+};
+
+export const isCleaningActive = (
+  animationState: OfficeAnimationState | null,
+): boolean => Boolean(animationState && animationState.cleaningCues.length > 0);

--- a/src/features/pixel-office/map/hermesHqMap.ts
+++ b/src/features/pixel-office/map/hermesHqMap.ts
@@ -1,0 +1,395 @@
+// The default Hermes HQ pixel map: a hand-authored Gather-style office.
+// All coordinates are in tiles (16px each). The layout mirrors the immersive
+// office's rooms: meeting room, kitchen, team pods, lounge, game corner,
+// phone/SMS booths, gym, reading nook, ops corner, and a server room.
+
+import type {
+  PixelDeskSlot,
+  PixelFacing,
+  PixelGroundTile,
+  PixelMapObject,
+  PixelOfficeMap,
+  PixelObjectKind,
+  PixelStation,
+  PixelStationKind,
+  PixelZone,
+} from "@/features/pixel-office/types";
+
+export const HQ_COLS = 56;
+export const HQ_ROWS = 42;
+
+type Grid = PixelGroundTile[];
+
+const fillRect = (
+  ground: Grid,
+  tile: PixelGroundTile,
+  tx: number,
+  ty: number,
+  tw: number,
+  th: number,
+) => {
+  for (let y = ty; y < ty + th; y += 1) {
+    for (let x = tx; x < tx + tw; x += 1) {
+      if (x < 0 || y < 0 || x >= HQ_COLS || y >= HQ_ROWS) continue;
+      ground[y * HQ_COLS + x] = tile;
+    }
+  }
+};
+
+/** Paints a horizontal wall run, skipping listed door tiles. */
+const hWall = (ground: Grid, y: number, x1: number, x2: number, doors: number[] = []) => {
+  for (let x = x1; x <= x2; x += 1) {
+    if (doors.includes(x)) continue;
+    fillRect(ground, "wall", x, y, 1, 1);
+  }
+};
+
+/** Paints a vertical wall run, skipping listed door tiles. */
+const vWall = (ground: Grid, x: number, y1: number, y2: number, doors: number[] = []) => {
+  for (let y = y1; y <= y2; y += 1) {
+    if (doors.includes(y)) continue;
+    fillRect(ground, "wall", x, y, 1, 1);
+  }
+};
+
+let objectSeq = 0;
+const obj = (
+  kind: PixelObjectKind,
+  tx: number,
+  ty: number,
+  blocking?: boolean,
+): PixelMapObject => {
+  objectSeq += 1;
+  return { id: `obj-${kind}-${objectSeq}`, kind, tx, ty, ...(blocking === undefined ? {} : { blocking }) };
+};
+
+let stationSeq = 0;
+const station = (
+  kind: PixelStationKind,
+  tx: number,
+  ty: number,
+  facing: PixelFacing,
+): PixelStation => {
+  stationSeq += 1;
+  return { id: `st-${kind}-${stationSeq}`, kind, tx, ty, facing };
+};
+
+const desk = (
+  id: string,
+  deskTx: number,
+  deskTy: number,
+  seatTx: number,
+  seatTy: number,
+  facing: PixelFacing = "down",
+): PixelDeskSlot => ({ id, deskTx, deskTy, seatTx, seatTy, facing });
+
+const zone = (
+  id: string,
+  kind: PixelZone["kind"],
+  label: string | null,
+  tx: number,
+  ty: number,
+  tw: number,
+  th: number,
+): PixelZone => ({ id, kind, label, tx, ty, tw, th });
+
+export const buildHermesHqMap = (): PixelOfficeMap => {
+  objectSeq = 0;
+  stationSeq = 0;
+
+  const ground: Grid = new Array<PixelGroundTile>(HQ_COLS * HQ_ROWS).fill("grass");
+
+  // ---------------------------------------------------------------------
+  // Floors. The building interior spans x 6..53, y 2..39.
+  // ---------------------------------------------------------------------
+  fillRect(ground, "floor_cream", 6, 2, 48, 38);
+  // Left column of rooms.
+  fillRect(ground, "carpet_purple", 6, 2, 11, 10); // Meeting room.
+  fillRect(ground, "floor_white", 6, 13, 11, 9); // Phone booths.
+  fillRect(ground, "gym_mat", 6, 23, 11, 10); // Gym.
+  // Top rooms.
+  fillRect(ground, "kitchen_tile", 18, 2, 10, 7); // Kitchen.
+  fillRect(ground, "floor_white", 29, 2, 10, 7); // CX team pod.
+  fillRect(ground, "floor_wood", 40, 2, 14, 11); // Reading nook.
+  // Center + south.
+  fillRect(ground, "carpet_purple", 18, 25, 16, 15); // Lounge.
+  fillRect(ground, "carpet_blue", 34, 25, 11, 9); // Game corner.
+  fillRect(ground, "server_floor", 45, 25, 9, 15); // Server room.
+
+  // ---------------------------------------------------------------------
+  // Walls. Perimeter first, then interior dividers with door gaps.
+  // ---------------------------------------------------------------------
+  hWall(ground, 1, 5, 54);
+  hWall(ground, 40, 5, 54);
+  vWall(ground, 5, 1, 40, [35, 36]); // Entrance on the west side.
+  vWall(ground, 54, 1, 40);
+  // Left column divider (meeting/phone/gym vs. central floor).
+  vWall(ground, 17, 2, 39, [17, 18, 36, 37]);
+  // Meeting room south wall.
+  hWall(ground, 12, 6, 16, [11, 12]);
+  // Phone room south wall.
+  hWall(ground, 22, 6, 16, [10, 11]);
+  // Gym south wall.
+  hWall(ground, 33, 6, 16, [9, 10]);
+  // Kitchen + CX south wall.
+  hWall(ground, 9, 18, 38, [22, 23, 33, 34]);
+  // Kitchen | CX divider.
+  vWall(ground, 28, 2, 8);
+  // CX | reading nook divider with a doorway.
+  vWall(ground, 39, 2, 8, [4, 5]);
+  // Server room walls.
+  vWall(ground, 44, 24, 39, [30, 31]);
+  hWall(ground, 24, 45, 53);
+
+  // ---------------------------------------------------------------------
+  // Objects.
+  // ---------------------------------------------------------------------
+  const objects: PixelMapObject[] = [
+    // Outdoors.
+    obj("tree", 1, 3),
+    obj("tree", 2, 13),
+    obj("tree", 1, 25),
+    obj("tree", 3, 33),
+    obj("flower", 3, 8),
+    obj("flower", 2, 20),
+    obj("flower", 4, 29),
+    obj("flower", 1, 38),
+
+    // Meeting room.
+    obj("whiteboard", 7, 2),
+    obj("tv_stand", 12, 2),
+    obj("meeting_table", 10, 6),
+    obj("plant_tall", 6, 2),
+    obj("plant", 16, 10),
+
+    // Kitchen.
+    obj("kitchen_counter", 19, 2),
+    obj("kitchen_counter", 21, 2),
+    obj("coffee_machine", 23, 2),
+    obj("fridge", 24, 2),
+    obj("vending_machine", 26, 2),
+    obj("coffee_table", 21, 6),
+    obj("water_cooler", 27, 8),
+    obj("plant", 18, 8),
+
+    // CX team pod.
+    obj("desk_monitor", 30, 4),
+    obj("desk_monitor", 34, 4),
+    obj("desk_monitor", 30, 7),
+    obj("desk_monitor", 34, 7),
+    obj("chair", 30, 5, false),
+    obj("chair", 34, 5, false),
+    obj("chair", 30, 8, false),
+    obj("chair", 34, 8, false),
+    obj("plant", 37, 2),
+    obj("kanban_board", 32, 2),
+
+    // Reading nook.
+    obj("bookshelf", 41, 2),
+    obj("bookshelf", 43, 2),
+    obj("bookshelf", 45, 2),
+    obj("bookshelf", 47, 2),
+    obj("aquarium", 50, 2),
+    obj("lamp", 52, 2),
+    obj("sofa_h", 44, 5),
+    obj("coffee_table", 44, 7),
+    obj("sofa_h", 44, 9),
+    obj("plant_tall", 40, 2),
+    obj("plant", 53, 11),
+    obj("rug", 47, 6, false),
+
+    // Product team pods (two pods of four desks).
+    obj("desk_monitor", 20, 13),
+    obj("desk_monitor", 23, 13),
+    obj("desk_monitor", 20, 16),
+    obj("desk_monitor", 23, 16),
+    obj("chair", 20, 14, false),
+    obj("chair", 23, 14, false),
+    obj("chair", 20, 17, false),
+    obj("chair", 23, 17, false),
+    obj("desk_monitor", 29, 13),
+    obj("desk_monitor", 32, 13),
+    obj("desk_monitor", 29, 16),
+    obj("desk_monitor", 32, 16),
+    obj("chair", 29, 14, false),
+    obj("chair", 32, 14, false),
+    obj("chair", 29, 17, false),
+    obj("chair", 32, 17, false),
+    obj("kanban_board", 26, 11),
+    obj("plant", 18, 10),
+    obj("plant", 38, 10),
+    obj("water_cooler", 38, 14),
+
+    // Planter row between product area and lounge.
+    obj("plant", 19, 24),
+    obj("plant_tall", 24, 24),
+    obj("plant", 29, 24),
+    obj("plant_tall", 34, 24),
+    obj("plant", 39, 24),
+
+    // Ops corner (east of product pods).
+    obj("desk_monitor", 45, 15),
+    obj("chair", 45, 16, false),
+    obj("whiteboard", 48, 13),
+    obj("plant", 41, 13),
+    obj("atm", 52, 20),
+
+    // Phone booths room.
+    obj("phone_booth", 8, 14),
+    obj("phone_booth", 10, 14),
+    obj("sms_booth", 13, 14),
+    obj("plant", 6, 13),
+    obj("plant", 16, 13),
+    obj("sofa_v", 6, 17),
+    obj("lamp", 16, 20),
+
+    // Gym.
+    obj("treadmill", 8, 24, false),
+    obj("treadmill", 11, 24, false),
+    obj("dumbbell_rack", 13, 24),
+    obj("water_cooler", 6, 30),
+    obj("plant", 16, 31),
+
+    // Entry hall (south-west).
+    obj("plant_tall", 6, 34),
+    obj("plant_tall", 6, 38),
+    obj("rug", 8, 36, false),
+    obj("bookshelf", 12, 34),
+
+    // Lounge.
+    obj("tv_stand", 20, 26),
+    obj("sofa_h", 24, 29),
+    obj("sofa_v", 22, 30),
+    obj("sofa_v", 27, 30),
+    obj("coffee_table", 25, 31),
+    obj("rug", 24, 30, false),
+    obj("ping_pong_table", 29, 34),
+    obj("plant", 18, 25),
+    obj("plant", 18, 38),
+    obj("flower", 33, 38),
+
+    // Game corner.
+    obj("arcade", 36, 26),
+    obj("arcade", 38, 26),
+    obj("jukebox", 42, 26),
+    obj("plant", 34, 25),
+    obj("vending_machine", 44, 30),
+
+    // South-east hall.
+    obj("water_cooler", 35, 36),
+    obj("plant", 43, 38),
+
+    // Server room.
+    obj("server_rack", 46, 26),
+    obj("server_rack", 48, 26),
+    obj("server_rack", 50, 26),
+    obj("server_rack", 52, 26),
+    obj("desk_monitor", 47, 31),
+    obj("chair", 47, 32, false),
+    obj("lamp", 52, 37),
+  ];
+
+  // ---------------------------------------------------------------------
+  // Desks (assignable seats). The github/qa desks are reserved stations.
+  // ---------------------------------------------------------------------
+  const desks: PixelDeskSlot[] = [
+    desk("desk-a1", 20, 13, 20, 14),
+    desk("desk-a2", 23, 13, 23, 14),
+    desk("desk-a3", 20, 16, 20, 17),
+    desk("desk-a4", 23, 16, 23, 17),
+    desk("desk-b1", 29, 13, 29, 14),
+    desk("desk-b2", 32, 13, 32, 14),
+    desk("desk-b3", 29, 16, 29, 17),
+    desk("desk-b4", 32, 16, 32, 17),
+    desk("desk-cx1", 30, 4, 30, 5),
+    desk("desk-cx2", 34, 4, 34, 5),
+    desk("desk-cx3", 30, 7, 30, 8),
+    desk("desk-cx4", 34, 7, 34, 8),
+  ];
+
+  // ---------------------------------------------------------------------
+  // Stations for holds and idle wandering.
+  // ---------------------------------------------------------------------
+  const stations: PixelStation[] = [
+    // Hold targets.
+    station("phone_booth", 8, 15, "up"),
+    station("phone_booth", 10, 15, "up"),
+    station("sms_booth", 13, 15, "up"),
+    station("gym", 8, 25, "up"),
+    station("gym", 11, 25, "up"),
+    station("gym", 13, 25, "up"),
+    station("gym", 10, 29, "down"),
+    station("qa_lab", 47, 32, "down"),
+    station("github_desk", 45, 16, "down"),
+    station("jukebox", 42, 27, "up"),
+    station("kanban", 26, 12, "up"),
+    station("kanban", 27, 12, "up"),
+    // Meeting seats around the big table.
+    station("meeting_seat", 10, 5, "down"),
+    station("meeting_seat", 11, 5, "down"),
+    station("meeting_seat", 12, 5, "down"),
+    station("meeting_seat", 10, 8, "up"),
+    station("meeting_seat", 11, 8, "up"),
+    station("meeting_seat", 12, 8, "up"),
+    station("meeting_seat", 9, 6, "right"),
+    station("meeting_seat", 9, 7, "right"),
+    station("meeting_seat", 13, 6, "left"),
+    station("meeting_seat", 13, 7, "left"),
+    // Idle wandering spots.
+    station("coffee", 23, 3, "up"),
+    station("coffee", 24, 3, "up"),
+    station("coffee", 20, 6, "right"),
+    station("coffee", 22, 6, "left"),
+    station("water_cooler", 26, 8, "right"),
+    station("water_cooler", 38, 15, "up"),
+    station("water_cooler", 35, 37, "up"),
+    station("lounge_seat", 24, 29, "down"),
+    station("lounge_seat", 25, 29, "down"),
+    station("lounge_seat", 22, 30, "right"),
+    station("lounge_seat", 27, 30, "left"),
+    station("library", 44, 5, "down"),
+    station("library", 45, 5, "down"),
+    station("library", 44, 9, "down"),
+    station("library", 45, 9, "down"),
+    station("ping_pong", 28, 34, "right"),
+    station("ping_pong", 32, 34, "left"),
+    station("arcade", 36, 27, "up"),
+    station("arcade", 38, 27, "up"),
+    station("wander", 27, 20, "down"),
+    station("wander", 21, 11, "down"),
+    station("wander", 35, 11, "down"),
+    station("wander", 41, 18, "down"),
+    station("wander", 21, 33, "right"),
+    station("wander", 40, 35, "left"),
+    station("wander", 12, 37, "up"),
+    station("wander", 10, 30, "down"),
+  ];
+
+  // ---------------------------------------------------------------------
+  // Zones with Gather-style floating labels.
+  // ---------------------------------------------------------------------
+  const zones: PixelZone[] = [
+    zone("z-meeting", "meeting", "Meeting room", 6, 2, 11, 10),
+    zone("z-kitchen", "kitchen", "Kitchen", 18, 2, 10, 7),
+    zone("z-cx", "team_pod", "CX team", 29, 2, 10, 7),
+    zone("z-reading", "library", "Reading nook", 40, 2, 14, 11),
+    zone("z-product", "team_pod", "Product team", 18, 10, 21, 15),
+    zone("z-ops", "focus", "Ops corner", 40, 13, 14, 11),
+    zone("z-phone", "phone", "Phone booths", 6, 13, 11, 9),
+    zone("z-gym", "gym", "Gym", 6, 23, 11, 10),
+    zone("z-lounge", "lounge", "Lounge", 18, 25, 16, 15),
+    zone("z-game", "game_room", "Game room", 34, 25, 11, 9),
+    zone("z-server", "server", "Server room", 45, 25, 9, 15),
+  ];
+
+  return {
+    cols: HQ_COLS,
+    rows: HQ_ROWS,
+    ground,
+    objects,
+    zones,
+    desks,
+    stations,
+    spawn: { tx: 8, ty: 37 },
+  };
+};

--- a/src/features/pixel-office/map/hermesHqMap.ts
+++ b/src/features/pixel-office/map/hermesHqMap.ts
@@ -52,6 +52,14 @@ const vWall = (ground: Grid, x: number, y1: number, y2: number, doors: number[] 
   }
 };
 
+/** Replaces horizontal wall tiles with window panes (still blocking). */
+const windows = (ground: Grid, y: number, xs: number[]) => {
+  for (const x of xs) {
+    if (ground[y * HQ_COLS + x] !== "wall") continue;
+    fillRect(ground, "wall_window", x, y, 1, 1);
+  }
+};
+
 let objectSeq = 0;
 const obj = (
   kind: PixelObjectKind,
@@ -140,6 +148,12 @@ export const buildHermesHqMap = (): PixelOfficeMap => {
   // Server room walls.
   vWall(ground, 44, 24, 39, [30, 31]);
   hWall(ground, 24, 45, 53);
+
+  // Window panes along the north facade and key interior walls (Gather-style).
+  windows(ground, 1, [8, 9, 13, 14, 20, 21, 25, 26, 31, 32, 36, 37, 43, 44, 49, 50]);
+  windows(ground, 9, [19, 20, 26, 27, 30, 31, 36, 37]);
+  windows(ground, 12, [8, 9, 14, 15]);
+  windows(ground, 22, [7, 8, 13, 14]);
 
   // ---------------------------------------------------------------------
   // Objects.

--- a/src/features/pixel-office/map/navGrid.ts
+++ b/src/features/pixel-office/map/navGrid.ts
@@ -1,0 +1,53 @@
+// Builds a NavGrid2D (one cell per tile) from a PixelOfficeMap so the shared
+// astar2D pathfinder can route agents around walls and furniture.
+
+import type { NavGrid2D } from "@/lib/office/pathfinding";
+import {
+  BLOCKING_OBJECT_KINDS,
+  OBJECT_FOOTPRINT,
+  PIXEL_TILE_SIZE,
+  type PixelOfficeMap,
+} from "@/features/pixel-office/types";
+
+export const tileCenter = (tx: number, ty: number) => ({
+  x: tx * PIXEL_TILE_SIZE + PIXEL_TILE_SIZE / 2,
+  y: ty * PIXEL_TILE_SIZE + PIXEL_TILE_SIZE / 2,
+});
+
+export const buildPixelNavGrid = (map: PixelOfficeMap): NavGrid2D => {
+  const { cols, rows } = map;
+  const cells = new Uint8Array(cols * rows);
+
+  for (let index = 0; index < map.ground.length; index += 1) {
+    const tile = map.ground[index];
+    if (tile === "wall" || tile === "void") {
+      cells[index] = 1;
+    }
+  }
+
+  for (const object of map.objects) {
+    const blocking = object.blocking ?? BLOCKING_OBJECT_KINDS.has(object.kind);
+    if (!blocking) continue;
+    const [fw, fh] = OBJECT_FOOTPRINT[object.kind];
+    for (let dy = 0; dy < fh; dy += 1) {
+      for (let dx = 0; dx < fw; dx += 1) {
+        const tx = object.tx + dx;
+        const ty = object.ty + dy;
+        if (tx < 0 || ty < 0 || tx >= cols || ty >= rows) continue;
+        cells[ty * cols + tx] = 1;
+      }
+    }
+  }
+
+  // Seats and station tiles must stay reachable even when they sit on top of
+  // furniture (sofas, treadmills), so carve them free last.
+  for (const deskSlot of map.desks) {
+    cells[deskSlot.seatTy * cols + deskSlot.seatTx] = 0;
+  }
+  for (const stationSlot of map.stations) {
+    cells[stationSlot.ty * cols + stationSlot.tx] = 0;
+  }
+  cells[map.spawn.ty * cols + map.spawn.tx] = 0;
+
+  return { cells, cols, rows, cellSize: PIXEL_TILE_SIZE };
+};

--- a/src/features/pixel-office/map/navGrid.ts
+++ b/src/features/pixel-office/map/navGrid.ts
@@ -20,7 +20,7 @@ export const buildPixelNavGrid = (map: PixelOfficeMap): NavGrid2D => {
 
   for (let index = 0; index < map.ground.length; index += 1) {
     const tile = map.ground[index];
-    if (tile === "wall" || tile === "void") {
+    if (tile === "wall" || tile === "wall_window" || tile === "void") {
       cells[index] = 1;
     }
   }

--- a/src/features/pixel-office/scene/PixelOfficeScene.ts
+++ b/src/features/pixel-office/scene/PixelOfficeScene.ts
@@ -48,11 +48,11 @@ const SEATED_STATION_KINDS: ReadonlySet<PixelStationKind> = new Set([
 const WALK_FRAME_MS = 140;
 const DANCE_FRAME_MS = 260;
 
-const MIN_ZOOM = 0.5;
-const MAX_ZOOM = 4;
+const MIN_ZOOM = 0.35;
+const MAX_ZOOM = 2;
 
 /** World-space radius around an agent's body that accepts clicks. */
-const AGENT_CLICK_RADIUS = 14;
+const AGENT_CLICK_RADIUS = 28;
 
 type AgentVisual = {
   container: Phaser.GameObjects.Container;
@@ -203,16 +203,16 @@ export const createPixelOfficeScene = (params: {
       for (const zoneEntry of map.zones) {
         if (!zoneEntry.label) continue;
         const centerX = (zoneEntry.tx + zoneEntry.tw / 2) * TILE;
-        const topY = zoneEntry.ty * TILE + 22;
+        const topY = zoneEntry.ty * TILE + 44;
         const text = this.add.text(0, 0, zoneEntry.label, {
           fontFamily: "system-ui, sans-serif",
-          fontSize: "8px",
+          fontSize: "16px",
           color: "#5b5346",
         });
-        text.setResolution(6);
+        text.setResolution(4);
         text.setOrigin(0.5, 0.5);
-        const paddingX = 6;
-        const paddingY = 3;
+        const paddingX = 11;
+        const paddingY = 5;
         const bg = this.add.graphics();
         bg.fillStyle(0xf7f1e3, 0.92);
         bg.fillRoundedRect(
@@ -263,7 +263,7 @@ export const createPixelOfficeScene = (params: {
       // Gather-style default: start close enough that the pixel art reads at
       // 1:1+ detail, centered on the main pods. Wheel out for the overview.
       const zoom = PhaserLib.Math.Clamp(
-        Math.max(1.5, Math.floor(this.containZoom() * 4) / 4),
+        Math.max(0.75, Math.floor(this.containZoom() * 4) / 4),
         this.minZoom(),
         MAX_ZOOM,
       );
@@ -385,7 +385,7 @@ export const createPixelOfficeScene = (params: {
     }
 
     private createVisual(id: string, name: string): AgentVisual {
-      const shadow = this.add.ellipse(0, -1, 15, 6, 0x000000, 0.2);
+      const shadow = this.add.ellipse(0, -2, 30, 11, 0x000000, 0.2);
       const sprite = this.add.image(0, 0, `char_${id}_idle_down`);
       sprite.setOrigin(0.5, 1);
       // Clicks are resolved scene-wide via pickAgentAt (more forgiving for
@@ -398,41 +398,41 @@ export const createPixelOfficeScene = (params: {
       const nameBg = this.add.graphics();
       const nameText = this.add.text(0, 0, name, {
         fontFamily: "system-ui, sans-serif",
-        fontSize: "7px",
+        fontSize: "14px",
         color: "#f4f7ff",
         fontStyle: "bold",
       });
-      nameText.setResolution(6);
+      nameText.setResolution(4);
       nameText.setOrigin(0.5, 0.5);
-      const statusDot = this.add.circle(0, 0, 2, 0x4ade80);
+      const statusDot = this.add.circle(0, 0, 4, 0x4ade80);
       const bubbleBg = this.add.graphics();
       const bubbleText = this.add.text(0, 0, "", {
         fontFamily: "system-ui, sans-serif",
-        fontSize: "6px",
+        fontSize: "12px",
         color: "#2b2b3a",
         align: "left",
-        wordWrap: { width: 88 },
+        wordWrap: { width: 170 },
       });
-      bubbleText.setResolution(6);
+      bubbleText.setResolution(4);
       bubbleText.setOrigin(0.5, 1);
       const thinkText = this.add.text(0, 0, "…", {
         fontFamily: "system-ui, sans-serif",
-        fontSize: "9px",
+        fontSize: "18px",
         color: "#2b2b3a",
         backgroundColor: "#f4f7ff",
-        padding: { left: 3, right: 3, top: 0, bottom: 1 },
+        padding: { left: 6, right: 6, top: 0, bottom: 2 },
       });
-      thinkText.setResolution(6);
+      thinkText.setResolution(4);
       thinkText.setOrigin(0.5, 1);
       const badgeText = this.add.text(0, 0, "!", {
         fontFamily: "system-ui, sans-serif",
-        fontSize: "8px",
+        fontSize: "16px",
         color: "#1f1303",
         fontStyle: "bold",
         backgroundColor: "#fbbf24",
-        padding: { left: 3, right: 3, top: 0, bottom: 1 },
+        padding: { left: 6, right: 6, top: 0, bottom: 2 },
       });
-      badgeText.setResolution(6);
+      badgeText.setResolution(4);
       badgeText.setOrigin(0.5, 1);
       const overlay = this.add.container(0, 0, [
         nameBg,
@@ -502,7 +502,7 @@ export const createPixelOfficeScene = (params: {
         visual.sprite.setTexture(frameKey);
       }
 
-      const overlayY = pose.y + TILE / 2 - CHARACTER_HEIGHT - 4;
+      const overlayY = pose.y + TILE / 2 - CHARACTER_HEIGHT - 8;
       visual.overlay.setPosition(pose.x, overlayY);
 
       // Nameplate pill with the status dot.
@@ -513,13 +513,13 @@ export const createPixelOfficeScene = (params: {
         visual.lastStatus = status;
         visual.nameText.setText(name.length > 16 ? `${name.slice(0, 15)}…` : name);
       }
-      const plateWidth = visual.nameText.width + 14;
-      const plateHeight = 10;
+      const plateWidth = visual.nameText.width + 26;
+      const plateHeight = 20;
       visual.nameBg.clear();
       visual.nameBg.fillStyle(0x11131c, 0.82);
-      visual.nameBg.fillRoundedRect(-plateWidth / 2, -plateHeight / 2, plateWidth, plateHeight, 4);
-      visual.nameText.setPosition(3, 0);
-      visual.statusDot.setPosition(-plateWidth / 2 + 5, 0);
+      visual.nameBg.fillRoundedRect(-plateWidth / 2, -plateHeight / 2, plateWidth, plateHeight, 8);
+      visual.nameText.setPosition(5, 0);
+      visual.statusDot.setPosition(-plateWidth / 2 + 9, 0);
       visual.statusDot.setFillStyle(STATUS_DOT_COLOR[status] ?? 0x9ca3af);
       if (status === "working") {
         visual.statusDot.setAlpha(0.6 + 0.4 * Math.abs(Math.sin(this.animClock / 400)));
@@ -529,7 +529,7 @@ export const createPixelOfficeScene = (params: {
 
       // Speech bubble (streaming text tail) with a short linger after the
       // stream finishes so quick replies stay readable.
-      const bubbleTail = bubble.trim().length > 0 ? tailOf(bubble, 90) : "";
+      const bubbleTail = bubble.trim().length > 0 ? tailOf(bubble, 110) : "";
       if (bubbleTail !== visual.lastBubble) {
         visual.lastBubble = bubbleTail;
         if (bubbleTail.length > 0) {
@@ -545,16 +545,16 @@ export const createPixelOfficeScene = (params: {
       visual.bubbleBg.setVisible(showBubble);
       visual.bubbleText.setVisible(showBubble);
       if (showBubble) {
-        const bw = visual.bubbleText.width + 10;
-        const bh = visual.bubbleText.height + 8;
-        const by = -8;
-        visual.bubbleText.setPosition(0, by - 4);
+        const bw = visual.bubbleText.width + 18;
+        const bh = visual.bubbleText.height + 14;
+        const by = -14;
+        visual.bubbleText.setPosition(0, by - 7);
         visual.bubbleBg.clear();
         visual.bubbleBg.fillStyle(0xf9fbff, 0.96);
-        visual.bubbleBg.lineStyle(1, 0x2b2b3a, 0.9);
-        visual.bubbleBg.fillRoundedRect(-bw / 2, by - bh, bw, bh, 4);
-        visual.bubbleBg.strokeRoundedRect(-bw / 2, by - bh, bw, bh, 4);
-        visual.bubbleBg.fillTriangle(-3, by, 3, by, 0, by + 4);
+        visual.bubbleBg.lineStyle(2, 0x2b2b3a, 0.9);
+        visual.bubbleBg.fillRoundedRect(-bw / 2, by - bh, bw, bh, 7);
+        visual.bubbleBg.strokeRoundedRect(-bw / 2, by - bh, bw, bh, 7);
+        visual.bubbleBg.fillTriangle(-6, by, 6, by, 0, by + 7);
       }
 
       // Thinking dots (hidden while a speech bubble is visible).
@@ -563,14 +563,14 @@ export const createPixelOfficeScene = (params: {
       if (thinking) {
         const dots = 1 + (Math.floor(this.animClock / 350) % 3);
         visual.thinkText.setText(".".repeat(dots));
-        visual.thinkText.setPosition(10, -8);
+        visual.thinkText.setPosition(20, -14);
       }
 
       // Approval badge.
       const approval = Boolean(input?.awaitingApproval);
       visual.badgeText.setVisible(approval);
       if (approval) {
-        visual.badgeText.setPosition(-11, -8);
+        visual.badgeText.setPosition(-22, -14);
         visual.badgeText.setAlpha(0.75 + 0.25 * Math.sin(this.animClock / 250));
       }
     }

--- a/src/features/pixel-office/scene/PixelOfficeScene.ts
+++ b/src/features/pixel-office/scene/PixelOfficeScene.ts
@@ -48,7 +48,7 @@ const SEATED_STATION_KINDS: ReadonlySet<PixelStationKind> = new Set([
 const WALK_FRAME_MS = 140;
 const DANCE_FRAME_MS = 260;
 
-const MIN_ZOOM = 0.75;
+const MIN_ZOOM = 0.5;
 const MAX_ZOOM = 4;
 
 /** World-space radius around an agent's body that accepts clicks. */
@@ -232,23 +232,43 @@ export const createPixelOfficeScene = (params: {
     // Camera + input.
     // -------------------------------------------------------------------
 
-    private setupCamera() {
-      const camera = this.cameras.main;
-      camera.setBounds(-TILE * 2, -TILE * 2, worldWidth + TILE * 4, worldHeight + TILE * 4);
-      camera.setRoundPixels(true);
-      // Start with the whole office in view (Gather-style overview) and let
-      // the user zoom in from there.
-      const containZoom = Math.min(
+    /** Zoom at which the whole map (plus a margin) fits the viewport. */
+    private containZoom(): number {
+      return Math.min(
         this.scale.width / (worldWidth + TILE * 2),
         this.scale.height / (worldHeight + TILE * 2),
       );
+    }
+
+    /** Lowest allowed zoom: never smaller than "whole map in view". */
+    private minZoom(): number {
+      return Math.min(MAX_ZOOM, Math.max(MIN_ZOOM, this.containZoom()));
+    }
+
+    private setupCamera() {
+      const camera = this.cameras.main;
+      // Bounds are at least as large as the viewport at minimum zoom and
+      // centered on the map, so a fully zoomed-out map sits centered with
+      // symmetric grass margins instead of pinned to a corner.
+      const minZoom = this.minZoom();
+      const boundsW = Math.max(worldWidth + TILE * 4, this.scale.width / minZoom);
+      const boundsH = Math.max(worldHeight + TILE * 4, this.scale.height / minZoom);
+      camera.setBounds(
+        worldWidth / 2 - boundsW / 2,
+        worldHeight / 2 - boundsH / 2,
+        boundsW,
+        boundsH,
+      );
+      camera.setRoundPixels(true);
+      // Gather-style default: start close enough that the pixel art reads at
+      // 1:1+ detail, centered on the main pods. Wheel out for the overview.
       const zoom = PhaserLib.Math.Clamp(
-        Math.floor(containZoom * 4) / 4,
-        MIN_ZOOM,
+        Math.max(1.5, Math.floor(this.containZoom() * 4) / 4),
+        this.minZoom(),
         MAX_ZOOM,
       );
       camera.setZoom(zoom);
-      camera.centerOn(worldWidth / 2, worldHeight / 2);
+      camera.centerOn(worldWidth / 2, worldHeight * 0.42);
     }
 
     private setupPointerControls() {
@@ -311,7 +331,7 @@ export const createPixelOfficeScene = (params: {
         ) => {
           const camera = this.cameras.main;
           const step = deltaY > 0 ? -0.25 : 0.25;
-          const next = PhaserLib.Math.Clamp(camera.zoom + step, MIN_ZOOM, MAX_ZOOM);
+          const next = PhaserLib.Math.Clamp(camera.zoom + step, this.minZoom(), MAX_ZOOM);
           camera.setZoom(next);
         },
       );
@@ -365,7 +385,7 @@ export const createPixelOfficeScene = (params: {
     }
 
     private createVisual(id: string, name: string): AgentVisual {
-      const shadow = this.add.ellipse(0, -1, 12, 5, 0x000000, 0.22);
+      const shadow = this.add.ellipse(0, -1, 15, 6, 0x000000, 0.2);
       const sprite = this.add.image(0, 0, `char_${id}_idle_down`);
       sprite.setOrigin(0.5, 1);
       // Clicks are resolved scene-wide via pickAgentAt (more forgiving for

--- a/src/features/pixel-office/scene/PixelOfficeScene.ts
+++ b/src/features/pixel-office/scene/PixelOfficeScene.ts
@@ -48,8 +48,11 @@ const SEATED_STATION_KINDS: ReadonlySet<PixelStationKind> = new Set([
 const WALK_FRAME_MS = 140;
 const DANCE_FRAME_MS = 260;
 
-const MIN_ZOOM = 1;
+const MIN_ZOOM = 0.75;
 const MAX_ZOOM = 4;
+
+/** World-space radius around an agent's body that accepts clicks. */
+const AGENT_CLICK_RADIUS = 14;
 
 type AgentVisual = {
   container: Phaser.GameObjects.Container;
@@ -64,10 +67,15 @@ type AgentVisual = {
   thinkText: Phaser.GameObjects.Text;
   badgeText: Phaser.GameObjects.Text;
   lastBubble: string;
+  lingerText: string;
+  bubbleChangedAt: number;
   lastStatus: string;
   lastName: string;
   seed: string;
 };
+
+/** How long a finished speech bubble stays readable, in ms. */
+const BUBBLE_LINGER_MS = 3_000;
 
 export const createPixelOfficeScene = (params: {
   PhaserLib: typeof import("phaser");
@@ -195,7 +203,7 @@ export const createPixelOfficeScene = (params: {
       for (const zoneEntry of map.zones) {
         if (!zoneEntry.label) continue;
         const centerX = (zoneEntry.tx + zoneEntry.tw / 2) * TILE;
-        const topY = zoneEntry.ty * TILE + 12;
+        const topY = zoneEntry.ty * TILE + 22;
         const text = this.add.text(0, 0, zoneEntry.label, {
           fontFamily: "system-ui, sans-serif",
           fontSize: "8px",
@@ -228,17 +236,19 @@ export const createPixelOfficeScene = (params: {
       const camera = this.cameras.main;
       camera.setBounds(-TILE * 2, -TILE * 2, worldWidth + TILE * 4, worldHeight + TILE * 4);
       camera.setRoundPixels(true);
-      const coverZoom = Math.max(
-        this.scale.width / worldWidth,
-        this.scale.height / worldHeight,
+      // Start with the whole office in view (Gather-style overview) and let
+      // the user zoom in from there.
+      const containZoom = Math.min(
+        this.scale.width / (worldWidth + TILE * 2),
+        this.scale.height / (worldHeight + TILE * 2),
       );
       const zoom = PhaserLib.Math.Clamp(
-        Math.round(coverZoom * 1.15 * 4) / 4,
+        Math.floor(containZoom * 4) / 4,
         MIN_ZOOM,
         MAX_ZOOM,
       );
       camera.setZoom(zoom);
-      camera.centerOn(worldWidth / 2, worldHeight / 2 - TILE * 2);
+      camera.centerOn(worldWidth / 2, worldHeight / 2);
     }
 
     private setupPointerControls() {
@@ -263,8 +273,33 @@ export const createPixelOfficeScene = (params: {
           this.dragStart.sy - dy / camera.zoom,
         );
       });
-      this.input.on("pointerup", () => {
+      this.input.on("pointerup", (pointer: Phaser.Input.Pointer) => {
+        const wasDrag = this.dragDistance > 6;
         this.dragStart = null;
+        if (wasDrag) return;
+        const world = this.cameras.main.getWorldPoint(pointer.x, pointer.y);
+        const agentId = this.pickAgentAt(world.x, world.y);
+        if (!agentId) return;
+        if (pointer.rightButtonReleased()) {
+          const nativeEvent = pointer.event as MouseEvent;
+          bridge.callbacks.onAgentContextMenu?.(
+            agentId,
+            nativeEvent.clientX ?? 0,
+            nativeEvent.clientY ?? 0,
+          );
+          return;
+        }
+        if (agentId === JANITOR_ID) return;
+        const visual = this.visuals.get(agentId);
+        if (visual) {
+          this.cameras.main.pan(
+            visual.container.x,
+            visual.container.y,
+            350,
+            "Sine.easeInOut",
+          );
+        }
+        bridge.callbacks.onAgentClick?.(agentId);
       });
       this.input.on(
         "wheel",
@@ -285,6 +320,23 @@ export const createPixelOfficeScene = (params: {
     // -------------------------------------------------------------------
     // Agents.
     // -------------------------------------------------------------------
+
+    /** Returns the id of the agent whose body is nearest to a world point. */
+    private pickAgentAt(worldX: number, worldY: number): string | null {
+      let bestId: string | null = null;
+      let bestDistance = AGENT_CLICK_RADIUS;
+      for (const [id, visual] of this.visuals) {
+        // The clickable center sits mid-body, above the feet anchor.
+        const bodyX = visual.container.x;
+        const bodyY = visual.container.y - CHARACTER_HEIGHT / 2;
+        const distance = Math.hypot(worldX - bodyX, worldY - bodyY);
+        if (distance < bestDistance) {
+          bestDistance = distance;
+          bestId = id;
+        }
+      }
+      return bestId;
+    }
 
     private syncAgents(poses: PixelAgentPose[]) {
       const state = bridge.getState();
@@ -316,22 +368,9 @@ export const createPixelOfficeScene = (params: {
       const shadow = this.add.ellipse(0, -1, 12, 5, 0x000000, 0.22);
       const sprite = this.add.image(0, 0, `char_${id}_idle_down`);
       sprite.setOrigin(0.5, 1);
+      // Clicks are resolved scene-wide via pickAgentAt (more forgiving for
+      // small moving targets); the sprite is interactive for hover feedback.
       sprite.setInteractive({ useHandCursor: true });
-      sprite.on("pointerup", (pointer: Phaser.Input.Pointer) => {
-        if (this.dragDistance > 6) return;
-        if (pointer.rightButtonReleased()) {
-          const nativeEvent = pointer.event as MouseEvent;
-          bridge.callbacks.onAgentContextMenu?.(
-            id,
-            nativeEvent.clientX ?? 0,
-            nativeEvent.clientY ?? 0,
-          );
-          return;
-        }
-        if (id === JANITOR_ID) return;
-        this.cameras.main.pan(sprite.parentContainer.x, sprite.parentContainer.y, 350, "Sine.easeInOut");
-        bridge.callbacks.onAgentClick?.(id);
-      });
       sprite.on("pointerover", () => sprite.setTint(0xd9f1ff));
       sprite.on("pointerout", () => sprite.clearTint());
       const container = this.add.container(0, 0, [shadow, sprite]);
@@ -399,6 +438,8 @@ export const createPixelOfficeScene = (params: {
         thinkText,
         badgeText,
         lastBubble: "",
+        lingerText: "",
+        bubbleChangedAt: -BUBBLE_LINGER_MS,
         lastStatus: "",
         lastName: name,
         seed: id,
@@ -466,13 +507,21 @@ export const createPixelOfficeScene = (params: {
         visual.statusDot.setAlpha(1);
       }
 
-      // Speech bubble (streaming text tail).
+      // Speech bubble (streaming text tail) with a short linger after the
+      // stream finishes so quick replies stay readable.
       const bubbleTail = bubble.trim().length > 0 ? tailOf(bubble, 90) : "";
       if (bubbleTail !== visual.lastBubble) {
         visual.lastBubble = bubbleTail;
-        visual.bubbleText.setText(bubbleTail);
+        if (bubbleTail.length > 0) {
+          visual.lingerText = bubbleTail;
+          visual.bubbleChangedAt = this.animClock;
+          visual.bubbleText.setText(bubbleTail);
+        }
       }
-      const showBubble = bubbleTail.length > 0;
+      const lingering =
+        visual.lingerText.length > 0 &&
+        this.animClock - visual.bubbleChangedAt < BUBBLE_LINGER_MS;
+      const showBubble = bubbleTail.length > 0 || lingering;
       visual.bubbleBg.setVisible(showBubble);
       visual.bubbleText.setVisible(showBubble);
       if (showBubble) {

--- a/src/features/pixel-office/scene/PixelOfficeScene.ts
+++ b/src/features/pixel-office/scene/PixelOfficeScene.ts
@@ -1,0 +1,517 @@
+// The Gather-style Phaser scene: renders the pixel office map, animates
+// agents from the simulation, and forwards clicks back to React.
+
+import type Phaser from "phaser";
+
+import {
+  buildCharacterFrames,
+  buildFurnitureSprites,
+  buildGroundTileSprites,
+  JANITOR_LOOK,
+  paintSpriteToContext,
+  spriteHeight,
+  spriteWidth,
+} from "@/features/pixel-office/art";
+import type { PixelSceneBridge } from "@/features/pixel-office/PixelSceneBridge";
+import {
+  createPixelSimulation,
+  JANITOR_ID,
+  type PixelSimulation,
+} from "@/features/pixel-office/sim/agentSimulation";
+import {
+  CHARACTER_HEIGHT,
+  OBJECT_FOOTPRINT,
+  PIXEL_TILE_SIZE,
+  type CharacterFrameName,
+  type PixelAgentPose,
+  type PixelFacing,
+  type PixelOfficeMap,
+  type PixelSprite,
+  type PixelStationKind,
+} from "@/features/pixel-office/types";
+
+const TILE = PIXEL_TILE_SIZE;
+
+const STATUS_DOT_COLOR: Record<string, number> = {
+  working: 0x4ade80,
+  idle: 0xfbbf24,
+  error: 0xef4444,
+};
+
+/** Station kinds where an arrived agent reads as seated. */
+const SEATED_STATION_KINDS: ReadonlySet<PixelStationKind> = new Set([
+  "lounge_seat",
+  "library",
+  "meeting_seat",
+]);
+
+const WALK_FRAME_MS = 140;
+const DANCE_FRAME_MS = 260;
+
+const MIN_ZOOM = 1;
+const MAX_ZOOM = 4;
+
+type AgentVisual = {
+  container: Phaser.GameObjects.Container;
+  sprite: Phaser.GameObjects.Image;
+  shadow: Phaser.GameObjects.Ellipse;
+  overlay: Phaser.GameObjects.Container;
+  nameBg: Phaser.GameObjects.Graphics;
+  nameText: Phaser.GameObjects.Text;
+  statusDot: Phaser.GameObjects.Arc;
+  bubbleBg: Phaser.GameObjects.Graphics;
+  bubbleText: Phaser.GameObjects.Text;
+  thinkText: Phaser.GameObjects.Text;
+  badgeText: Phaser.GameObjects.Text;
+  lastBubble: string;
+  lastStatus: string;
+  lastName: string;
+  seed: string;
+};
+
+export const createPixelOfficeScene = (params: {
+  PhaserLib: typeof import("phaser");
+  bridge: PixelSceneBridge;
+  map: PixelOfficeMap;
+}): Phaser.Scene => {
+  const { PhaserLib, bridge, map } = params;
+  const worldWidth = map.cols * TILE;
+  const worldHeight = map.rows * TILE;
+
+  class PixelOfficeScene extends PhaserLib.Scene {
+    private sim: PixelSimulation | null = null;
+    private visuals = new Map<string, AgentVisual>();
+    private frameSetReady = new Set<string>();
+    private animClock = 0;
+    private dragStart: { x: number; y: number; sx: number; sy: number } | null = null;
+    private dragDistance = 0;
+
+    constructor() {
+      super("pixel-office-scene");
+    }
+
+    create() {
+      this.sim = createPixelSimulation(map);
+      this.registerSprites([...buildGroundTileSprites(), ...buildFurnitureSprites()]);
+      this.renderGround();
+      this.renderFurniture();
+      this.renderZoneLabels();
+      this.setupCamera();
+      this.setupPointerControls();
+      this.events.once(PhaserLib.Scenes.Events.SHUTDOWN, () => {
+        this.visuals.clear();
+        this.sim = null;
+      });
+    }
+
+    update(_time: number, delta: number) {
+      if (!this.sim) return;
+      this.animClock += delta;
+      const state = bridge.getState();
+      const poses = this.sim.tick({
+        inputs: state.agents,
+        nowMs: Date.now(),
+        dtMs: delta,
+        cleaningActive: state.cleaningActive,
+      });
+      this.syncAgents(poses);
+    }
+
+    // -------------------------------------------------------------------
+    // Texture helpers.
+    // -------------------------------------------------------------------
+
+    private registerSprites(sprites: PixelSprite[]) {
+      for (const sprite of sprites) {
+        if (this.textures.exists(sprite.key)) continue;
+        const width = spriteWidth(sprite);
+        const height = spriteHeight(sprite);
+        const canvasTexture = this.textures.createCanvas(sprite.key, width, height);
+        if (!canvasTexture) continue;
+        const context = canvasTexture.getContext();
+        paintSpriteToContext(sprite, context, 0, 0);
+        canvasTexture.refresh();
+      }
+    }
+
+    private ensureCharacterTextures(seed: string, accentColor: string) {
+      if (this.frameSetReady.has(seed)) return;
+      const look = seed === JANITOR_ID ? JANITOR_LOOK : { seed, accentColor };
+      const frames = buildCharacterFrames(look);
+      this.registerSprites(Object.values(frames));
+      this.frameSetReady.add(seed);
+    }
+
+    // -------------------------------------------------------------------
+    // Static world rendering.
+    // -------------------------------------------------------------------
+
+    private renderGround() {
+      const rt = this.add.renderTexture(0, 0, worldWidth, worldHeight);
+      rt.setOrigin(0, 0);
+      rt.setDepth(0);
+      rt.beginDraw();
+      for (let ty = 0; ty < map.rows; ty += 1) {
+        for (let tx = 0; tx < map.cols; tx += 1) {
+          const tile = map.ground[ty * map.cols + tx];
+          if (tile === "void") continue;
+          const altKey = `tile_${tile}_alt`;
+          const useAlt =
+            this.textures.exists(altKey) && ((tx * 7 + ty * 13 + tx * ty) % 5 === 0);
+          const key = useAlt ? altKey : `tile_${tile}`;
+          if (!this.textures.exists(key)) continue;
+          rt.batchDraw(key, tx * TILE, ty * TILE);
+        }
+      }
+      rt.endDraw();
+    }
+
+    private renderFurniture() {
+      for (const object of map.objects) {
+        const key = `furn_${object.kind}`;
+        if (!this.textures.exists(key)) continue;
+        const [, fh] = OBJECT_FOOTPRINT[object.kind];
+        const bottomY = (object.ty + fh) * TILE;
+        const image = this.add.image(object.tx * TILE, bottomY, key);
+        image.setOrigin(0, 1);
+        // Flat decor stays under everything that walks over it.
+        const flat = object.kind === "rug" || object.kind === "flower";
+        image.setDepth(flat ? 1 : bottomY);
+        if (object.kind === "jukebox" || object.kind === "kanban_board") {
+          const stationKind = object.kind === "jukebox" ? "jukebox" : "kanban";
+          image.setInteractive({ useHandCursor: true });
+          image.on("pointerover", () => image.setTint(0xbfe8ff));
+          image.on("pointerout", () => image.clearTint());
+          image.on("pointerup", (pointer: Phaser.Input.Pointer) => {
+            if (this.dragDistance > 6) return;
+            if (pointer.rightButtonReleased()) return;
+            bridge.callbacks.onStationInteract?.(stationKind);
+          });
+        }
+      }
+    }
+
+    private renderZoneLabels() {
+      for (const zoneEntry of map.zones) {
+        if (!zoneEntry.label) continue;
+        const centerX = (zoneEntry.tx + zoneEntry.tw / 2) * TILE;
+        const topY = zoneEntry.ty * TILE + 12;
+        const text = this.add.text(0, 0, zoneEntry.label, {
+          fontFamily: "system-ui, sans-serif",
+          fontSize: "8px",
+          color: "#5b5346",
+        });
+        text.setResolution(6);
+        text.setOrigin(0.5, 0.5);
+        const paddingX = 6;
+        const paddingY = 3;
+        const bg = this.add.graphics();
+        bg.fillStyle(0xf7f1e3, 0.92);
+        bg.fillRoundedRect(
+          -text.width / 2 - paddingX,
+          -text.height / 2 - paddingY,
+          text.width + paddingX * 2,
+          text.height + paddingY * 2,
+          5,
+        );
+        const container = this.add.container(centerX, topY, [bg, text]);
+        container.setDepth(45_000);
+        container.setAlpha(0.95);
+      }
+    }
+
+    // -------------------------------------------------------------------
+    // Camera + input.
+    // -------------------------------------------------------------------
+
+    private setupCamera() {
+      const camera = this.cameras.main;
+      camera.setBounds(-TILE * 2, -TILE * 2, worldWidth + TILE * 4, worldHeight + TILE * 4);
+      camera.setRoundPixels(true);
+      const coverZoom = Math.max(
+        this.scale.width / worldWidth,
+        this.scale.height / worldHeight,
+      );
+      const zoom = PhaserLib.Math.Clamp(
+        Math.round(coverZoom * 1.15 * 4) / 4,
+        MIN_ZOOM,
+        MAX_ZOOM,
+      );
+      camera.setZoom(zoom);
+      camera.centerOn(worldWidth / 2, worldHeight / 2 - TILE * 2);
+    }
+
+    private setupPointerControls() {
+      this.input.mouse?.disableContextMenu();
+      this.input.on("pointerdown", (pointer: Phaser.Input.Pointer) => {
+        this.dragStart = {
+          x: pointer.x,
+          y: pointer.y,
+          sx: this.cameras.main.scrollX,
+          sy: this.cameras.main.scrollY,
+        };
+        this.dragDistance = 0;
+      });
+      this.input.on("pointermove", (pointer: Phaser.Input.Pointer) => {
+        if (!pointer.isDown || !this.dragStart) return;
+        const camera = this.cameras.main;
+        const dx = pointer.x - this.dragStart.x;
+        const dy = pointer.y - this.dragStart.y;
+        this.dragDistance = Math.max(this.dragDistance, Math.hypot(dx, dy));
+        camera.setScroll(
+          this.dragStart.sx - dx / camera.zoom,
+          this.dragStart.sy - dy / camera.zoom,
+        );
+      });
+      this.input.on("pointerup", () => {
+        this.dragStart = null;
+      });
+      this.input.on(
+        "wheel",
+        (
+          _pointer: Phaser.Input.Pointer,
+          _objects: unknown[],
+          _deltaX: number,
+          deltaY: number,
+        ) => {
+          const camera = this.cameras.main;
+          const step = deltaY > 0 ? -0.25 : 0.25;
+          const next = PhaserLib.Math.Clamp(camera.zoom + step, MIN_ZOOM, MAX_ZOOM);
+          camera.setZoom(next);
+        },
+      );
+    }
+
+    // -------------------------------------------------------------------
+    // Agents.
+    // -------------------------------------------------------------------
+
+    private syncAgents(poses: PixelAgentPose[]) {
+      const state = bridge.getState();
+      const inputById = new Map(state.agents.map((agent) => [agent.id, agent]));
+      const seen = new Set<string>();
+
+      for (const pose of poses) {
+        seen.add(pose.id);
+        const input = inputById.get(pose.id) ?? null;
+        const accent = input?.color ?? "#8a8f98";
+        this.ensureCharacterTextures(pose.id, accent);
+        let visual = this.visuals.get(pose.id);
+        if (!visual) {
+          visual = this.createVisual(pose.id, input?.name ?? "Janitor");
+          this.visuals.set(pose.id, visual);
+        }
+        this.updateVisual(visual, pose, input, state.bubbleTextByAgentId[pose.id] ?? "");
+      }
+
+      for (const [id, visual] of this.visuals) {
+        if (seen.has(id)) continue;
+        visual.container.destroy();
+        visual.overlay.destroy();
+        this.visuals.delete(id);
+      }
+    }
+
+    private createVisual(id: string, name: string): AgentVisual {
+      const shadow = this.add.ellipse(0, -1, 12, 5, 0x000000, 0.22);
+      const sprite = this.add.image(0, 0, `char_${id}_idle_down`);
+      sprite.setOrigin(0.5, 1);
+      sprite.setInteractive({ useHandCursor: true });
+      sprite.on("pointerup", (pointer: Phaser.Input.Pointer) => {
+        if (this.dragDistance > 6) return;
+        if (pointer.rightButtonReleased()) {
+          const nativeEvent = pointer.event as MouseEvent;
+          bridge.callbacks.onAgentContextMenu?.(
+            id,
+            nativeEvent.clientX ?? 0,
+            nativeEvent.clientY ?? 0,
+          );
+          return;
+        }
+        if (id === JANITOR_ID) return;
+        this.cameras.main.pan(sprite.parentContainer.x, sprite.parentContainer.y, 350, "Sine.easeInOut");
+        bridge.callbacks.onAgentClick?.(id);
+      });
+      sprite.on("pointerover", () => sprite.setTint(0xd9f1ff));
+      sprite.on("pointerout", () => sprite.clearTint());
+      const container = this.add.container(0, 0, [shadow, sprite]);
+
+      const nameBg = this.add.graphics();
+      const nameText = this.add.text(0, 0, name, {
+        fontFamily: "system-ui, sans-serif",
+        fontSize: "7px",
+        color: "#f4f7ff",
+        fontStyle: "bold",
+      });
+      nameText.setResolution(6);
+      nameText.setOrigin(0.5, 0.5);
+      const statusDot = this.add.circle(0, 0, 2, 0x4ade80);
+      const bubbleBg = this.add.graphics();
+      const bubbleText = this.add.text(0, 0, "", {
+        fontFamily: "system-ui, sans-serif",
+        fontSize: "6px",
+        color: "#2b2b3a",
+        align: "left",
+        wordWrap: { width: 88 },
+      });
+      bubbleText.setResolution(6);
+      bubbleText.setOrigin(0.5, 1);
+      const thinkText = this.add.text(0, 0, "…", {
+        fontFamily: "system-ui, sans-serif",
+        fontSize: "9px",
+        color: "#2b2b3a",
+        backgroundColor: "#f4f7ff",
+        padding: { left: 3, right: 3, top: 0, bottom: 1 },
+      });
+      thinkText.setResolution(6);
+      thinkText.setOrigin(0.5, 1);
+      const badgeText = this.add.text(0, 0, "!", {
+        fontFamily: "system-ui, sans-serif",
+        fontSize: "8px",
+        color: "#1f1303",
+        fontStyle: "bold",
+        backgroundColor: "#fbbf24",
+        padding: { left: 3, right: 3, top: 0, bottom: 1 },
+      });
+      badgeText.setResolution(6);
+      badgeText.setOrigin(0.5, 1);
+      const overlay = this.add.container(0, 0, [
+        nameBg,
+        nameText,
+        statusDot,
+        bubbleBg,
+        bubbleText,
+        thinkText,
+        badgeText,
+      ]);
+      overlay.setDepth(40_000);
+
+      return {
+        container,
+        sprite,
+        shadow,
+        overlay,
+        nameBg,
+        nameText,
+        statusDot,
+        bubbleBg,
+        bubbleText,
+        thinkText,
+        badgeText,
+        lastBubble: "",
+        lastStatus: "",
+        lastName: name,
+        seed: id,
+      };
+    }
+
+    private frameFor(pose: PixelAgentPose): CharacterFrameName {
+      const facing: PixelFacing = pose.facing;
+      if (pose.activity === "dancing") {
+        return Math.floor(this.animClock / DANCE_FRAME_MS) % 2 === 0 ? "dance_a" : "dance_b";
+      }
+      if (pose.moving) {
+        const step = Math.floor(this.animClock / WALK_FRAME_MS) % 4;
+        if (step === 0) return `walk_${facing}_a` as CharacterFrameName;
+        if (step === 2) return `walk_${facing}_b` as CharacterFrameName;
+        return `idle_${facing}` as CharacterFrameName;
+      }
+      if (pose.activity === "sitting_desk" || pose.activity === "meeting") {
+        return `sit_${facing}` as CharacterFrameName;
+      }
+      if (pose.activity === "station" && pose.stationId) {
+        const stationEntry = map.stations.find((entry) => entry.id === pose.stationId);
+        if (stationEntry && SEATED_STATION_KINDS.has(stationEntry.kind)) {
+          return `sit_${facing}` as CharacterFrameName;
+        }
+      }
+      return `idle_${facing}` as CharacterFrameName;
+    }
+
+    private updateVisual(
+      visual: AgentVisual,
+      pose: PixelAgentPose,
+      input: { name: string; status: string; thinking: boolean; awaitingApproval: boolean } | null,
+      bubble: string,
+    ) {
+      visual.container.setPosition(pose.x, pose.y + TILE / 2 - 1);
+      visual.container.setDepth(pose.y + TILE / 2);
+      const frameKey = `char_${visual.seed}_${this.frameFor(pose)}`;
+      if (this.textures.exists(frameKey) && visual.sprite.texture.key !== frameKey) {
+        visual.sprite.setTexture(frameKey);
+      }
+
+      const overlayY = pose.y + TILE / 2 - CHARACTER_HEIGHT - 4;
+      visual.overlay.setPosition(pose.x, overlayY);
+
+      // Nameplate pill with the status dot.
+      const name = input?.name ?? "Janitor";
+      const status = input?.status ?? "idle";
+      if (name !== visual.lastName || status !== visual.lastStatus) {
+        visual.lastName = name;
+        visual.lastStatus = status;
+        visual.nameText.setText(name.length > 16 ? `${name.slice(0, 15)}…` : name);
+      }
+      const plateWidth = visual.nameText.width + 14;
+      const plateHeight = 10;
+      visual.nameBg.clear();
+      visual.nameBg.fillStyle(0x11131c, 0.82);
+      visual.nameBg.fillRoundedRect(-plateWidth / 2, -plateHeight / 2, plateWidth, plateHeight, 4);
+      visual.nameText.setPosition(3, 0);
+      visual.statusDot.setPosition(-plateWidth / 2 + 5, 0);
+      visual.statusDot.setFillStyle(STATUS_DOT_COLOR[status] ?? 0x9ca3af);
+      if (status === "working") {
+        visual.statusDot.setAlpha(0.6 + 0.4 * Math.abs(Math.sin(this.animClock / 400)));
+      } else {
+        visual.statusDot.setAlpha(1);
+      }
+
+      // Speech bubble (streaming text tail).
+      const bubbleTail = bubble.trim().length > 0 ? tailOf(bubble, 90) : "";
+      if (bubbleTail !== visual.lastBubble) {
+        visual.lastBubble = bubbleTail;
+        visual.bubbleText.setText(bubbleTail);
+      }
+      const showBubble = bubbleTail.length > 0;
+      visual.bubbleBg.setVisible(showBubble);
+      visual.bubbleText.setVisible(showBubble);
+      if (showBubble) {
+        const bw = visual.bubbleText.width + 10;
+        const bh = visual.bubbleText.height + 8;
+        const by = -8;
+        visual.bubbleText.setPosition(0, by - 4);
+        visual.bubbleBg.clear();
+        visual.bubbleBg.fillStyle(0xf9fbff, 0.96);
+        visual.bubbleBg.lineStyle(1, 0x2b2b3a, 0.9);
+        visual.bubbleBg.fillRoundedRect(-bw / 2, by - bh, bw, bh, 4);
+        visual.bubbleBg.strokeRoundedRect(-bw / 2, by - bh, bw, bh, 4);
+        visual.bubbleBg.fillTriangle(-3, by, 3, by, 0, by + 4);
+      }
+
+      // Thinking dots (hidden while a speech bubble is visible).
+      const thinking = Boolean(input?.thinking) && !showBubble;
+      visual.thinkText.setVisible(thinking);
+      if (thinking) {
+        const dots = 1 + (Math.floor(this.animClock / 350) % 3);
+        visual.thinkText.setText(".".repeat(dots));
+        visual.thinkText.setPosition(10, -8);
+      }
+
+      // Approval badge.
+      const approval = Boolean(input?.awaitingApproval);
+      visual.badgeText.setVisible(approval);
+      if (approval) {
+        visual.badgeText.setPosition(-11, -8);
+        visual.badgeText.setAlpha(0.75 + 0.25 * Math.sin(this.animClock / 250));
+      }
+    }
+  }
+
+  return new PixelOfficeScene();
+};
+
+const tailOf = (value: string, max: number): string => {
+  const compact = value.replace(/\s+/g, " ").trim();
+  if (compact.length <= max) return compact;
+  return `…${compact.slice(compact.length - max)}`;
+};

--- a/src/features/pixel-office/sim/agentSimulation.ts
+++ b/src/features/pixel-office/sim/agentSimulation.ts
@@ -1,0 +1,533 @@
+// Pure agent-behavior simulation for the 2D pixel office. No Phaser or React
+// imports, so the logic stays unit-testable in node/jsdom. The scene layer
+// feeds PixelAgentInput[] in and renders the returned PixelAgentPose[].
+
+import { astar2D } from "@/lib/office/pathfinding";
+import { buildPixelNavGrid, tileCenter } from "@/features/pixel-office/map/navGrid";
+import {
+  PIXEL_TILE_SIZE,
+  type PixelAgentActivity,
+  type PixelAgentInput,
+  type PixelAgentPose,
+  type PixelFacing,
+  type PixelOfficeMap,
+  type PixelSimAgentState,
+  type PixelSimState,
+  type PixelStation,
+  type PixelStationKind,
+} from "@/features/pixel-office/types";
+
+export type PixelSimulation = {
+  tick: (params: {
+    inputs: PixelAgentInput[];
+    nowMs: number;
+    dtMs: number;
+    cleaningActive: boolean;
+  }) => PixelAgentPose[];
+  /** Exposes internal state for tests/debugging. */
+  getState: () => PixelSimState;
+};
+
+export const JANITOR_ID = "npc-janitor";
+
+// Walking speeds in world pixels per second.
+const AGENT_SPEED = 90;
+const JANITOR_SPEED = 70;
+// Movement dt is capped so a sleeping tab does not teleport agents on resume.
+const MAX_STEP_MS = 100;
+// Idle wanderers pause 4-10 seconds at a station before picking a new one.
+const IDLE_PAUSE_MIN_MS = 4000;
+const IDLE_PAUSE_RANGE_MS = 6000;
+// The janitor pauses briefly at each wander spot while cleaning.
+const JANITOR_PAUSE_MS = 2000;
+
+/** Station kinds idle agents wander between. */
+const IDLE_STATION_KINDS: readonly PixelStationKind[] = [
+  "coffee",
+  "water_cooler",
+  "lounge_seat",
+  "library",
+  "ping_pong",
+  "arcade",
+  "wander",
+];
+
+type HoldKind = NonNullable<PixelAgentInput["hold"]>;
+
+/** Hold cue -> station kind the agent should walk to. */
+const HOLD_TO_STATION_KIND: Readonly<Record<HoldKind, PixelStationKind>> = {
+  phone_booth: "phone_booth",
+  sms_booth: "sms_booth",
+  gym: "gym",
+  qa_lab: "qa_lab",
+  github_desk: "github_desk",
+  jukebox: "jukebox",
+  kanban: "kanban",
+};
+
+/** Sim agent state plus private bookkeeping the public contract omits. */
+type InternalAgentState = PixelSimAgentState & {
+  /** Seeded per-agent PRNG so wandering is deterministic in tests. */
+  rng: () => number;
+  /** Hold currently being serviced; keeps the chosen station sticky. */
+  holdKind: PixelAgentInput["hold"];
+  /** Exact world target and its tile, used to detect goal changes. */
+  targetX: number;
+  targetY: number;
+  targetTx: number;
+  targetTy: number;
+  /** Facing to snap to on arrival (station/desk facing). */
+  targetFacing: PixelFacing;
+  /** Last wander station, excluded from the next random pick. */
+  lastStationId: string | null;
+  /** Janitor-only cursor into the wander station cycle. */
+  wanderIndex: number;
+};
+
+const hashString = (value: string): number => {
+  // FNV-1a keeps the seed stable and well-distributed across agent ids.
+  let hash = 2166136261 >>> 0;
+  for (let index = 0; index < value.length; index += 1) {
+    hash ^= value.charCodeAt(index);
+    hash = Math.imul(hash, 16777619);
+  }
+  return hash >>> 0;
+};
+
+const mulberry32 = (seed: number): (() => number) => {
+  let a = seed >>> 0;
+  return () => {
+    a = (a + 0x6d2b79f5) >>> 0;
+    let t = a;
+    t = Math.imul(t ^ (t >>> 15), t | 1);
+    t ^= t + Math.imul(t ^ (t >>> 7), t | 61);
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+};
+
+export const createPixelSimulation = (map: PixelOfficeMap): PixelSimulation => {
+  const navGrid = buildPixelNavGrid(map);
+  const stationById = new Map<string, PixelStation>(
+    map.stations.map((stationSlot) => [stationSlot.id, stationSlot]),
+  );
+  const stationsByKind = new Map<PixelStationKind, PixelStation[]>();
+  for (const stationSlot of map.stations) {
+    const bucket = stationsByKind.get(stationSlot.kind);
+    if (bucket) bucket.push(stationSlot);
+    else stationsByKind.set(stationSlot.kind, [stationSlot]);
+  }
+  const wanderStations = stationsByKind.get("wander") ?? [];
+  const idleStations = map.stations.filter((stationSlot) =>
+    IDLE_STATION_KINDS.includes(stationSlot.kind),
+  );
+  const deskById = new Map(map.desks.map((deskSlot) => [deskSlot.id, deskSlot]));
+  const spawnCenter = tileCenter(map.spawn.tx, map.spawn.ty);
+
+  const state: {
+    agents: Record<string, InternalAgentState>;
+    deskByAgentId: Record<string, string>;
+    janitor: InternalAgentState | null;
+  } = {
+    agents: {},
+    deskByAgentId: {},
+    janitor: null,
+  };
+
+  const createAgentState = (id: string): InternalAgentState => ({
+    id,
+    x: spawnCenter.x,
+    y: spawnCenter.y,
+    facing: "down",
+    path: [],
+    goalKind: "wander",
+    goalStationId: null,
+    deskId: null,
+    pauseUntil: 0,
+    arrived: false,
+    rng: mulberry32(hashString(id)),
+    holdKind: null,
+    targetX: spawnCenter.x,
+    targetY: spawnCenter.y,
+    // Sentinel target tile so the first real goal always triggers a repath.
+    targetTx: -1,
+    targetTy: -1,
+    targetFacing: "down",
+    lastStationId: null,
+    wanderIndex: 0,
+  });
+
+  /** True when another agent currently targets or sits on the station. */
+  const isStationOccupied = (stationId: string, selfId: string): boolean => {
+    for (const other of Object.values(state.agents)) {
+      if (other.id !== selfId && other.goalStationId === stationId) return true;
+    }
+    return false;
+  };
+
+  const distanceSq = (agent: InternalAgentState, stationSlot: PixelStation): number => {
+    const center = tileCenter(stationSlot.tx, stationSlot.ty);
+    const dx = center.x - agent.x;
+    const dy = center.y - agent.y;
+    return dx * dx + dy * dy;
+  };
+
+  /** Nearest station, preferring unoccupied; map order breaks distance ties. */
+  const pickNearestStation = (
+    agent: InternalAgentState,
+    candidates: PixelStation[],
+  ): PixelStation | null => {
+    const free = candidates.filter(
+      (stationSlot) => !isStationOccupied(stationSlot.id, agent.id),
+    );
+    const pool = free.length > 0 ? free : candidates;
+    let best: PixelStation | null = null;
+    let bestDistance = Infinity;
+    for (const stationSlot of pool) {
+      const distance = distanceSq(agent, stationSlot);
+      if (distance < bestDistance) {
+        bestDistance = distance;
+        best = stationSlot;
+      }
+    }
+    return best;
+  };
+
+  /** Random idle station via the agent's seeded RNG, preferring unoccupied. */
+  const pickRandomIdleStation = (agent: InternalAgentState): PixelStation | null => {
+    const withoutLast = idleStations.filter(
+      (stationSlot) => stationSlot.id !== agent.lastStationId,
+    );
+    const candidates = withoutLast.length > 0 ? withoutLast : idleStations;
+    const free = candidates.filter(
+      (stationSlot) => !isStationOccupied(stationSlot.id, agent.id),
+    );
+    const pool = free.length > 0 ? free : candidates;
+    if (pool.length === 0) return null;
+    return pool[Math.min(pool.length - 1, Math.floor(agent.rng() * pool.length))];
+  };
+
+  /** Records the goal point and repaths only when the target tile changed. */
+  const setTarget = (
+    agent: InternalAgentState,
+    x: number,
+    y: number,
+    facing: PixelFacing,
+  ) => {
+    const targetTx = Math.floor(x / PIXEL_TILE_SIZE);
+    const targetTy = Math.floor(y / PIXEL_TILE_SIZE);
+    agent.targetX = x;
+    agent.targetY = y;
+    agent.targetFacing = facing;
+    if (targetTx !== agent.targetTx || targetTy !== agent.targetTy) {
+      agent.targetTx = targetTx;
+      agent.targetTy = targetTy;
+      agent.arrived = false;
+      agent.path = astar2D(agent.x, agent.y, x, y, navGrid);
+    } else if (!agent.arrived && agent.path.length === 0) {
+      // Retry unreachable goals; astar2D returned an empty path last time.
+      agent.path = astar2D(agent.x, agent.y, x, y, navGrid);
+    }
+  };
+
+  /** Parks the agent in place (used for dancing and missing stations). */
+  const holdPosition = (agent: InternalAgentState) => {
+    agent.path = [];
+    agent.arrived = true;
+    // Invalidate the target tile so the next real goal always repaths.
+    agent.targetTx = -1;
+    agent.targetTy = -1;
+    agent.targetX = agent.x;
+    agent.targetY = agent.y;
+  };
+
+  const resolveWander = (agent: InternalAgentState, nowMs: number) => {
+    if (agent.goalKind !== "wander" && agent.goalKind !== "idle_pause") {
+      agent.goalKind = "wander";
+      agent.goalStationId = null;
+      agent.pauseUntil = 0;
+    }
+    if (agent.goalStationId && agent.arrived) {
+      if (agent.pauseUntil === 0) {
+        agent.pauseUntil =
+          nowMs + IDLE_PAUSE_MIN_MS + agent.rng() * IDLE_PAUSE_RANGE_MS;
+        agent.goalKind = "idle_pause";
+      } else if (nowMs >= agent.pauseUntil) {
+        agent.lastStationId = agent.goalStationId;
+        agent.goalStationId = null;
+        agent.pauseUntil = 0;
+        agent.goalKind = "wander";
+      }
+    }
+    if (!agent.goalStationId) {
+      const pick = pickRandomIdleStation(agent);
+      agent.goalStationId = pick?.id ?? null;
+    }
+    const stationSlot = agent.goalStationId
+      ? stationById.get(agent.goalStationId)
+      : undefined;
+    if (stationSlot) {
+      const center = tileCenter(stationSlot.tx, stationSlot.ty);
+      setTarget(agent, center.x, center.y, stationSlot.facing);
+    } else {
+      holdPosition(agent);
+    }
+  };
+
+  const resolveGoal = (
+    agent: InternalAgentState,
+    input: PixelAgentInput,
+    nowMs: number,
+  ) => {
+    // Priority a: an active hold routes the agent to a matching station.
+    if (input.hold) {
+      if (agent.holdKind !== input.hold || agent.goalKind !== "station") {
+        agent.holdKind = input.hold;
+        agent.goalKind = "station";
+        agent.pauseUntil = 0;
+        const candidates = stationsByKind.get(HOLD_TO_STATION_KIND[input.hold]) ?? [];
+        agent.goalStationId = pickNearestStation(agent, candidates)?.id ?? null;
+      }
+      const stationSlot = agent.goalStationId
+        ? stationById.get(agent.goalStationId)
+        : undefined;
+      if (stationSlot) {
+        const center = tileCenter(stationSlot.tx, stationSlot.ty);
+        setTarget(agent, center.x, center.y, stationSlot.facing);
+      } else {
+        holdPosition(agent);
+      }
+      return;
+    }
+    agent.holdKind = null;
+
+    // Priority b: standup gathers everyone at meeting seats.
+    if (input.standup) {
+      if (agent.goalKind !== "meeting" || !agent.goalStationId) {
+        agent.goalKind = "meeting";
+        agent.pauseUntil = 0;
+        const seats = stationsByKind.get("meeting_seat") ?? [];
+        agent.goalStationId = pickNearestStation(agent, seats)?.id ?? null;
+      }
+      const stationSlot = agent.goalStationId
+        ? stationById.get(agent.goalStationId)
+        : undefined;
+      if (stationSlot) {
+        const center = tileCenter(stationSlot.tx, stationSlot.ty);
+        setTarget(agent, center.x, center.y, stationSlot.facing);
+      } else {
+        holdPosition(agent);
+      }
+      return;
+    }
+    if (agent.goalKind === "meeting") {
+      // Release the meeting seat once the standup ends.
+      agent.goalStationId = null;
+    }
+
+    // Priority c: dancing happens in place.
+    if (input.dancing) {
+      agent.goalKind = "dance";
+      agent.goalStationId = null;
+      holdPosition(agent);
+      return;
+    }
+
+    // Priority d: working/error agents head to their assigned desk seat.
+    if (input.status === "working" || input.status === "error") {
+      const deskId = state.deskByAgentId[input.id];
+      const deskSlot = deskId ? deskById.get(deskId) : undefined;
+      if (deskSlot) {
+        if (agent.goalKind !== "desk") {
+          agent.goalKind = "desk";
+          agent.goalStationId = null;
+          agent.pauseUntil = 0;
+        }
+        const seat = tileCenter(deskSlot.seatTx, deskSlot.seatTy);
+        setTarget(agent, seat.x, seat.y, deskSlot.facing);
+        return;
+      }
+      // No free desk: fall through to wander behavior.
+    }
+
+    // Priority e: idle agents wander between break stations.
+    resolveWander(agent, nowMs);
+  };
+
+  const moveAgent = (agent: InternalAgentState, stepMs: number, speed: number) => {
+    if (agent.arrived) return;
+    let budget = speed * (stepMs / 1000);
+    while (budget > 0 && agent.path.length > 0) {
+      const waypoint = agent.path[0];
+      const dx = waypoint.x - agent.x;
+      const dy = waypoint.y - agent.y;
+      const distance = Math.hypot(dx, dy);
+      if (distance <= 1e-6) {
+        agent.path.shift();
+        continue;
+      }
+      // Face along the dominant axis of the current path segment.
+      agent.facing =
+        Math.abs(dx) > Math.abs(dy)
+          ? dx > 0
+            ? "right"
+            : "left"
+          : dy > 0
+            ? "down"
+            : "up";
+      if (distance <= budget) {
+        agent.x = waypoint.x;
+        agent.y = waypoint.y;
+        budget -= distance;
+        agent.path.shift();
+      } else {
+        agent.x += (dx / distance) * budget;
+        agent.y += (dy / distance) * budget;
+        budget = 0;
+      }
+    }
+    if (agent.path.length === 0) {
+      const dx = agent.targetX - agent.x;
+      const dy = agent.targetY - agent.y;
+      if (Math.hypot(dx, dy) < 0.5) {
+        // Snap exactly onto the goal and adopt the station/desk facing.
+        agent.x = agent.targetX;
+        agent.y = agent.targetY;
+        agent.arrived = true;
+        agent.facing = agent.targetFacing;
+      }
+    }
+  };
+
+  const activityFor = (agent: InternalAgentState): PixelAgentActivity => {
+    if (agent.goalKind === "dance") return "dancing";
+    if (!agent.arrived && agent.path.length > 0) return "walking";
+    if (!agent.arrived) return "standing";
+    switch (agent.goalKind) {
+      case "desk":
+        return "sitting_desk";
+      case "meeting":
+        return "meeting";
+      case "station":
+      case "wander":
+      case "idle_pause": {
+        const stationSlot = agent.goalStationId
+          ? stationById.get(agent.goalStationId)
+          : undefined;
+        if (!stationSlot) return "standing";
+        return stationSlot.kind === "wander" ? "standing" : "station";
+      }
+      default:
+        return "standing";
+    }
+  };
+
+  const poseFor = (agent: InternalAgentState): PixelAgentPose => ({
+    id: agent.id,
+    x: agent.x,
+    y: agent.y,
+    facing: agent.facing,
+    activity: activityFor(agent),
+    moving: agent.goalKind !== "dance" && !agent.arrived && agent.path.length > 0,
+    stationId: agent.goalStationId,
+    deskId: state.deskByAgentId[agent.id] ?? null,
+  });
+
+  const updateJanitor = (nowMs: number, stepMs: number, cleaningActive: boolean) => {
+    if (cleaningActive) {
+      if (!state.janitor) {
+        state.janitor = createAgentState(JANITOR_ID);
+      }
+      const janitor = state.janitor;
+      if (wanderStations.length === 0) {
+        holdPosition(janitor);
+        return;
+      }
+      if (janitor.arrived && janitor.goalStationId) {
+        if (janitor.pauseUntil === 0) {
+          janitor.pauseUntil = nowMs + JANITOR_PAUSE_MS;
+        } else if (nowMs >= janitor.pauseUntil) {
+          janitor.wanderIndex = (janitor.wanderIndex + 1) % wanderStations.length;
+          janitor.pauseUntil = 0;
+        }
+      }
+      const stationSlot = wanderStations[janitor.wanderIndex];
+      janitor.goalKind = "wander";
+      janitor.goalStationId = stationSlot.id;
+      const center = tileCenter(stationSlot.tx, stationSlot.ty);
+      setTarget(janitor, center.x, center.y, stationSlot.facing);
+      moveAgent(janitor, stepMs, JANITOR_SPEED);
+      return;
+    }
+    if (!state.janitor) return;
+    const janitor = state.janitor;
+    janitor.goalKind = "wander";
+    janitor.goalStationId = null;
+    janitor.pauseUntil = 0;
+    setTarget(janitor, spawnCenter.x, spawnCenter.y, "down");
+    moveAgent(janitor, stepMs, JANITOR_SPEED);
+    if (janitor.arrived) {
+      // Back at the spawn door: the janitor leaves the office.
+      state.janitor = null;
+    }
+  };
+
+  const tick = ({
+    inputs,
+    nowMs,
+    dtMs,
+    cleaningActive,
+  }: {
+    inputs: PixelAgentInput[];
+    nowMs: number;
+    dtMs: number;
+    cleaningActive: boolean;
+  }): PixelAgentPose[] => {
+    const stepMs = Math.min(Math.max(dtMs, 0), MAX_STEP_MS);
+
+    // Roster sync: drop absent agents and free their desks.
+    const inputIds = new Set(inputs.map((input) => input.id));
+    for (const id of Object.keys(state.agents)) {
+      if (!inputIds.has(id)) {
+        delete state.agents[id];
+        delete state.deskByAgentId[id];
+      }
+    }
+
+    // Iterate agents sorted by id so assignments and picks are deterministic.
+    const sortedInputs = [...inputs].sort((a, b) =>
+      a.id < b.id ? -1 : a.id > b.id ? 1 : 0,
+    );
+    for (const input of sortedInputs) {
+      if (!state.agents[input.id]) {
+        state.agents[input.id] = createAgentState(input.id);
+      }
+    }
+
+    // Sticky desk assignment: first free desk in map order, agents by id.
+    for (const input of sortedInputs) {
+      if (input.status !== "working" && input.status !== "error") continue;
+      if (state.deskByAgentId[input.id]) continue;
+      const used = new Set(Object.values(state.deskByAgentId));
+      const freeDesk = map.desks.find((deskSlot) => !used.has(deskSlot.id));
+      if (freeDesk) state.deskByAgentId[input.id] = freeDesk.id;
+    }
+
+    for (const input of sortedInputs) {
+      const agent = state.agents[input.id];
+      agent.deskId = state.deskByAgentId[input.id] ?? null;
+      resolveGoal(agent, input, nowMs);
+      moveAgent(agent, stepMs, AGENT_SPEED);
+    }
+
+    updateJanitor(nowMs, stepMs, cleaningActive);
+
+    const poses = inputs.map((input) => poseFor(state.agents[input.id]));
+    if (state.janitor) poses.push(poseFor(state.janitor));
+    return poses;
+  };
+
+  return {
+    tick,
+    getState: () => state,
+  };
+};

--- a/src/features/pixel-office/sim/agentSimulation.ts
+++ b/src/features/pixel-office/sim/agentSimulation.ts
@@ -30,9 +30,9 @@ export type PixelSimulation = {
 
 export const JANITOR_ID = "npc-janitor";
 
-// Walking speeds in world pixels per second.
-const AGENT_SPEED = 90;
-const JANITOR_SPEED = 70;
+// Walking speeds in world pixels per second (~5.6 and ~4.4 tiles/s).
+const AGENT_SPEED = 180;
+const JANITOR_SPEED = 140;
 // Movement dt is capped so a sleeping tab does not teleport agents on resume.
 const MAX_STEP_MS = 100;
 // Idle wanderers pause 4-10 seconds at a station before picking a new one.

--- a/src/features/pixel-office/types.ts
+++ b/src/features/pixel-office/types.ts
@@ -54,8 +54,8 @@ export type CharacterLook = {
   accentColor: string;
 };
 
-export const CHARACTER_WIDTH = 16;
-export const CHARACTER_HEIGHT = 24;
+export const CHARACTER_WIDTH = 20;
+export const CHARACTER_HEIGHT = 30;
 
 /** All frames for a single character, keyed by frame name. */
 export type CharacterFrameSet = Record<CharacterFrameName, PixelSprite>;
@@ -80,6 +80,7 @@ export type PixelGroundTile =
   | "gym_mat"
   | "server_floor"
   | "wall"
+  | "wall_window"
   | "void";
 
 /** Furniture / decor object kinds the art module must provide sprites for. */

--- a/src/features/pixel-office/types.ts
+++ b/src/features/pixel-office/types.ts
@@ -1,0 +1,364 @@
+// Shared contracts for the 2D pixel office (Gather-style renderer).
+// Everything here is pure data — no Phaser or React imports — so the art,
+// map, and simulation modules stay unit-testable in jsdom/node.
+
+// ---------------------------------------------------------------------------
+// Pixel art
+// ---------------------------------------------------------------------------
+
+/**
+ * A pixel sprite described as character rows. Each character indexes into the
+ * palette; "." and " " mean transparent. Rows may have differing lengths —
+ * missing trailing cells are transparent.
+ */
+export type PixelSprite = {
+  /** Unique texture key, e.g. "tile_floor_cream" or "furn_desk". */
+  key: string;
+  rows: string[];
+  /** Char -> "#rrggbb" or "#rrggbbaa". */
+  palette: Record<string, string>;
+};
+
+/** Facing directions for characters. */
+export type PixelFacing = "down" | "up" | "left" | "right";
+
+/**
+ * Frame names produced by the character generator. Walk cycles are 3-frame
+ * (idle acts as the middle frame): idle_X, walk_X_a, walk_X_b.
+ */
+export type CharacterFrameName =
+  | "idle_down"
+  | "walk_down_a"
+  | "walk_down_b"
+  | "idle_up"
+  | "walk_up_a"
+  | "walk_up_b"
+  | "idle_left"
+  | "walk_left_a"
+  | "walk_left_b"
+  | "idle_right"
+  | "walk_right_a"
+  | "walk_right_b"
+  | "sit_down"
+  | "sit_up"
+  | "sit_left"
+  | "sit_right"
+  | "dance_a"
+  | "dance_b";
+
+/** Deterministic appearance derived from an agent's id + accent color. */
+export type CharacterLook = {
+  /** Stable seed (agent id). */
+  seed: string;
+  /** Accent color from the agent roster ("#rrggbb"); used for the shirt. */
+  accentColor: string;
+};
+
+export const CHARACTER_WIDTH = 16;
+export const CHARACTER_HEIGHT = 24;
+
+/** All frames for a single character, keyed by frame name. */
+export type CharacterFrameSet = Record<CharacterFrameName, PixelSprite>;
+
+// ---------------------------------------------------------------------------
+// Map
+// ---------------------------------------------------------------------------
+
+export const PIXEL_TILE_SIZE = 16;
+
+/** Ground tile ids paintable in the ASCII grid. */
+export type PixelGroundTile =
+  | "grass"
+  | "grass_dark"
+  | "path"
+  | "floor_cream"
+  | "floor_white"
+  | "floor_wood"
+  | "carpet_purple"
+  | "carpet_blue"
+  | "kitchen_tile"
+  | "gym_mat"
+  | "server_floor"
+  | "wall"
+  | "void";
+
+/** Furniture / decor object kinds the art module must provide sprites for. */
+export type PixelObjectKind =
+  | "desk"
+  | "desk_monitor"
+  | "chair"
+  | "meeting_table"
+  | "sofa_h"
+  | "sofa_v"
+  | "coffee_table"
+  | "plant"
+  | "plant_tall"
+  | "bookshelf"
+  | "kitchen_counter"
+  | "fridge"
+  | "coffee_machine"
+  | "water_cooler"
+  | "vending_machine"
+  | "ping_pong_table"
+  | "arcade"
+  | "jukebox"
+  | "kanban_board"
+  | "phone_booth"
+  | "sms_booth"
+  | "treadmill"
+  | "dumbbell_rack"
+  | "server_rack"
+  | "tv_stand"
+  | "whiteboard"
+  | "rug"
+  | "tree"
+  | "flower"
+  | "atm"
+  | "lamp"
+  | "aquarium";
+
+export type PixelMapObject = {
+  id: string;
+  kind: PixelObjectKind;
+  /** Tile coordinates of the object's top-left tile. */
+  tx: number;
+  ty: number;
+  /**
+   * Whether the object blocks the nav grid. Defaults per kind; may be
+   * overridden (e.g. rugs never block).
+   */
+  blocking?: boolean;
+};
+
+export type PixelZoneKind =
+  | "team_pod"
+  | "meeting"
+  | "lounge"
+  | "kitchen"
+  | "library"
+  | "game_room"
+  | "gym"
+  | "phone"
+  | "server"
+  | "focus"
+  | "outdoor";
+
+export type PixelZone = {
+  id: string;
+  kind: PixelZoneKind;
+  label: string | null;
+  /** Tile-rect bounds (inclusive of tx/ty, exclusive of tx+tw/ty+th). */
+  tx: number;
+  ty: number;
+  tw: number;
+  th: number;
+};
+
+/** A desk an agent can be assigned to. */
+export type PixelDeskSlot = {
+  id: string;
+  /** Tile of the desk object itself. */
+  deskTx: number;
+  deskTy: number;
+  /** Tile the agent stands/sits on while working. */
+  seatTx: number;
+  seatTy: number;
+  /** Which way the seated agent faces. */
+  facing: PixelFacing;
+};
+
+/** Stations agents visit for animation holds and idle wandering. */
+export type PixelStationKind =
+  | "gym"
+  | "phone_booth"
+  | "sms_booth"
+  | "qa_lab"
+  | "github_desk"
+  | "jukebox"
+  | "kanban"
+  | "coffee"
+  | "water_cooler"
+  | "lounge_seat"
+  | "ping_pong"
+  | "arcade"
+  | "meeting_seat"
+  | "library"
+  | "wander";
+
+export type PixelStation = {
+  id: string;
+  kind: PixelStationKind;
+  /** Tile the agent occupies when using the station. */
+  tx: number;
+  ty: number;
+  facing: PixelFacing;
+};
+
+export type PixelOfficeMap = {
+  /** Grid dimensions in tiles. */
+  cols: number;
+  rows: number;
+  /** Ground tile per cell, row-major. */
+  ground: PixelGroundTile[];
+  objects: PixelMapObject[];
+  zones: PixelZone[];
+  desks: PixelDeskSlot[];
+  stations: PixelStation[];
+  /** Where new agents appear before walking to their spot. */
+  spawn: { tx: number; ty: number };
+};
+
+/** Object kinds that block movement by default. */
+export const BLOCKING_OBJECT_KINDS: ReadonlySet<PixelObjectKind> = new Set([
+  "desk",
+  "desk_monitor",
+  "meeting_table",
+  "sofa_h",
+  "sofa_v",
+  "coffee_table",
+  "plant",
+  "plant_tall",
+  "bookshelf",
+  "kitchen_counter",
+  "fridge",
+  "coffee_machine",
+  "water_cooler",
+  "vending_machine",
+  "ping_pong_table",
+  "arcade",
+  "jukebox",
+  "kanban_board",
+  "treadmill",
+  "dumbbell_rack",
+  "server_rack",
+  "tv_stand",
+  "whiteboard",
+  "tree",
+  "atm",
+  "lamp",
+  "aquarium",
+]);
+
+/** Footprint in tiles for each object kind: [width, height]. */
+export const OBJECT_FOOTPRINT: Readonly<Record<PixelObjectKind, [number, number]>> = {
+  desk: [2, 1],
+  desk_monitor: [2, 1],
+  chair: [1, 1],
+  meeting_table: [3, 2],
+  sofa_h: [2, 1],
+  sofa_v: [1, 2],
+  coffee_table: [1, 1],
+  plant: [1, 1],
+  plant_tall: [1, 1],
+  bookshelf: [2, 1],
+  kitchen_counter: [2, 1],
+  fridge: [1, 1],
+  coffee_machine: [1, 1],
+  water_cooler: [1, 1],
+  vending_machine: [1, 1],
+  ping_pong_table: [3, 2],
+  arcade: [1, 1],
+  jukebox: [1, 1],
+  kanban_board: [2, 1],
+  phone_booth: [1, 1],
+  sms_booth: [1, 1],
+  treadmill: [1, 2],
+  dumbbell_rack: [2, 1],
+  server_rack: [1, 1],
+  tv_stand: [2, 1],
+  whiteboard: [2, 1],
+  rug: [2, 2],
+  tree: [2, 2],
+  flower: [1, 1],
+  atm: [1, 1],
+  lamp: [1, 1],
+  aquarium: [2, 1],
+};
+
+// ---------------------------------------------------------------------------
+// Simulation
+// ---------------------------------------------------------------------------
+
+/** What a Hermes agent currently looks like to the pixel office. */
+export type PixelAgentInput = {
+  id: string;
+  name: string;
+  status: "working" | "idle" | "error";
+  color: string;
+  /** True while the agent streams tokens (drives speech bubble). */
+  streaming: boolean;
+  /** True while the agent is in a reasoning/thinking stretch. */
+  thinking: boolean;
+  /** True while the agent waits for a human approval. */
+  awaitingApproval: boolean;
+  /** True until the timestamp while a dance trigger is active. */
+  dancing: boolean;
+  /** Active hold routing the agent to a station (highest priority first). */
+  hold:
+    | "phone_booth"
+    | "sms_booth"
+    | "gym"
+    | "qa_lab"
+    | "github_desk"
+    | "jukebox"
+    | "kanban"
+    | null;
+  /** True when a standup meeting is gathering everyone. */
+  standup: boolean;
+};
+
+export type PixelAgentActivity =
+  | "sitting_desk"
+  | "walking"
+  | "standing"
+  | "station"
+  | "dancing"
+  | "meeting";
+
+/** Live pose of one agent inside the pixel office. */
+export type PixelAgentPose = {
+  id: string;
+  /** World position in pixels. */
+  x: number;
+  y: number;
+  facing: PixelFacing;
+  activity: PixelAgentActivity;
+  /** True while mid-path (drives the walk animation). */
+  moving: boolean;
+  /** Station id when activity === "station". */
+  stationId: string | null;
+  /** Desk slot id when the agent has an assigned desk. */
+  deskId: string | null;
+};
+
+export type PixelSimAgentState = {
+  id: string;
+  x: number;
+  y: number;
+  facing: PixelFacing;
+  /** Remaining waypoints in world pixels. */
+  path: Array<{ x: number; y: number }>;
+  /** What the agent is currently doing or heading to do. */
+  goalKind:
+    | "desk"
+    | "station"
+    | "wander"
+    | "meeting"
+    | "dance"
+    | "idle_pause";
+  /** Station id for station goals. */
+  goalStationId: string | null;
+  deskId: string | null;
+  /** Epoch ms until which the agent pauses before picking a new wander target. */
+  pauseUntil: number;
+  /** True once the agent reached its goal tile. */
+  arrived: boolean;
+};
+
+export type PixelSimState = {
+  agents: Record<string, PixelSimAgentState>;
+  /** Deterministic desk assignment: agentId -> desk slot id. */
+  deskByAgentId: Record<string, string>;
+  /** Janitor NPC state, present while cleaning cues are active. */
+  janitor: PixelSimAgentState | null;
+};

--- a/src/features/pixel-office/types.ts
+++ b/src/features/pixel-office/types.ts
@@ -54,8 +54,8 @@ export type CharacterLook = {
   accentColor: string;
 };
 
-export const CHARACTER_WIDTH = 20;
-export const CHARACTER_HEIGHT = 30;
+export const CHARACTER_WIDTH = 40;
+export const CHARACTER_HEIGHT = 60;
 
 /** All frames for a single character, keyed by frame name. */
 export type CharacterFrameSet = Record<CharacterFrameName, PixelSprite>;
@@ -64,7 +64,7 @@ export type CharacterFrameSet = Record<CharacterFrameName, PixelSprite>;
 // Map
 // ---------------------------------------------------------------------------
 
-export const PIXEL_TILE_SIZE = 16;
+export const PIXEL_TILE_SIZE = 32;
 
 /** Ground tile ids paintable in the ASCII grid. */
 export type PixelGroundTile =

--- a/src/features/retro-office/RetroOffice3D.tsx
+++ b/src/features/retro-office/RetroOffice3D.tsx
@@ -28,6 +28,7 @@ import { Canvas, useFrame, useThree } from "@react-three/fiber";
 import { OrbitControls } from "@react-three/drei";
 import * as THREE from "three";
 import { SettingsPanel } from "@/features/office/components/panels/SettingsPanel";
+import type { OfficeRenderMode } from "@/features/office/renderMode";
 import { AtmImmersiveScreen } from "@/features/office/screens/AtmImmersiveScreen";
 import { GithubImmersiveScreen } from "@/features/office/screens/GithubImmersiveScreen";
 import { KanbanImmersiveScreen } from "@/features/office/screens/KanbanImmersiveScreen";
@@ -2600,6 +2601,8 @@ export function RetroOffice3D({
   onGatewayTokenChange,
   onGatewayAdapterTypeChange,
   onOpenOnboarding,
+  renderMode = "3d",
+  onRenderModeChange,
   atmAnalytics = null,
   feedEvents = EMPTY_FEED_EVENTS,
   gatewayStatus = "disconnected",
@@ -2716,6 +2719,8 @@ export function RetroOffice3D({
   onGatewayTokenChange?: (value: string) => void;
   onGatewayAdapterTypeChange?: (value: StudioGatewayAdapterType) => void;
   onOpenOnboarding?: () => void;
+  renderMode?: OfficeRenderMode;
+  onRenderModeChange?: (mode: OfficeRenderMode) => void;
   atmAnalytics?: OfficeUsageAnalyticsParams | null;
   feedEvents?: FeedEvent[];
   gatewayStatus?: string;
@@ -7586,6 +7591,15 @@ export function RetroOffice3D({
               <span>Add</span>
             </button>
           ) : null}
+          {onRenderModeChange ? (
+            <button
+              onClick={() => onRenderModeChange("2d")}
+              title="Switch to the 2D pixel office"
+              className="flex h-7 items-center justify-center gap-1 rounded-md border border-white/15 bg-[#120e08]/92 px-2 text-[10px] font-semibold uppercase tracking-[0.12em] text-white/75 transition-all backdrop-blur-sm hover:border-cyan-400/45 hover:text-cyan-100"
+            >
+              <span>2D</span>
+            </button>
+          ) : null}
           <div
             className={`flex h-7 items-center rounded-md border px-2 text-[10px] font-mono uppercase tracking-[0.12em] ${
               gatewayStatus === "connected"
@@ -7692,6 +7706,8 @@ export function RetroOffice3D({
               <SettingsPanel
                 graphicsQuality={graphicsQuality}
                 onGraphicsQualityChange={setGraphicsQuality}
+                renderMode={renderMode}
+                onRenderModeChange={onRenderModeChange}
                 gatewayStatus={gatewayStatus}
                 gatewayUrl={gatewayUrl}
                 gatewayToken={gatewayToken}

--- a/tests/e2e/pixel-office-2d.spec.ts
+++ b/tests/e2e/pixel-office-2d.spec.ts
@@ -1,0 +1,34 @@
+import { expect, test } from "@playwright/test";
+import { stubStudioRoute } from "./helpers/studioRoute";
+
+// The pixel office is forced on through the persisted render-mode preference,
+// exactly how a low-power user would have it configured.
+test("renders the 2D pixel office when the preference is set", async ({ page }) => {
+  await stubStudioRoute(page);
+  await page.addInitScript(() => {
+    window.localStorage.setItem("hermes-office-render-mode-v1", "2d");
+  });
+  await page.goto("/office");
+
+  await expect(page.getByText("2D PIXEL")).toBeVisible();
+  await expect(page.getByTitle("Switch to the 3D office")).toBeVisible();
+  await expect(page.getByTitle("Studio settings")).toBeVisible();
+  // Phaser mounts a canvas inside the pixel office root.
+  await expect(page.locator("canvas").first()).toBeVisible({ timeout: 20_000 });
+});
+
+test("switches back to the 3D office from the pixel HUD", async ({ page }) => {
+  await stubStudioRoute(page);
+  await page.addInitScript(() => {
+    window.localStorage.setItem("hermes-office-render-mode-v1", "2d");
+  });
+  await page.goto("/office");
+
+  await expect(page.getByText("2D PIXEL")).toBeVisible();
+  await page.getByTitle("Switch to the 3D office").click();
+  await expect(page.getByText("2D PIXEL")).toHaveCount(0);
+  const storedMode = await page.evaluate(() =>
+    window.localStorage.getItem("hermes-office-render-mode-v1"),
+  );
+  expect(storedMode).toBe("3d");
+});

--- a/tests/unit/officeRenderMode.test.ts
+++ b/tests/unit/officeRenderMode.test.ts
@@ -1,0 +1,53 @@
+import { beforeEach, describe, expect, it } from "vitest";
+
+import {
+  isOfficeRenderMode,
+  loadStoredOfficeRenderMode,
+  OFFICE_RENDER_MODE_STORAGE_KEY,
+  resolveInitialOfficeRenderMode,
+  saveOfficeRenderMode,
+} from "@/features/office/renderMode";
+
+describe("officeRenderMode", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("validates render mode values", () => {
+    expect(isOfficeRenderMode("3d")).toBe(true);
+    expect(isOfficeRenderMode("2d")).toBe(true);
+    expect(isOfficeRenderMode("vr")).toBe(false);
+    expect(isOfficeRenderMode(null)).toBe(false);
+  });
+
+  it("returns null when nothing was stored", () => {
+    expect(loadStoredOfficeRenderMode()).toBeNull();
+  });
+
+  it("round-trips the stored preference", () => {
+    saveOfficeRenderMode("2d");
+    expect(window.localStorage.getItem(OFFICE_RENDER_MODE_STORAGE_KEY)).toBe("2d");
+    expect(loadStoredOfficeRenderMode()).toBe("2d");
+    saveOfficeRenderMode("3d");
+    expect(loadStoredOfficeRenderMode()).toBe("3d");
+  });
+
+  it("ignores corrupt stored values", () => {
+    window.localStorage.setItem(OFFICE_RENDER_MODE_STORAGE_KEY, "banana");
+    expect(loadStoredOfficeRenderMode()).toBeNull();
+  });
+
+  it("prefers the explicit user choice over hardware detection", () => {
+    saveOfficeRenderMode("3d");
+    expect(resolveInitialOfficeRenderMode()).toBe("3d");
+    saveOfficeRenderMode("2d");
+    expect(resolveInitialOfficeRenderMode()).toBe("2d");
+  });
+
+  it("falls back to 2d when WebGL is unavailable (jsdom has no WebGL)", () => {
+    // In jsdom canvas.getContext returns null, which the detector treats as
+    // a software/no-GL environment — exactly the machines the pixel office
+    // is designed for.
+    expect(resolveInitialOfficeRenderMode()).toBe("2d");
+  });
+});

--- a/tests/unit/pixelOfficeArt.test.ts
+++ b/tests/unit/pixelOfficeArt.test.ts
@@ -67,7 +67,7 @@ function expectPaletteCovers(sprite: PixelSprite): void {
 }
 
 describe("pixel office art", () => {
-  it("provides a 16x16 sprite for every paintable ground tile plus alt variants", () => {
+  it("provides a tile-sized sprite for every paintable ground tile plus alt variants", () => {
     const sprites = buildGroundTileSprites();
     const byKey = new Map(sprites.map((s) => [s.key, s]));
 
@@ -113,7 +113,7 @@ describe("pixel office art", () => {
     expect(sprites).toHaveLength(kinds.length);
   });
 
-  it("builds all character frames at exactly 20x30 with covered palettes", () => {
+  it("builds all character frames at the exact character dimensions with covered palettes", () => {
     const frames = buildCharacterFrames({ seed: "agent-alpha", accentColor: "#e06c50" });
     for (const name of FRAME_NAMES) {
       const sprite = frames[name];

--- a/tests/unit/pixelOfficeArt.test.ts
+++ b/tests/unit/pixelOfficeArt.test.ts
@@ -1,0 +1,178 @@
+import { describe, expect, it } from "vitest";
+import {
+  buildCharacterFrames,
+  buildFurnitureSprites,
+  buildGroundTileSprites,
+  JANITOR_LOOK,
+  spriteHeight,
+  spriteWidth,
+} from "@/features/pixel-office/art";
+import {
+  CHARACTER_HEIGHT,
+  CHARACTER_WIDTH,
+  OBJECT_FOOTPRINT,
+  PIXEL_TILE_SIZE,
+  type CharacterFrameName,
+  type PixelGroundTile,
+  type PixelObjectKind,
+  type PixelSprite,
+} from "@/features/pixel-office/types";
+
+const GROUND_TILES: Exclude<PixelGroundTile, "void">[] = [
+  "grass",
+  "grass_dark",
+  "path",
+  "floor_cream",
+  "floor_white",
+  "floor_wood",
+  "carpet_purple",
+  "carpet_blue",
+  "kitchen_tile",
+  "gym_mat",
+  "server_floor",
+  "wall",
+];
+
+const FRAME_NAMES: CharacterFrameName[] = [
+  "idle_down",
+  "walk_down_a",
+  "walk_down_b",
+  "idle_up",
+  "walk_up_a",
+  "walk_up_b",
+  "idle_left",
+  "walk_left_a",
+  "walk_left_b",
+  "idle_right",
+  "walk_right_a",
+  "walk_right_b",
+  "sit_down",
+  "sit_up",
+  "sit_left",
+  "sit_right",
+  "dance_a",
+  "dance_b",
+];
+
+function expectPaletteCovers(sprite: PixelSprite): void {
+  for (const row of sprite.rows) {
+    for (const ch of row) {
+      if (ch === "." || ch === " ") continue;
+      expect(sprite.palette[ch], `char "${ch}" in sprite "${sprite.key}"`).toMatch(
+        /^#[0-9a-f]{6}([0-9a-f]{2})?$/i,
+      );
+    }
+  }
+}
+
+describe("pixel office art", () => {
+  it("provides a 16x16 sprite for every paintable ground tile plus alt variants", () => {
+    const sprites = buildGroundTileSprites();
+    const byKey = new Map(sprites.map((s) => [s.key, s]));
+
+    for (const tile of GROUND_TILES) {
+      const sprite = byKey.get(`tile_${tile}`);
+      expect(sprite, `missing tile sprite for "${tile}"`).toBeDefined();
+      expect(spriteWidth(sprite!)).toBe(PIXEL_TILE_SIZE);
+      expect(spriteHeight(sprite!)).toBe(PIXEL_TILE_SIZE);
+    }
+
+    for (const altKey of ["tile_grass_alt", "tile_floor_cream_alt", "tile_floor_wood_alt"]) {
+      const sprite = byKey.get(altKey);
+      expect(sprite, `missing alt tile sprite "${altKey}"`).toBeDefined();
+      expect(spriteWidth(sprite!)).toBe(PIXEL_TILE_SIZE);
+      expect(spriteHeight(sprite!)).toBe(PIXEL_TILE_SIZE);
+    }
+
+    for (const sprite of sprites) expectPaletteCovers(sprite);
+  });
+
+  it("alt tile variants differ from their base tiles", () => {
+    const byKey = new Map(buildGroundTileSprites().map((s) => [s.key, s]));
+    for (const base of ["tile_grass", "tile_floor_cream", "tile_floor_wood"]) {
+      expect(byKey.get(`${base}_alt`)!.rows).not.toEqual(byKey.get(base)!.rows);
+    }
+  });
+
+  it("provides a sprite per object kind matching the footprint contract", () => {
+    const sprites = buildFurnitureSprites();
+    const byKey = new Map(sprites.map((s) => [s.key, s]));
+    const kinds = Object.keys(OBJECT_FOOTPRINT) as PixelObjectKind[];
+
+    for (const kind of kinds) {
+      const sprite = byKey.get(`furn_${kind}`);
+      expect(sprite, `missing furniture sprite for "${kind}"`).toBeDefined();
+      const [fw, fh] = OBJECT_FOOTPRINT[kind];
+      expect(spriteWidth(sprite!), `width of furn_${kind}`).toBe(fw * PIXEL_TILE_SIZE);
+      expect(spriteHeight(sprite!), `height of furn_${kind}`).toBeGreaterThanOrEqual(
+        fh * PIXEL_TILE_SIZE,
+      );
+      expectPaletteCovers(sprite!);
+    }
+    expect(sprites).toHaveLength(kinds.length);
+  });
+
+  it("builds all character frames at exactly 16x24 with covered palettes", () => {
+    const frames = buildCharacterFrames({ seed: "agent-alpha", accentColor: "#e06c50" });
+    for (const name of FRAME_NAMES) {
+      const sprite = frames[name];
+      expect(sprite, `missing frame "${name}"`).toBeDefined();
+      expect(sprite.key).toBe(`char_agent-alpha_${name}`);
+      expect(spriteWidth(sprite), `width of ${name}`).toBe(CHARACTER_WIDTH);
+      expect(spriteHeight(sprite), `height of ${name}`).toBe(CHARACTER_HEIGHT);
+      expectPaletteCovers(sprite);
+    }
+  });
+
+  it("derives different hair/skin appearances from different seeds", () => {
+    const seeds = ["agent-a", "agent-b", "agent-c", "agent-d", "agent-e", "agent-f"];
+    const combos = new Set(
+      seeds.map((seed) => {
+        const frames = buildCharacterFrames({ seed, accentColor: "#4a90d9" });
+        const palette = frames.idle_down.palette;
+        return `${palette.h}|${palette.s}`;
+      }),
+    );
+    expect(combos.size).toBeGreaterThan(1);
+  });
+
+  it("mirrors right-facing frames from left-facing ones", () => {
+    const frames = buildCharacterFrames({ seed: "agent-alpha", accentColor: "#e06c50" });
+    expect(frames.idle_right.rows).not.toEqual(frames.idle_left.rows);
+    const mirroredBack = frames.idle_right.rows.map((row) =>
+      row.split("").reverse().join(""),
+    );
+    expect(mirroredBack).toEqual(
+      frames.idle_left.rows.map((row) => row.padEnd(CHARACTER_WIDTH, ".")),
+    );
+  });
+
+  it("makes sitting frames read shorter than standing frames", () => {
+    const frames = buildCharacterFrames({ seed: "agent-alpha", accentColor: "#e06c50" });
+    const firstInkRow = (sprite: PixelSprite) =>
+      sprite.rows.findIndex((row) => [...row].some((ch) => ch !== "." && ch !== " "));
+    expect(firstInkRow(frames.sit_down)).toBeGreaterThan(firstInkRow(frames.idle_down));
+    expect(spriteHeight(frames.sit_down)).toBe(CHARACTER_HEIGHT);
+  });
+
+  it("gives the janitor a stable look with a yellow cap", () => {
+    expect(JANITOR_LOOK.seed).toBe("npc-janitor");
+    expect(JANITOR_LOOK.accentColor).toBe("#8a8f98");
+    const first = buildCharacterFrames(JANITOR_LOOK);
+    const second = buildCharacterFrames(JANITOR_LOOK);
+    for (const name of FRAME_NAMES) {
+      expect(second[name].rows).toEqual(first[name].rows);
+      expect(second[name].palette).toEqual(first[name].palette);
+    }
+    // The cap band uses the "y" palette char somewhere on the head.
+    expect(first.idle_down.rows.some((row) => row.includes("y"))).toBe(true);
+    // Any other npc-janitor-prefixed seed shares the fixed appearance.
+    const variant = buildCharacterFrames({ seed: "npc-janitor-2", accentColor: "#8a8f98" });
+    expect(variant.idle_down.rows).toEqual(first.idle_down.rows);
+  });
+
+  it("falls back to the default shirt color on invalid accent hex", () => {
+    const frames = buildCharacterFrames({ seed: "agent-alpha", accentColor: "not-a-color" });
+    expect(frames.idle_down.palette.t).toBe("#4a90d9");
+  });
+});

--- a/tests/unit/pixelOfficeArt.test.ts
+++ b/tests/unit/pixelOfficeArt.test.ts
@@ -31,6 +31,7 @@ const GROUND_TILES: Exclude<PixelGroundTile, "void">[] = [
   "gym_mat",
   "server_floor",
   "wall",
+  "wall_window",
 ];
 
 const FRAME_NAMES: CharacterFrameName[] = [
@@ -112,7 +113,7 @@ describe("pixel office art", () => {
     expect(sprites).toHaveLength(kinds.length);
   });
 
-  it("builds all character frames at exactly 16x24 with covered palettes", () => {
+  it("builds all character frames at exactly 20x30 with covered palettes", () => {
     const frames = buildCharacterFrames({ seed: "agent-alpha", accentColor: "#e06c50" });
     for (const name of FRAME_NAMES) {
       const sprite = frames[name];

--- a/tests/unit/pixelOfficeInputs.test.ts
+++ b/tests/unit/pixelOfficeInputs.test.ts
@@ -1,0 +1,143 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  buildPixelAgentInputs,
+  isCleaningActive,
+} from "@/features/pixel-office/buildPixelInputs";
+import type { OfficeAgent } from "@/features/retro-office/core/types";
+import type { OfficeAnimationState } from "@/lib/office/eventTriggers";
+
+const agent = (id: string, status: OfficeAgent["status"] = "idle"): OfficeAgent => ({
+  id,
+  name: `Agent ${id}`,
+  status,
+  color: "#4a90d9",
+  item: "coffee",
+});
+
+const emptyAnimationState = (): OfficeAnimationState => ({
+  awaitingApprovalByAgentId: {},
+  cleaningCues: [],
+  danceUntilByAgentId: {},
+  deskHoldByAgentId: {},
+  githubHoldByAgentId: {},
+  gymHoldByAgentId: {},
+  jukeboxHoldByAgentId: {},
+  manualGymUntilByAgentId: {},
+  pendingStandupRequest: null,
+  phoneBoothHoldByAgentId: {},
+  phoneCallByAgentId: {},
+  qaHoldByAgentId: {},
+  smsBoothHoldByAgentId: {},
+  skillGymHoldByAgentId: {},
+  streamingByAgentId: {},
+  textMessageByAgentId: {},
+  thinkingByAgentId: {},
+  workingUntilByAgentId: {},
+});
+
+describe("buildPixelAgentInputs", () => {
+  it("maps a bare roster with no animation state", () => {
+    const inputs = buildPixelAgentInputs({
+      agents: [agent("a", "working"), agent("b", "error")],
+      animationState: null,
+      nowMs: 1_000,
+    });
+    expect(inputs).toHaveLength(2);
+    expect(inputs[0]).toMatchObject({
+      id: "a",
+      status: "working",
+      hold: null,
+      dancing: false,
+      standup: false,
+      streaming: false,
+    });
+    expect(inputs[1].status).toBe("error");
+  });
+
+  it("prioritizes the phone booth hold over the gym hold", () => {
+    const state = emptyAnimationState();
+    state.phoneBoothHoldByAgentId = { a: true };
+    state.gymHoldByAgentId = { a: true };
+    const [input] = buildPixelAgentInputs({
+      agents: [agent("a")],
+      animationState: state,
+      nowMs: 1_000,
+    });
+    expect(input.hold).toBe("phone_booth");
+  });
+
+  it("maps each hold kind to its station", () => {
+    const cases: Array<[Partial<OfficeAnimationState>, string]> = [
+      [{ smsBoothHoldByAgentId: { a: true } }, "sms_booth"],
+      [{ gymHoldByAgentId: { a: true } }, "gym"],
+      [{ skillGymHoldByAgentId: { a: true } }, "gym"],
+      [{ manualGymUntilByAgentId: { a: 2_000 } }, "gym"],
+      [{ qaHoldByAgentId: { a: true } }, "qa_lab"],
+      [{ githubHoldByAgentId: { a: true } }, "github_desk"],
+      [{ jukeboxHoldByAgentId: { a: true } }, "jukebox"],
+    ];
+    for (const [patch, expected] of cases) {
+      const state = { ...emptyAnimationState(), ...patch };
+      const [input] = buildPixelAgentInputs({
+        agents: [agent("a")],
+        animationState: state,
+        nowMs: 1_000,
+      });
+      expect(input.hold).toBe(expected);
+    }
+  });
+
+  it("expires timed holds and dances by nowMs", () => {
+    const state = emptyAnimationState();
+    state.manualGymUntilByAgentId = { a: 5_000 };
+    state.danceUntilByAgentId = { a: 5_000 };
+    const before = buildPixelAgentInputs({
+      agents: [agent("a")],
+      animationState: state,
+      nowMs: 4_999,
+    })[0];
+    const after = buildPixelAgentInputs({
+      agents: [agent("a")],
+      animationState: state,
+      nowMs: 5_001,
+    })[0];
+    expect(before.hold).toBe("gym");
+    expect(before.dancing).toBe(true);
+    expect(after.hold).toBeNull();
+    expect(after.dancing).toBe(false);
+  });
+
+  it("maps streaming, thinking, approval, and standup flags", () => {
+    const state = emptyAnimationState();
+    state.streamingByAgentId = { a: true };
+    state.thinkingByAgentId = { a: true };
+    state.awaitingApprovalByAgentId = { a: true };
+    state.pendingStandupRequest = {
+      key: "k",
+      message: "standup",
+      requestedAt: 1,
+    };
+    const [input] = buildPixelAgentInputs({
+      agents: [agent("a")],
+      animationState: state,
+      nowMs: 1_000,
+    });
+    expect(input.streaming).toBe(true);
+    expect(input.thinking).toBe(true);
+    expect(input.awaitingApproval).toBe(true);
+    expect(input.standup).toBe(true);
+  });
+});
+
+describe("isCleaningActive", () => {
+  it("is false without cues and true with cues", () => {
+    expect(isCleaningActive(null)).toBe(false);
+    expect(isCleaningActive(emptyAnimationState())).toBe(false);
+    const state = emptyAnimationState();
+    state.cleaningCues = [
+      { id: "c1", agentId: "a", agentName: "Agent a", ts: 1 },
+    ];
+    expect(isCleaningActive(state)).toBe(true);
+  });
+});

--- a/tests/unit/pixelOfficeInputs.test.ts
+++ b/tests/unit/pixelOfficeInputs.test.ts
@@ -108,6 +108,27 @@ describe("buildPixelAgentInputs", () => {
     expect(after.dancing).toBe(false);
   });
 
+  it("latches working status through the desk hold and working-until window", () => {
+    const state = emptyAnimationState();
+    state.workingUntilByAgentId = { a: 5_000 };
+    state.deskHoldByAgentId = { b: true };
+    const inputs = buildPixelAgentInputs({
+      agents: [agent("a"), agent("b"), agent("c", "error")],
+      animationState: state,
+      nowMs: 4_000,
+    });
+    expect(inputs[0].status).toBe("working");
+    expect(inputs[1].status).toBe("working");
+    // Error status always wins over the latch.
+    expect(inputs[2].status).toBe("error");
+    const expired = buildPixelAgentInputs({
+      agents: [agent("a")],
+      animationState: state,
+      nowMs: 6_000,
+    });
+    expect(expired[0].status).toBe("idle");
+  });
+
   it("maps streaming, thinking, approval, and standup flags", () => {
     const state = emptyAnimationState();
     state.streamingByAgentId = { a: true };

--- a/tests/unit/pixelOfficeMap.test.ts
+++ b/tests/unit/pixelOfficeMap.test.ts
@@ -1,0 +1,88 @@
+// Integrity checks for the Hermes HQ pixel map: bounds, walkability, and
+// reachability of every desk seat and station tile from the spawn point.
+
+import { describe, expect, it } from "vitest";
+
+import { buildHermesHqMap } from "@/features/pixel-office/map/hermesHqMap";
+import { buildPixelNavGrid, tileCenter } from "@/features/pixel-office/map/navGrid";
+import { astar2D } from "@/lib/office/pathfinding";
+
+describe("hermes hq pixel map integrity", () => {
+  const map = buildHermesHqMap();
+  const grid = buildPixelNavGrid(map);
+  const spawnCenter = tileCenter(map.spawn.tx, map.spawn.ty);
+
+  const inBounds = (tx: number, ty: number): boolean =>
+    tx >= 0 && ty >= 0 && tx < map.cols && ty < map.rows;
+
+  const reachableFromSpawn = (tx: number, ty: number): boolean => {
+    if (tx === map.spawn.tx && ty === map.spawn.ty) return true;
+    const center = tileCenter(tx, ty);
+    return astar2D(spawnCenter.x, spawnCenter.y, center.x, center.y, grid).length > 0;
+  };
+
+  it("keeps every desk tile and seat inside bounds", () => {
+    for (const desk of map.desks) {
+      expect(inBounds(desk.deskTx, desk.deskTy), `desk ${desk.id} tile`).toBe(true);
+      expect(inBounds(desk.seatTx, desk.seatTy), `desk ${desk.id} seat`).toBe(true);
+    }
+  });
+
+  it("keeps every station tile inside bounds", () => {
+    for (const station of map.stations) {
+      expect(inBounds(station.tx, station.ty), `station ${station.id}`).toBe(true);
+    }
+  });
+
+  it("makes every desk seat walkable and reachable from spawn", () => {
+    for (const desk of map.desks) {
+      expect(
+        grid.cells[desk.seatTy * grid.cols + desk.seatTx],
+        `desk ${desk.id} seat (${desk.seatTx}, ${desk.seatTy}) blocked`,
+      ).toBe(0);
+      expect(
+        reachableFromSpawn(desk.seatTx, desk.seatTy),
+        `desk ${desk.id} seat (${desk.seatTx}, ${desk.seatTy}) unreachable`,
+      ).toBe(true);
+    }
+  });
+
+  it("makes every station tile walkable and reachable from spawn", () => {
+    for (const station of map.stations) {
+      expect(
+        grid.cells[station.ty * grid.cols + station.tx],
+        `station ${station.id} (${station.tx}, ${station.ty}) blocked`,
+      ).toBe(0);
+      expect(
+        reachableFromSpawn(station.tx, station.ty),
+        `station ${station.id} (${station.tx}, ${station.ty}) unreachable`,
+      ).toBe(true);
+    }
+  });
+
+  it("gives every desk a unique seat tile", () => {
+    const seats = new Set(map.desks.map((desk) => `${desk.seatTx},${desk.seatTy}`));
+    expect(seats.size).toBe(map.desks.length);
+  });
+
+  it("keeps all zones within map bounds", () => {
+    for (const zone of map.zones) {
+      expect(zone.tx, `zone ${zone.id} tx`).toBeGreaterThanOrEqual(0);
+      expect(zone.ty, `zone ${zone.id} ty`).toBeGreaterThanOrEqual(0);
+      expect(zone.tw, `zone ${zone.id} tw`).toBeGreaterThan(0);
+      expect(zone.th, `zone ${zone.id} th`).toBeGreaterThan(0);
+      expect(zone.tx + zone.tw, `zone ${zone.id} right edge`).toBeLessThanOrEqual(
+        map.cols,
+      );
+      expect(zone.ty + zone.th, `zone ${zone.id} bottom edge`).toBeLessThanOrEqual(
+        map.rows,
+      );
+    }
+  });
+
+  it("places spawn on a non-wall walkable tile", () => {
+    expect(inBounds(map.spawn.tx, map.spawn.ty)).toBe(true);
+    expect(map.ground[map.spawn.ty * map.cols + map.spawn.tx]).not.toBe("wall");
+    expect(grid.cells[map.spawn.ty * grid.cols + map.spawn.tx]).toBe(0);
+  });
+});

--- a/tests/unit/pixelOfficeSim.test.ts
+++ b/tests/unit/pixelOfficeSim.test.ts
@@ -1,0 +1,272 @@
+// Behavior tests for the pixel office agent simulation (no Phaser involved).
+
+import { describe, expect, it } from "vitest";
+
+import { buildHermesHqMap } from "@/features/pixel-office/map/hermesHqMap";
+import { tileCenter } from "@/features/pixel-office/map/navGrid";
+import {
+  createPixelSimulation,
+  JANITOR_ID,
+  type PixelSimulation,
+} from "@/features/pixel-office/sim/agentSimulation";
+import type { PixelAgentInput, PixelAgentPose } from "@/features/pixel-office/types";
+
+const DT_MS = 50;
+
+const makeInput = (
+  id: string,
+  overrides: Partial<PixelAgentInput> = {},
+): PixelAgentInput => ({
+  id,
+  name: id,
+  status: "working",
+  color: "#7c5cff",
+  streaming: false,
+  thinking: false,
+  awaitingApproval: false,
+  dancing: false,
+  hold: null,
+  standup: false,
+  ...overrides,
+});
+
+type Clock = { nowMs: number };
+
+const makeClock = (): Clock => ({ nowMs: 1_000_000 });
+
+const runTicks = (
+  sim: PixelSimulation,
+  clock: Clock,
+  inputs: PixelAgentInput[],
+  ticks: number,
+  cleaningActive = false,
+): PixelAgentPose[] => {
+  let poses: PixelAgentPose[] = [];
+  for (let index = 0; index < ticks; index += 1) {
+    clock.nowMs += DT_MS;
+    poses = sim.tick({ inputs, nowMs: clock.nowMs, dtMs: DT_MS, cleaningActive });
+  }
+  return poses;
+};
+
+const poseById = (poses: PixelAgentPose[], id: string): PixelAgentPose => {
+  const pose = poses.find((candidate) => candidate.id === id);
+  if (!pose) throw new Error(`missing pose for ${id}`);
+  return pose;
+};
+
+describe("pixel office simulation", () => {
+  it("walks a working agent from spawn to its desk seat", () => {
+    const map = buildHermesHqMap();
+    const sim = createPixelSimulation(map);
+    const clock = makeClock();
+    const inputs = [makeInput("agent-a")];
+
+    const early = runTicks(sim, clock, inputs, 2);
+    expect(early[0].activity).toBe("walking");
+    expect(early[0].moving).toBe(true);
+
+    const poses = runTicks(sim, clock, inputs, 1200);
+    const pose = poses[0];
+    const deskId = sim.getState().deskByAgentId["agent-a"];
+    expect(deskId).toBe(map.desks[0].id);
+    const desk = map.desks.find((slot) => slot.id === deskId);
+    if (!desk) throw new Error("desk not found");
+    const seat = tileCenter(desk.seatTx, desk.seatTy);
+    expect(pose.activity).toBe("sitting_desk");
+    expect(pose.moving).toBe(false);
+    expect(pose.x).toBe(seat.x);
+    expect(pose.y).toBe(seat.y);
+    expect(pose.facing).toBe(desk.facing);
+    expect(pose.deskId).toBe(desk.id);
+    expect(pose.stationId).toBeNull();
+  });
+
+  it("assigns desks deterministically and keeps them sticky across roster reorders", () => {
+    const map = buildHermesHqMap();
+    const inputs = [makeInput("agent-b"), makeInput("agent-a")];
+
+    const simOne = createPixelSimulation(map);
+    const clockOne = makeClock();
+    runTicks(simOne, clockOne, inputs, 5);
+    const firstRun = { ...simOne.getState().deskByAgentId };
+
+    const simTwo = createPixelSimulation(buildHermesHqMap());
+    const clockTwo = makeClock();
+    runTicks(simTwo, clockTwo, inputs, 5);
+    expect(simTwo.getState().deskByAgentId).toEqual(firstRun);
+
+    // Sorted by id: agent-a takes the first desk even though agent-b is first
+    // in the roster array.
+    expect(firstRun["agent-a"]).toBe(map.desks[0].id);
+    expect(firstRun["agent-b"]).toBe(map.desks[1].id);
+
+    // Reordering the roster must not reshuffle assignments.
+    runTicks(simOne, clockOne, [makeInput("agent-a"), makeInput("agent-b")], 5);
+    expect(simOne.getState().deskByAgentId).toEqual(firstRun);
+  });
+
+  it("routes a gym hold to a gym station and returns to the desk afterwards", () => {
+    const map = buildHermesHqMap();
+    const sim = createPixelSimulation(map);
+    const clock = makeClock();
+
+    const holdPoses = runTicks(sim, clock, [makeInput("agent-a", { hold: "gym" })], 1200);
+    const holdPose = holdPoses[0];
+    expect(holdPose.activity).toBe("station");
+    expect(holdPose.stationId).not.toBeNull();
+    const station = map.stations.find((slot) => slot.id === holdPose.stationId);
+    expect(station?.kind).toBe("gym");
+    const stationCenter = tileCenter(station?.tx ?? 0, station?.ty ?? 0);
+    expect(holdPose.x).toBe(stationCenter.x);
+    expect(holdPose.y).toBe(stationCenter.y);
+
+    const releasedPoses = runTicks(sim, clock, [makeInput("agent-a")], 1200);
+    const releasedPose = releasedPoses[0];
+    expect(releasedPose.activity).toBe("sitting_desk");
+    const desk = map.desks.find(
+      (slot) => slot.id === sim.getState().deskByAgentId["agent-a"],
+    );
+    if (!desk) throw new Error("desk not found");
+    const seat = tileCenter(desk.seatTx, desk.seatTy);
+    expect(releasedPose.x).toBe(seat.x);
+    expect(releasedPose.y).toBe(seat.y);
+  });
+
+  it("sends two phone_booth holds to two different booths", () => {
+    const map = buildHermesHqMap();
+    const sim = createPixelSimulation(map);
+    const clock = makeClock();
+    const inputs = [
+      makeInput("agent-a", { hold: "phone_booth" }),
+      makeInput("agent-b", { hold: "phone_booth" }),
+    ];
+
+    const poses = runTicks(sim, clock, inputs, 1200);
+    const poseA = poseById(poses, "agent-a");
+    const poseB = poseById(poses, "agent-b");
+    expect(poseA.activity).toBe("station");
+    expect(poseB.activity).toBe("station");
+    expect(poseA.stationId).not.toBeNull();
+    expect(poseB.stationId).not.toBeNull();
+    expect(poseA.stationId).not.toBe(poseB.stationId);
+    for (const stationId of [poseA.stationId, poseB.stationId]) {
+      const station = map.stations.find((slot) => slot.id === stationId);
+      expect(station?.kind).toBe("phone_booth");
+    }
+  });
+
+  it("dances in place without teleporting", () => {
+    const map = buildHermesHqMap();
+    const sim = createPixelSimulation(map);
+    const clock = makeClock();
+
+    const walking = runTicks(sim, clock, [makeInput("agent-a")], 10);
+    expect(walking[0].moving).toBe(true);
+    const before = walking[0];
+
+    const dancing = runTicks(sim, clock, [makeInput("agent-a", { dancing: true })], 1);
+    expect(dancing[0].activity).toBe("dancing");
+    expect(dancing[0].moving).toBe(false);
+    expect(dancing[0].x).toBe(before.x);
+    expect(dancing[0].y).toBe(before.y);
+
+    const stillDancing = runTicks(
+      sim,
+      clock,
+      [makeInput("agent-a", { dancing: true })],
+      20,
+    );
+    expect(stillDancing[0].activity).toBe("dancing");
+    expect(stillDancing[0].x).toBe(before.x);
+    expect(stillDancing[0].y).toBe(before.y);
+  });
+
+  it("gathers everyone at distinct meeting seats during a standup", () => {
+    const map = buildHermesHqMap();
+    const sim = createPixelSimulation(map);
+    const clock = makeClock();
+    const inputs = [
+      makeInput("agent-a", { standup: true }),
+      makeInput("agent-b", { standup: true }),
+      makeInput("agent-c", { standup: true }),
+    ];
+
+    const poses = runTicks(sim, clock, inputs, 1600);
+    const stationIds = new Set<string>();
+    for (const pose of poses) {
+      expect(pose.activity).toBe("meeting");
+      expect(pose.moving).toBe(false);
+      expect(pose.stationId).not.toBeNull();
+      const station = map.stations.find((slot) => slot.id === pose.stationId);
+      expect(station?.kind).toBe("meeting_seat");
+      if (pose.stationId) stationIds.add(pose.stationId);
+    }
+    expect(stationIds.size).toBe(inputs.length);
+  });
+
+  it("makes an idle agent visit a station, pause, then pick a different one", () => {
+    const map = buildHermesHqMap();
+    const sim = createPixelSimulation(map);
+    const clock = makeClock();
+    const inputs = [makeInput("agent-idle", { status: "idle" })];
+
+    const visited: string[] = [];
+    for (let index = 0; index < 2400 && visited.length < 2; index += 1) {
+      const poses = runTicks(sim, clock, inputs, 1);
+      const pose = poses[0];
+      const settled =
+        !pose.moving &&
+        pose.stationId !== null &&
+        (pose.activity === "station" || pose.activity === "standing");
+      if (settled && visited[visited.length - 1] !== pose.stationId) {
+        visited.push(pose.stationId as string);
+      }
+    }
+    expect(visited.length).toBeGreaterThanOrEqual(2);
+    expect(visited[0]).not.toBe(visited[1]);
+  });
+
+  it("spawns the janitor while cleaning and walks it back to spawn afterwards", () => {
+    const map = buildHermesHqMap();
+    const sim = createPixelSimulation(map);
+    const clock = makeClock();
+
+    const active = runTicks(sim, clock, [], 100, true);
+    const janitorPose = poseById(active, JANITOR_ID);
+    expect(janitorPose).toBeDefined();
+    expect(sim.getState().janitor).not.toBeNull();
+
+    let lastSeen = janitorPose;
+    let despawned = false;
+    for (let index = 0; index < 2000; index += 1) {
+      const poses = runTicks(sim, clock, [], 1, false);
+      const pose = poses.find((candidate) => candidate.id === JANITOR_ID);
+      if (!pose) {
+        despawned = true;
+        break;
+      }
+      lastSeen = pose;
+    }
+    expect(despawned).toBe(true);
+    expect(sim.getState().janitor).toBeNull();
+    const spawn = tileCenter(map.spawn.tx, map.spawn.ty);
+    const distance = Math.hypot(lastSeen.x - spawn.x, lastSeen.y - spawn.y);
+    expect(distance).toBeLessThan(16);
+  });
+
+  it("frees a removed agent's desk for the next assignee", () => {
+    const map = buildHermesHqMap();
+    const sim = createPixelSimulation(map);
+    const clock = makeClock();
+
+    runTicks(sim, clock, [makeInput("agent-a")], 5);
+    expect(sim.getState().deskByAgentId["agent-a"]).toBe(map.desks[0].id);
+
+    runTicks(sim, clock, [makeInput("agent-c")], 5);
+    const deskByAgentId = sim.getState().deskByAgentId;
+    expect(deskByAgentId["agent-a"]).toBeUndefined();
+    expect(deskByAgentId["agent-c"]).toBe(map.desks[0].id);
+    expect(sim.getState().agents["agent-a"]).toBeUndefined();
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a Gather.town-style 2D pixel-art office as an alternative renderer for users on low-power machines, switchable with the existing 3D office.

- **Renderer preference** (`src/features/office/renderMode.ts`): persisted in localStorage; machines with software-only WebGL default to the pixel office. Toggle lives in Settings → "Office renderer" plus quick-switch buttons in both scenes' toolbars (`2D` / `3D`).
- **Choose before anything loads**: the gateway connect screen shows an "Office renderer" picker, and neither the Three.js nor the Phaser scene mounts until the gateway is connected (a lightweight dark backdrop shows instead). The connect overlay is also scrollable now.
- **Soft pastel Gather-style art** (all generated procedurally in TypeScript — no binary assets):
  - Pastel tile set: mottled light grass, near-uniform cream/white floors with subtle checker, pink-beige wood planks, periwinkle/soft-blue carpets, sage kitchen checker, and light gray paneled walls with baseboards and sky-blue window panes along the facade.
  - 32 detailed furniture sprites with soft outlines and drop shadows: white pod desks with colorful code-editor monitors + keyboards + props, office chairs with backrests, peach sofas, colorful bookshelves, lush potted plants and trees, indigo ping-pong table, arcade, jukebox, sticky-note boards, glass phone/SMS booths, LED server racks, aquarium, and more.
  - Chunkier 20x30 characters: 5+ skin tones, 7 hair colors with highlight bands, 4 hair styles plus seed-based headphones/caps, shirts tinted by each agent's accent color, full walk/sit/dance frame sets.
  - Gather-like camera: starts zoomed on the pods; zooming out stops at a centered full-map overview.
- **Live Hermes behavior**: working agents walk to deterministic desks and sit (with the same post-run desk latch the 3D office uses), idle agents wander to coffee/lounge/arcade spots, `OfficeAnimationState` holds route agents to the gym/booths/QA lab/GitHub desk/jukebox, standups gather in the meeting room, cleaning cues spawn a janitor, and streaming replies render as speech bubbles with nameplates + status dots. Click an agent to open its chat; right-click for edit/delete.
- **Docs**: README and ARCHITECTURE mention the new renderer.

## Demo

[pastel_pixel_office_art_overhaul_tour.mp4](https://cursor.com/agents/bc-01a038e7-ecec-7338-bcb4-c398a003306a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpastel_pixel_office_art_overhaul_tour.mp4)

[Pastel pixel office full overview](https://cursor.com/agents/bc-01a038e7-ecec-7338-bcb4-c398a003306a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpixel_office_pastel_overview.webp)

[Close-up of desks and characters](https://cursor.com/agents/bc-01a038e7-ecec-7338-bcb4-c398a003306a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpixel_office_pastel_closeup.webp)

[Agent replying with a speech bubble while heading to its desk](https://cursor.com/agents/bc-01a038e7-ecec-7338-bcb4-c398a003306a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fpixel_office_pastel_chat_bubble.webp)

[connect_screen_renderer_choice_and_2d_office.mp4](https://cursor.com/agents/bc-01a038e7-ecec-7338-bcb4-c398a003306a/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fconnect_screen_renderer_choice_and_2d_office.mp4)

## Testing

- 38 vitest unit tests (`pixelOfficeArt`, `pixelOfficeSim`, `pixelOfficeMap`, `pixelOfficeInputs`, `officeRenderMode`) — all passing.
- Playwright spec `tests/e2e/pixel-office-2d.spec.ts` covering forced 2D mode and HUD switch back to 3D.
- Manual browser verification with the demo gateway: connect-screen picker, deferred scene mount, click-to-chat, speech bubbles, desk sitting (also verified deterministically via simulation traces), and both 2D↔3D switches.
- `npm run lint`: 0 errors (only pre-existing warnings). `npm run typecheck`: clean apart from documented pre-existing test-file errors.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#team-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-01a038e7-ecec-7338-bcb4-c398a003306a?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-01a038e7-ecec-7338-bcb4-c398a003306a&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

