### PR TITLE
fix: recover agent fleet hydration when demo placeholder is seeded before connect

### DIFF
--- a/src/features/office/screens/OfficeScreen.tsx
+++ b/src/features/office/screens/OfficeScreen.tsx
@@ -2427,10 +2427,25 @@ export function OfficeScreen({
     [requestAgentHistoryRefresh],
   );
 
+  // Local patch (2026-08-27): the demo-adapter placeholder seed below sets
+  // agentsLoaded=true while disconnected, so when the (auto-)connect lands a
+  // moment later this effect used to skip hydration and the office stayed
+  // stuck on the lone "Main" placeholder. When connected and the fleet is
+  // still exactly that placeholder, force one reload per connection.
+  const demoPlaceholderReloadRef = useRef(false);
   useEffect(() => {
-    if (status !== "connected" || agentsLoaded) return;
+    if (status !== "connected") {
+      demoPlaceholderReloadRef.current = false;
+      return;
+    }
+    const onlyDemoPlaceholder =
+      state.agents.length === 1 && state.agents[0]?.agentId === MAIN_AGENT_ID;
+    const shouldRecoverFromPlaceholder =
+      onlyDemoPlaceholder && !demoPlaceholderReloadRef.current;
+    if (agentsLoaded && !shouldRecoverFromPlaceholder) return;
+    if (shouldRecoverFromPlaceholder) demoPlaceholderReloadRef.current = true;
     void loadAgents({ forceSettings: true });
-  }, [agentsLoaded, loadAgents, status]);
+  }, [agentsLoaded, loadAgents, state.agents, status]);
 
   useEffect(() => {
     if (status !== "connected") return;


### PR DESCRIPTION
## Problem

With the demo adapter selected, the disconnected-state effect in `OfficeScreen.tsx` seeds a local **"Main"** placeholder agent and sets `agentsLoaded = true`. If the (auto-)connect lands a moment later:

- the connected effect (`if (status !== "connected" || agentsLoaded) return`) skips hydration, and
- the retry effect requires `state.agents.length === 0`, which is now 1.

So the office stays stuck on the lone "Main" placeholder even though the gateway is healthy — `agents.list` through the Studio proxy returns the full fleet. The race is timing-dependent: dev builds usually connect before the seed wins, while production builds render faster and hit it reliably (repro: production build + a gateway on the default `ws://localhost:18789`, demo backend selected → "demo • connected" with 1 agent).

## Fix

When connected and the fleet is still exactly the placeholder (`length === 1 && agents[0].id === MAIN_AGENT_ID`), force one reload per connection. Guarded by a ref reset on disconnect so a gateway that genuinely serves a single `main` agent doesn't re-trigger in a loop.

## Verification

On the reproducing setup (production build, 12-agent custom gateway): before the fix the office showed 1 placeholder agent while a direct WS probe through `/api/gateway/ws` returned 12; after the fix the full fleet hydrates on first load.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Q5Cv161iLU4Uh1aGi11cwe