### PR TITLE
fix: allow WebAssembly compilation in production CSP

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -14,9 +14,13 @@ const securityHeaders = [
       "style-src 'self' 'unsafe-inline' https:",
       // 'unsafe-eval' is required by Next.js dev mode (source maps, HMR).
       // In production it is dropped — React and Three.js do not need eval.
+      // 'wasm-unsafe-eval' is required in production too: a three.js chunk
+      // (draco/basis decoder) calls WebAssembly.instantiate during module
+      // evaluation, and without it the whole chunk fails and the agent
+      // roster never renders (observed 2026-08-27, local patch).
       ...(process.env.NODE_ENV !== "production"
         ? ["script-src 'self' 'unsafe-inline' 'unsafe-eval' blob:"]
-        : ["script-src 'self' 'unsafe-inline' blob:"]),
+        : ["script-src 'self' 'unsafe-inline' 'wasm-unsafe-eval' blob:"]),
       // connect-src is intentionally broad: gateway URLs are user-configured
       // at runtime and cannot be enumerated at build time.
       // Restrict further when a fixed deployment target is known.


### PR DESCRIPTION
## Problem

In a production build (`npm run build && npm run start`), the CSP drops `'unsafe-eval'` entirely — but a three.js chunk (draco/basis decoder preload) calls `WebAssembly.instantiate` during module evaluation. The whole chunk dies with a `CompileError` and dependent UI never renders. Observed symptom: agent roster stuck empty on production while `npm run dev` works fine (dev's `'unsafe-eval'` covers WASM, which is why it never reproduces there).

```
CompileError: WebAssembly.instantiate(): ... violates the following Content Security Policy
directive because 'unsafe-eval' is not an allowed source of script:
"script-src 'self' 'unsafe-inline' blob:"
```

## Fix

Add `'wasm-unsafe-eval'` to the production `script-src`. It only permits WASM compilation — JS `eval` stays blocked, so the production hardening intent is preserved. Dev mode unchanged.

## Verification

Reproduced on a production build connected to a custom gateway (12-agent fleet): before the fix the chunk errored on load; after rebuild the console is clean and the office renders fully.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q5Cv161iLU4Uh1aGi11cwe