### PR TITLE
Add female avatar presets and clothing options

### DIFF
--- a/src/features/agents/components/AgentAvatarEditorPanel.tsx
+++ b/src/features/agents/components/AgentAvatarEditorPanel.tsx
@@ -5,6 +5,7 @@ import { RefreshCcw, Shuffle } from "lucide-react";
 import {
   AGENT_AVATAR_BOTTOM_STYLE_OPTIONS,
   AGENT_AVATAR_CLOTHING_COLOR_OPTIONS,
+  AGENT_AVATAR_FEMALE_PRESETS,
   AGENT_AVATAR_HAIR_COLOR_OPTIONS,
   AGENT_AVATAR_HAIR_STYLE_OPTIONS,
   AGENT_AVATAR_HAT_STYLE_OPTIONS,
@@ -12,6 +13,7 @@ import {
   AGENT_AVATAR_SKIN_TONE_OPTIONS,
   AGENT_AVATAR_TOP_STYLE_OPTIONS,
   type AgentAvatarProfile,
+  applyAgentAvatarFemalePreset,
   createDefaultAgentAvatarProfile,
 } from "@/lib/avatars/profile";
 import { AgentAvatarPreview3D } from "@/features/agents/components/AgentAvatarPreview3D";
@@ -151,6 +153,46 @@ export const AgentAvatarEditorPanel = forwardRef<
             </button>
           </div>
         ) : null}
+        <section className="mb-6 space-y-3 border-b border-border/40 pb-6">
+          <div>
+            <h3 className="font-mono text-[11px] font-semibold tracking-[0.06em] text-muted-foreground">
+              Female presets
+            </h3>
+            <p className="mt-1 text-[11px] text-muted-foreground">
+              Applies hair, outfit, and colors while keeping skin tone and accessories.
+            </p>
+          </div>
+          <div className="grid grid-cols-2 gap-2 sm:grid-cols-3">
+            {AGENT_AVATAR_FEMALE_PRESETS.map((preset) => {
+              const selected =
+                draft.hair.style === preset.hairStyle &&
+                draft.hair.color === preset.hairColor &&
+                draft.clothing.topStyle === preset.topStyle &&
+                draft.clothing.topColor === preset.topColor &&
+                draft.clothing.bottomStyle === preset.bottomStyle &&
+                draft.clothing.bottomColor === preset.bottomColor;
+              return (
+                <button
+                  key={preset.id}
+                  type="button"
+                  aria-label={`Apply ${preset.label} preset`}
+                  className={`rounded-lg border px-3 py-2 text-left transition-colors ${
+                    selected
+                      ? "border-primary bg-primary/15 text-foreground"
+                      : "border-border/50 bg-muted/20 text-muted-foreground hover:bg-muted/40"
+                  }`}
+                  onClick={() =>
+                    setDraft((current) => applyAgentAvatarFemalePreset(current, preset.id))
+                  }
+                  disabled={saving}
+                >
+                  <span className="block text-xs font-medium">{preset.label}</span>
+                  <span className="mt-0.5 block text-[10px]">{preset.hairLabel}</span>
+                </button>
+              );
+            })}
+          </div>
+        </section>
         <div className="grid gap-6 xl:grid-cols-2">
           <section className="space-y-3">
             <h3 className="font-mono text-[11px] font-semibold tracking-[0.06em] text-muted-foreground">

--- a/src/features/agents/components/AgentAvatarPreview3D.tsx
+++ b/src/features/agents/components/AgentAvatarPreview3D.tsx
@@ -39,8 +39,13 @@ const PreviewFigure = ({
   const shoeColor = profile.clothing.shoesColor;
   const hairColor = profile.hair.color;
   const accessoryColor = topColor;
-  const sleeveColor = profile.clothing.topStyle === "jacket" ? "#dbe4ff" : topColor;
-  const cuffColor = profile.clothing.topStyle === "hoodie" ? "#d1d5db" : sleeveColor;
+  const topStyle = profile.clothing.topStyle;
+  const bottomStyle = profile.clothing.bottomStyle;
+  const isLongDress = topStyle === "long-dress";
+  const isShortDress = topStyle === "short-dress";
+  const isDress = isLongDress || isShortDress;
+  const sleeveColor = topStyle === "jacket" ? "#dbe4ff" : topColor;
+  const cuffColor = topStyle === "hoodie" ? "#d1d5db" : sleeveColor;
 
   return (
     <group ref={groupRef} position={[0, -0.72, 0]} scale={[1.45, 1.45, 1.45]}>
@@ -58,58 +63,78 @@ const PreviewFigure = ({
         </group>
       ) : null}
 
-      <group position={[-0.05, 0.12, 0]}>
-        {profile.clothing.bottomStyle === "shorts" ? (
-          <>
-            <mesh position={[0, 0.03, 0]}>
-              <boxGeometry args={[0.07, 0.08, 0.08]} />
-              <meshLambertMaterial color={bottomColor} />
-            </mesh>
-            <mesh position={[0, -0.045, 0]}>
-              <boxGeometry args={[0.05, 0.06, 0.05]} />
+      {[-0.05, 0.05].map((x) => (
+        <group key={x} position={[x, 0.12, 0]}>
+          {isDress || bottomStyle === "long-skirt" || bottomStyle === "mini-skirt" ? (
+            <mesh>
+              <boxGeometry args={[0.05, 0.14, 0.05]} />
               <meshLambertMaterial color={skin} />
             </mesh>
-          </>
-        ) : (
-          <mesh>
-            <boxGeometry args={[0.07, 0.14, 0.08]} />
-            <meshLambertMaterial color={bottomColor} />
-          </mesh>
-        )}
-        <mesh position={[0, -0.09, 0]}>
-          <boxGeometry args={[0.07, 0.05, 0.12]} />
-          <meshLambertMaterial color={shoeColor} />
-        </mesh>
-      </group>
-      <group position={[0.05, 0.12, 0]}>
-        {profile.clothing.bottomStyle === "shorts" ? (
-          <>
-            <mesh position={[0, 0.03, 0]}>
-              <boxGeometry args={[0.07, 0.08, 0.08]} />
+          ) : bottomStyle === "shorts" ? (
+            <>
+              <mesh position={[0, 0.03, 0]}>
+                <boxGeometry args={[0.07, 0.08, 0.08]} />
+                <meshLambertMaterial color={bottomColor} />
+              </mesh>
+              <mesh position={[0, -0.045, 0]}>
+                <boxGeometry args={[0.05, 0.06, 0.05]} />
+                <meshLambertMaterial color={skin} />
+              </mesh>
+            </>
+          ) : bottomStyle === "hot-pants" ? (
+            <>
+              <mesh position={[0, 0.052, 0]}>
+                <boxGeometry args={[0.07, 0.04, 0.08]} />
+                <meshLambertMaterial color={bottomColor} />
+              </mesh>
+              <mesh position={[0, -0.025, 0]}>
+                <boxGeometry args={[0.05, 0.1, 0.05]} />
+                <meshLambertMaterial color={skin} />
+              </mesh>
+            </>
+          ) : (
+            <mesh>
+              <boxGeometry args={[0.07, 0.14, 0.08]} />
               <meshLambertMaterial color={bottomColor} />
             </mesh>
-            <mesh position={[0, -0.045, 0]}>
-              <boxGeometry args={[0.05, 0.06, 0.05]} />
-              <meshLambertMaterial color={skin} />
-            </mesh>
-          </>
-        ) : (
-          <mesh>
-            <boxGeometry args={[0.07, 0.14, 0.08]} />
-            <meshLambertMaterial color={bottomColor} />
+          )}
+          <mesh position={[0, -0.09, 0]}>
+            <boxGeometry args={[0.07, 0.05, 0.12]} />
+            <meshLambertMaterial color={shoeColor} />
           </mesh>
-        )}
-        <mesh position={[0, -0.09, 0]}>
-          <boxGeometry args={[0.07, 0.05, 0.12]} />
-          <meshLambertMaterial color={shoeColor} />
+        </group>
+      ))}
+
+      {!isDress && bottomStyle === "long-skirt" ? (
+        <mesh position={[0, 0.14, 0]} rotation={[0, Math.PI / 4, 0]}>
+          <cylinderGeometry args={[0.085, 0.145, 0.25, 4]} />
+          <meshLambertMaterial color={bottomColor} />
         </mesh>
-      </group>
+      ) : null}
+      {!isDress && bottomStyle === "mini-skirt" ? (
+        <mesh position={[0, 0.215, 0]} rotation={[0, Math.PI / 4, 0]}>
+          <cylinderGeometry args={[0.09, 0.13, 0.09, 4]} />
+          <meshLambertMaterial color={bottomColor} />
+        </mesh>
+      ) : null}
 
       <mesh position={[0, 0.3, 0]}>
         <boxGeometry args={[0.2, 0.22, 0.1]} />
         <meshLambertMaterial color={topColor} />
       </mesh>
-      {profile.clothing.topStyle === "hoodie" ? (
+      {isLongDress ? (
+        <mesh position={[0, 0.16, 0]} rotation={[0, Math.PI / 4, 0]}>
+          <cylinderGeometry args={[0.095, 0.15, 0.28, 4]} />
+          <meshLambertMaterial color={topColor} />
+        </mesh>
+      ) : null}
+      {isShortDress ? (
+        <mesh position={[0, 0.205, 0]} rotation={[0, Math.PI / 4, 0]}>
+          <cylinderGeometry args={[0.095, 0.14, 0.14, 4]} />
+          <meshLambertMaterial color={topColor} />
+        </mesh>
+      ) : null}
+      {topStyle === "hoodie" ? (
         <>
           <mesh position={[0, 0.37, -0.045]}>
             <boxGeometry args={[0.18, 0.1, 0.03]} />
@@ -121,7 +146,7 @@ const PreviewFigure = ({
           </mesh>
         </>
       ) : null}
-      {profile.clothing.topStyle === "jacket" ? (
+      {topStyle === "jacket" ? (
         <>
           <mesh position={[0, 0.3, 0.056]}>
             <boxGeometry args={[0.202, 0.23, 0.012]} />
@@ -133,13 +158,41 @@ const PreviewFigure = ({
           </mesh>
         </>
       ) : null}
+      {topStyle === "sweater" ? (
+        <>
+          <mesh position={[0, 0.395, 0.056]}>
+            <boxGeometry args={[0.095, 0.025, 0.012]} />
+            <meshLambertMaterial color="#e5e7eb" />
+          </mesh>
+          <mesh position={[0, 0.205, 0.056]}>
+            <boxGeometry args={[0.19, 0.025, 0.012]} />
+            <meshLambertMaterial color="#e5e7eb" />
+          </mesh>
+        </>
+      ) : null}
+      {topStyle === "shirt" ? (
+        <>
+          <mesh position={[0, 0.3, 0.057]}>
+            <boxGeometry args={[0.018, 0.2, 0.012]} />
+            <meshLambertMaterial color="#cbd5e1" />
+          </mesh>
+          <mesh position={[-0.035, 0.39, 0.058]} rotation={[0, 0, -0.4]}>
+            <boxGeometry args={[0.075, 0.025, 0.012]} />
+            <meshLambertMaterial color="#f8fafc" />
+          </mesh>
+          <mesh position={[0.035, 0.39, 0.058]} rotation={[0, 0, 0.4]}>
+            <boxGeometry args={[0.075, 0.025, 0.012]} />
+            <meshLambertMaterial color="#f8fafc" />
+          </mesh>
+        </>
+      ) : null}
 
       <group position={[-0.13, 0.3, 0]}>
         <mesh position={[0, -0.08, 0]}>
           <boxGeometry args={[0.06, 0.16, 0.06]} />
           <meshLambertMaterial color={sleeveColor} />
         </mesh>
-        {profile.clothing.topStyle === "hoodie" ? (
+        {topStyle === "hoodie" || topStyle === "sweater" ? (
           <mesh position={[0, -0.145, 0]}>
             <boxGeometry args={[0.064, 0.03, 0.064]} />
             <meshLambertMaterial color={cuffColor} />
@@ -155,7 +208,7 @@ const PreviewFigure = ({
           <boxGeometry args={[0.06, 0.16, 0.06]} />
           <meshLambertMaterial color={sleeveColor} />
         </mesh>
-        {profile.clothing.topStyle === "hoodie" ? (
+        {topStyle === "hoodie" || topStyle === "sweater" ? (
           <mesh position={[0, -0.145, 0]}>
             <boxGeometry args={[0.064, 0.03, 0.064]} />
             <meshLambertMaterial color={cuffColor} />
@@ -224,6 +277,94 @@ const PreviewFigure = ({
             <sphereGeometry args={[0.045, 16, 16]} />
             <meshLambertMaterial color={hairColor} />
           </mesh>
+        </>
+      ) : null}
+      {profile.hair.style === "long" ? (
+        <>
+          <mesh position={[0, 0.58, -0.025]}>
+            <boxGeometry args={[0.18, 0.05, 0.16]} />
+            <meshLambertMaterial color={hairColor} />
+          </mesh>
+          <mesh position={[0, 0.46, -0.075]}>
+            <boxGeometry args={[0.17, 0.25, 0.045]} />
+            <meshLambertMaterial color={hairColor} />
+          </mesh>
+          {[-0.09, 0.09].map((x) => (
+            <mesh key={x} position={[x, 0.47, 0.005]}>
+              <boxGeometry args={[0.035, 0.22, 0.07]} />
+              <meshLambertMaterial color={hairColor} />
+            </mesh>
+          ))}
+        </>
+      ) : null}
+      {profile.hair.style === "bob" ? (
+        <>
+          <mesh position={[0, 0.58, 0]}>
+            <boxGeometry args={[0.18, 0.05, 0.15]} />
+            <meshLambertMaterial color={hairColor} />
+          </mesh>
+          {[-0.095, 0.095].map((x) => (
+            <mesh key={x} position={[x, 0.515, 0]}>
+              <boxGeometry args={[0.035, 0.13, 0.15]} />
+              <meshLambertMaterial color={hairColor} />
+            </mesh>
+          ))}
+        </>
+      ) : null}
+      {profile.hair.style === "twin-tails" ? (
+        <>
+          <mesh position={[0, 0.58, 0]}>
+            <boxGeometry args={[0.18, 0.05, 0.15]} />
+            <meshLambertMaterial color={hairColor} />
+          </mesh>
+          {[-0.125, 0.125].map((x) => (
+            <group key={x} position={[x, 0.51, -0.01]}>
+              <mesh position={[0, 0.06, 0]}>
+                <sphereGeometry args={[0.04, 12, 12]} />
+                <meshLambertMaterial color={hairColor} />
+              </mesh>
+              <mesh position={[0, -0.045, 0]}>
+                <boxGeometry args={[0.055, 0.18, 0.06]} />
+                <meshLambertMaterial color={hairColor} />
+              </mesh>
+            </group>
+          ))}
+        </>
+      ) : null}
+      {profile.hair.style === "ponytail" ? (
+        <>
+          <mesh position={[0, 0.58, 0]}>
+            <boxGeometry args={[0.18, 0.05, 0.15]} />
+            <meshLambertMaterial color={hairColor} />
+          </mesh>
+          <mesh position={[0, 0.565, -0.105]}>
+            <sphereGeometry args={[0.045, 12, 12]} />
+            <meshLambertMaterial color={hairColor} />
+          </mesh>
+          <mesh position={[0, 0.46, -0.12]} rotation={[0.15, 0, 0]}>
+            <boxGeometry args={[0.06, 0.2, 0.06]} />
+            <meshLambertMaterial color={hairColor} />
+          </mesh>
+        </>
+      ) : null}
+      {profile.hair.style === "long-wave" ? (
+        <>
+          <mesh position={[0, 0.58, -0.02]}>
+            <boxGeometry args={[0.18, 0.05, 0.16]} />
+            <meshLambertMaterial color={hairColor} />
+          </mesh>
+          {[-0.095, 0.095].flatMap((x) =>
+            [0.52, 0.44, 0.36].map((y, index) => (
+              <mesh
+                key={`${x}-${y}`}
+                position={[x + (index % 2 === 0 ? -0.008 : 0.008) * Math.sign(x), y, -0.015]}
+                rotation={[0, 0, (index % 2 === 0 ? 0.12 : -0.12) * Math.sign(x)]}
+              >
+                <boxGeometry args={[0.045, 0.1, 0.07]} />
+                <meshLambertMaterial color={hairColor} />
+              </mesh>
+            )),
+          )}
         </>
       ) : null}
 

--- a/src/features/retro-office/objects/agents.tsx
+++ b/src/features/retro-office/objects/agents.tsx
@@ -616,6 +616,9 @@ export const AgentModel = memo(function AgentModel({
   const showHeadset = resolvedAppearance.accessories.headset;
   const showBackpack = resolvedAppearance.accessories.backpack;
   const accessoryColor = topColor;
+  const isLongDress = topStyle === "long-dress";
+  const isShortDress = topStyle === "short-dress";
+  const isDress = isLongDress || isShortDress;
   const sleeveColor = topStyle === "jacket" ? "#dbe4ff" : topColor;
   const cuffColor = topStyle === "hoodie" ? "#d1d5db" : sleeveColor;
   // Jacket accent brightened ~10% so it doesn't turn muddy under ACES tone mapping.
@@ -747,7 +750,12 @@ export const AgentModel = memo(function AgentModel({
         <meshBasicMaterial color="#000" transparent opacity={0.2} />
       </mesh>
       <group ref={rightLegRef} position={[-0.045, 0.1, 0]}>
-        {bottomStyle === "shorts" ? (
+        {isDress || bottomStyle === "long-skirt" || bottomStyle === "mini-skirt" ? (
+          <mesh castShadow>
+            <boxGeometry args={[0.05, 0.14, 0.05]} />
+            <meshStandardMaterial color={skin} roughness={0.55} />
+          </mesh>
+        ) : bottomStyle === "shorts" ? (
           <>
             <mesh position={[0, 0.03, 0]} castShadow>
               <boxGeometry args={[0.07, 0.08, 0.08]} />
@@ -755,6 +763,17 @@ export const AgentModel = memo(function AgentModel({
             </mesh>
             <mesh position={[0, -0.045, 0]} castShadow>
               <boxGeometry args={[0.05, 0.06, 0.05]} />
+              <meshStandardMaterial color={skin} roughness={0.55} />
+            </mesh>
+          </>
+        ) : bottomStyle === "hot-pants" ? (
+          <>
+            <mesh position={[0, 0.052, 0]} castShadow>
+              <boxGeometry args={[0.07, 0.04, 0.08]} />
+              <meshStandardMaterial color={trouserColor} roughness={0.75} />
+            </mesh>
+            <mesh position={[0, -0.025, 0]} castShadow>
+              <boxGeometry args={[0.05, 0.1, 0.05]} />
               <meshStandardMaterial color={skin} roughness={0.55} />
             </mesh>
           </>
@@ -778,7 +797,12 @@ export const AgentModel = memo(function AgentModel({
         </mesh>
       </group>
       <group ref={leftLegRef} position={[0.045, 0.1, 0]}>
-        {bottomStyle === "shorts" ? (
+        {isDress || bottomStyle === "long-skirt" || bottomStyle === "mini-skirt" ? (
+          <mesh castShadow>
+            <boxGeometry args={[0.05, 0.14, 0.05]} />
+            <meshStandardMaterial color={skin} roughness={0.55} />
+          </mesh>
+        ) : bottomStyle === "shorts" ? (
           <>
             <mesh position={[0, 0.03, 0]} castShadow>
               <boxGeometry args={[0.07, 0.08, 0.08]} />
@@ -786,6 +810,17 @@ export const AgentModel = memo(function AgentModel({
             </mesh>
             <mesh position={[0, -0.045, 0]} castShadow>
               <boxGeometry args={[0.05, 0.06, 0.05]} />
+              <meshStandardMaterial color={skin} roughness={0.55} />
+            </mesh>
+          </>
+        ) : bottomStyle === "hot-pants" ? (
+          <>
+            <mesh position={[0, 0.052, 0]} castShadow>
+              <boxGeometry args={[0.07, 0.04, 0.08]} />
+              <meshStandardMaterial color={trouserColor} roughness={0.75} />
+            </mesh>
+            <mesh position={[0, -0.025, 0]} castShadow>
+              <boxGeometry args={[0.05, 0.1, 0.05]} />
               <meshStandardMaterial color={skin} roughness={0.55} />
             </mesh>
           </>
@@ -808,6 +843,18 @@ export const AgentModel = memo(function AgentModel({
           <meshStandardMaterial color={shoeColor} roughness={0.75} />
         </mesh>
       </group>
+      {!isDress && bottomStyle === "long-skirt" ? (
+        <mesh position={[0, 0.13, 0]} rotation={[0, Math.PI / 4, 0]} castShadow>
+          <cylinderGeometry args={[0.08, 0.135, 0.24, 4]} />
+          <meshStandardMaterial color={trouserColor} roughness={0.72} />
+        </mesh>
+      ) : null}
+      {!isDress && bottomStyle === "mini-skirt" ? (
+        <mesh position={[0, 0.205, 0]} rotation={[0, Math.PI / 4, 0]} castShadow>
+          <cylinderGeometry args={[0.085, 0.12, 0.085, 4]} />
+          <meshStandardMaterial color={trouserColor} roughness={0.72} />
+        </mesh>
+      ) : null}
       {showBackpack ? (
         <group position={[0, 0.28, -0.08]}>
           <mesh castShadow>
@@ -828,6 +875,18 @@ export const AgentModel = memo(function AgentModel({
         <boxGeometry args={[0.18, 0.2, 0.1]} />
         <meshStandardMaterial ref={bodyMatRef} color={topColor} roughness={0.75} />
       </mesh>
+      {isLongDress ? (
+        <mesh position={[0, 0.15, 0]} rotation={[0, Math.PI / 4, 0]} castShadow>
+          <cylinderGeometry args={[0.09, 0.14, 0.27, 4]} />
+          <meshStandardMaterial color={topColor} roughness={0.7} />
+        </mesh>
+      ) : null}
+      {isShortDress ? (
+        <mesh position={[0, 0.195, 0]} rotation={[0, Math.PI / 4, 0]} castShadow>
+          <cylinderGeometry args={[0.09, 0.13, 0.135, 4]} />
+          <meshStandardMaterial color={topColor} roughness={0.7} />
+        </mesh>
+      ) : null}
       {topStyle === "hoodie" ? (
         <>
           <mesh position={[0, 0.35, -0.045]} castShadow>
@@ -852,12 +911,40 @@ export const AgentModel = memo(function AgentModel({
           </mesh>
         </>
       ) : null}
+      {topStyle === "sweater" ? (
+        <>
+          <mesh position={[0, 0.37, 0.056]}>
+            <boxGeometry args={[0.09, 0.024, 0.012]} />
+            <meshStandardMaterial color="#e5e7eb" roughness={0.78} />
+          </mesh>
+          <mesh position={[0, 0.195, 0.056]}>
+            <boxGeometry args={[0.175, 0.024, 0.012]} />
+            <meshStandardMaterial color="#e5e7eb" roughness={0.78} />
+          </mesh>
+        </>
+      ) : null}
+      {topStyle === "shirt" ? (
+        <>
+          <mesh position={[0, 0.28, 0.057]}>
+            <boxGeometry args={[0.016, 0.19, 0.012]} />
+            <meshStandardMaterial color="#cbd5e1" roughness={0.7} />
+          </mesh>
+          <mesh position={[-0.032, 0.365, 0.058]} rotation={[0, 0, -0.4]}>
+            <boxGeometry args={[0.07, 0.024, 0.012]} />
+            <meshStandardMaterial color="#f8fafc" roughness={0.7} />
+          </mesh>
+          <mesh position={[0.032, 0.365, 0.058]} rotation={[0, 0, 0.4]}>
+            <boxGeometry args={[0.07, 0.024, 0.012]} />
+            <meshStandardMaterial color="#f8fafc" roughness={0.7} />
+          </mesh>
+        </>
+      ) : null}
       <group ref={rightArmRef} position={[-0.12, 0.28, 0]}>
         <mesh position={[0, -0.08, 0]} castShadow>
           <boxGeometry args={[0.06, 0.16, 0.06]} />
           <meshStandardMaterial color={sleeveColor} roughness={0.75} />
         </mesh>
-        {topStyle === "hoodie" ? (
+        {topStyle === "hoodie" || topStyle === "sweater" ? (
           <mesh position={[0, -0.145, 0]}>
             <boxGeometry args={[0.064, 0.03, 0.064]} />
             <meshStandardMaterial color={cuffColor} roughness={0.75} />
@@ -960,7 +1047,7 @@ export const AgentModel = memo(function AgentModel({
           <boxGeometry args={[0.06, 0.16, 0.06]} />
           <meshStandardMaterial color={sleeveColor} roughness={0.75} />
         </mesh>
-        {topStyle === "hoodie" ? (
+        {topStyle === "hoodie" || topStyle === "sweater" ? (
           <mesh position={[0, -0.145, 0]}>
             <boxGeometry args={[0.064, 0.03, 0.064]} />
             <meshStandardMaterial color={cuffColor} roughness={0.75} />
@@ -1032,6 +1119,95 @@ export const AgentModel = memo(function AgentModel({
             <sphereGeometry args={[0.042, 14, 14]} />
             <meshStandardMaterial color={hairColor} roughness={0.35} metalness={0.05} />
           </mesh>
+        </>
+      ) : null}
+      {hairStyle === "long" ? (
+        <>
+          <mesh position={[0, 0.55, -0.02]} castShadow>
+            <boxGeometry args={[0.17, 0.05, 0.15]} />
+            <meshStandardMaterial color={hairColor} roughness={0.35} metalness={0.05} />
+          </mesh>
+          <mesh position={[0, 0.44, -0.07]} castShadow>
+            <boxGeometry args={[0.16, 0.23, 0.04]} />
+            <meshStandardMaterial color={hairColor} roughness={0.35} metalness={0.05} />
+          </mesh>
+          {[-0.085, 0.085].map((x) => (
+            <mesh key={x} position={[x, 0.45, 0.005]} castShadow>
+              <boxGeometry args={[0.032, 0.2, 0.065]} />
+              <meshStandardMaterial color={hairColor} roughness={0.35} metalness={0.05} />
+            </mesh>
+          ))}
+        </>
+      ) : null}
+      {hairStyle === "bob" ? (
+        <>
+          <mesh position={[0, 0.55, 0]} castShadow>
+            <boxGeometry args={[0.17, 0.05, 0.15]} />
+            <meshStandardMaterial color={hairColor} roughness={0.35} metalness={0.05} />
+          </mesh>
+          {[-0.09, 0.09].map((x) => (
+            <mesh key={x} position={[x, 0.49, 0]} castShadow>
+              <boxGeometry args={[0.032, 0.12, 0.14]} />
+              <meshStandardMaterial color={hairColor} roughness={0.35} metalness={0.05} />
+            </mesh>
+          ))}
+        </>
+      ) : null}
+      {hairStyle === "twin-tails" ? (
+        <>
+          <mesh position={[0, 0.55, 0]} castShadow>
+            <boxGeometry args={[0.17, 0.05, 0.15]} />
+            <meshStandardMaterial color={hairColor} roughness={0.35} metalness={0.05} />
+          </mesh>
+          {[-0.115, 0.115].map((x) => (
+            <group key={x} position={[x, 0.485, -0.01]}>
+              <mesh position={[0, 0.055, 0]} castShadow>
+                <sphereGeometry args={[0.038, 12, 12]} />
+                <meshStandardMaterial color={hairColor} roughness={0.35} metalness={0.05} />
+              </mesh>
+              <mesh position={[0, -0.04, 0]} castShadow>
+                <boxGeometry args={[0.05, 0.17, 0.055]} />
+                <meshStandardMaterial color={hairColor} roughness={0.35} metalness={0.05} />
+              </mesh>
+            </group>
+          ))}
+        </>
+      ) : null}
+      {hairStyle === "ponytail" ? (
+        <>
+          <mesh position={[0, 0.55, 0]} castShadow>
+            <boxGeometry args={[0.17, 0.05, 0.15]} />
+            <meshStandardMaterial color={hairColor} roughness={0.35} metalness={0.05} />
+          </mesh>
+          <mesh position={[0, 0.535, -0.1]} castShadow>
+            <sphereGeometry args={[0.042, 12, 12]} />
+            <meshStandardMaterial color={hairColor} roughness={0.35} metalness={0.05} />
+          </mesh>
+          <mesh position={[0, 0.44, -0.115]} rotation={[0.15, 0, 0]} castShadow>
+            <boxGeometry args={[0.055, 0.19, 0.055]} />
+            <meshStandardMaterial color={hairColor} roughness={0.35} metalness={0.05} />
+          </mesh>
+        </>
+      ) : null}
+      {hairStyle === "long-wave" ? (
+        <>
+          <mesh position={[0, 0.55, -0.02]} castShadow>
+            <boxGeometry args={[0.17, 0.05, 0.15]} />
+            <meshStandardMaterial color={hairColor} roughness={0.35} metalness={0.05} />
+          </mesh>
+          {[-0.09, 0.09].flatMap((x) =>
+            [0.49, 0.42, 0.35].map((y, index) => (
+              <mesh
+                key={`${x}-${y}`}
+                position={[x + (index % 2 === 0 ? -0.007 : 0.007) * Math.sign(x), y, -0.015]}
+                rotation={[0, 0, (index % 2 === 0 ? 0.12 : -0.12) * Math.sign(x)]}
+                castShadow
+              >
+                <boxGeometry args={[0.04, 0.09, 0.065]} />
+                <meshStandardMaterial color={hairColor} roughness={0.35} metalness={0.05} />
+              </mesh>
+            )),
+          )}
         </>
       ) : null}
       {hatStyle === "cap" ? (

--- a/src/lib/avatars/profile.ts
+++ b/src/lib/avatars/profile.ts
@@ -1,6 +1,28 @@
-export type AgentAvatarHairStyle = "short" | "parted" | "spiky" | "bun";
-export type AgentAvatarTopStyle = "tee" | "hoodie" | "jacket";
-export type AgentAvatarBottomStyle = "pants" | "shorts" | "cuffed";
+export type AgentAvatarHairStyle =
+  | "short"
+  | "parted"
+  | "spiky"
+  | "bun"
+  | "long"
+  | "bob"
+  | "twin-tails"
+  | "ponytail"
+  | "long-wave";
+export type AgentAvatarTopStyle =
+  | "tee"
+  | "hoodie"
+  | "jacket"
+  | "sweater"
+  | "shirt"
+  | "long-dress"
+  | "short-dress";
+export type AgentAvatarBottomStyle =
+  | "pants"
+  | "shorts"
+  | "cuffed"
+  | "long-skirt"
+  | "mini-skirt"
+  | "hot-pants";
 export type AgentAvatarHatStyle = "none" | "cap" | "beanie";
 
 export type AgentAvatarProfile = {
@@ -53,6 +75,11 @@ export const AGENT_AVATAR_HAIR_STYLE_OPTIONS: EnumOption<AgentAvatarHairStyle>[]
   { id: "parted", label: "Parted" },
   { id: "spiky", label: "Spiky" },
   { id: "bun", label: "Bun" },
+  { id: "long", label: "Long" },
+  { id: "bob", label: "Bob" },
+  { id: "twin-tails", label: "Twin tails" },
+  { id: "ponytail", label: "Ponytail" },
+  { id: "long-wave", label: "Long wave" },
 ];
 
 export const AGENT_AVATAR_HAIR_COLOR_OPTIONS: ColorOption[] = [
@@ -67,15 +94,22 @@ export const AGENT_AVATAR_HAIR_COLOR_OPTIONS: ColorOption[] = [
 ];
 
 export const AGENT_AVATAR_TOP_STYLE_OPTIONS: EnumOption<AgentAvatarTopStyle>[] = [
-  { id: "tee", label: "Tee" },
+  { id: "tee", label: "T-shirt" },
   { id: "hoodie", label: "Hoodie" },
   { id: "jacket", label: "Jacket" },
+  { id: "sweater", label: "Sweater" },
+  { id: "shirt", label: "Y-shirt" },
+  { id: "long-dress", label: "Long dress" },
+  { id: "short-dress", label: "Short dress" },
 ];
 
 export const AGENT_AVATAR_BOTTOM_STYLE_OPTIONS: EnumOption<AgentAvatarBottomStyle>[] = [
-  { id: "pants", label: "Pants" },
+  { id: "pants", label: "Long pants" },
   { id: "shorts", label: "Shorts" },
   { id: "cuffed", label: "Cuffed" },
+  { id: "long-skirt", label: "Long skirt" },
+  { id: "mini-skirt", label: "Mini skirt" },
+  { id: "hot-pants", label: "Hot" },
 ];
 
 export const AGENT_AVATAR_HAT_STYLE_OPTIONS: EnumOption<AgentAvatarHatStyle>[] = [
@@ -103,6 +137,121 @@ export const AGENT_AVATAR_SHOE_COLOR_OPTIONS: ColorOption[] = [
 ];
 
 const AGENT_AVATAR_VERSION = 1 as const;
+
+const LEGACY_AGENT_AVATAR_HAIR_STYLES = ["short", "parted", "spiky", "bun"] as const;
+const LEGACY_AGENT_AVATAR_TOP_STYLES = ["tee", "hoodie", "jacket"] as const;
+const LEGACY_AGENT_AVATAR_BOTTOM_STYLES = ["pants", "shorts", "cuffed"] as const;
+
+export type AgentAvatarFemalePreset = Readonly<{
+  id: string;
+  label: string;
+  hairLabel: string;
+  hairStyle: AgentAvatarHairStyle;
+  hairColor: string;
+  topStyle: AgentAvatarTopStyle;
+  topColor: string;
+  bottomStyle: AgentAvatarBottomStyle;
+  bottomColor: string;
+  shoesColor: string;
+}>;
+
+export const AGENT_AVATAR_FEMALE_PRESETS: readonly AgentAvatarFemalePreset[] = [
+  {
+    id: "long-dress",
+    label: "Long dress",
+    hairLabel: "Long wave",
+    hairStyle: "long-wave",
+    hairColor: "#3e2723",
+    topStyle: "long-dress",
+    topColor: "#8b5cf6",
+    bottomStyle: "pants",
+    bottomColor: "#8b5cf6",
+    shoesColor: "#1a1a1a",
+  },
+  {
+    id: "short-dress",
+    label: "Short dress",
+    hairLabel: "Bob",
+    hairStyle: "bob",
+    hairColor: "#7b341e",
+    topStyle: "short-dress",
+    topColor: "#f43f5e",
+    bottomStyle: "mini-skirt",
+    bottomColor: "#f43f5e",
+    shoesColor: "#e5e7eb",
+  },
+  {
+    id: "long-skirt",
+    label: "Long skirt",
+    hairLabel: "Long",
+    hairStyle: "long",
+    hairColor: "#151515",
+    topStyle: "sweater",
+    topColor: "#f5f5f4",
+    bottomStyle: "long-skirt",
+    bottomColor: "#2d3748",
+    shoesColor: "#7c4a2d",
+  },
+  {
+    id: "mini-skirt",
+    label: "Mini skirt",
+    hairLabel: "Twin tails",
+    hairStyle: "twin-tails",
+    hairColor: "#db2777",
+    topStyle: "shirt",
+    topColor: "#f5f5f4",
+    bottomStyle: "mini-skirt",
+    bottomColor: "#7090ff",
+    shoesColor: "#1e3a8a",
+  },
+  {
+    id: "hot",
+    label: "Hot",
+    hairLabel: "Ponytail",
+    hairStyle: "ponytail",
+    hairColor: "#6b4f3a",
+    topStyle: "tee",
+    topColor: "#34d399",
+    bottomStyle: "hot-pants",
+    bottomColor: "#2d3748",
+    shoesColor: "#e5e7eb",
+  },
+  {
+    id: "long-pants",
+    label: "Long pants",
+    hairLabel: "Bob",
+    hairStyle: "bob",
+    hairColor: "#d6b56c",
+    topStyle: "sweater",
+    topColor: "#7090ff",
+    bottomStyle: "pants",
+    bottomColor: "#64748b",
+    shoesColor: "#1a1a1a",
+  },
+] as const;
+
+export const applyAgentAvatarFemalePreset = (
+  profile: AgentAvatarProfile,
+  presetId: string,
+): AgentAvatarProfile => {
+  const preset = AGENT_AVATAR_FEMALE_PRESETS.find((entry) => entry.id === presetId);
+  if (!preset) return profile;
+
+  return {
+    ...profile,
+    hair: {
+      style: preset.hairStyle,
+      color: preset.hairColor,
+    },
+    clothing: {
+      topStyle: preset.topStyle,
+      topColor: preset.topColor,
+      bottomStyle: preset.bottomStyle,
+      bottomColor: preset.bottomColor,
+      shoesColor: preset.shoesColor,
+    },
+  };
+};
 
 const isRecord = (value: unknown): value is Record<string, unknown> =>
   Boolean(value && typeof value === "object" && !Array.isArray(value));
@@ -143,11 +292,11 @@ export const createAgentAvatarProfileFromSeed = (seed: string): AgentAvatarProfi
   const normalizedSeed = seed.trim() || "agent";
   const hash = hashSeed(normalizedSeed);
   const skinTone = pick(AGENT_AVATAR_SKIN_TONE_OPTIONS, hash).color;
-  const hairStyle = pick(AGENT_AVATAR_HAIR_STYLE_OPTIONS, hash >>> 3).id;
+  const hairStyle = pick(LEGACY_AGENT_AVATAR_HAIR_STYLES, hash >>> 3);
   const hairColor = pick(AGENT_AVATAR_HAIR_COLOR_OPTIONS, hash >>> 5).color;
-  const topStyle = pick(AGENT_AVATAR_TOP_STYLE_OPTIONS, hash >>> 7).id;
+  const topStyle = pick(LEGACY_AGENT_AVATAR_TOP_STYLES, hash >>> 7);
   const topColor = pick(AGENT_AVATAR_CLOTHING_COLOR_OPTIONS, hash >>> 9).color;
-  const bottomStyle = pick(AGENT_AVATAR_BOTTOM_STYLE_OPTIONS, hash >>> 11).id;
+  const bottomStyle = pick(LEGACY_AGENT_AVATAR_BOTTOM_STYLES, hash >>> 11);
   const bottomColor = pick(AGENT_AVATAR_CLOTHING_COLOR_OPTIONS, hash >>> 13).color;
   const shoesColor = pick(AGENT_AVATAR_SHOE_COLOR_OPTIONS, hash >>> 15).color;
   const hatStyle = pick(AGENT_AVATAR_HAT_STYLE_OPTIONS, hash >>> 17).id;

--- a/src/lib/avatars/profilePortrait.ts
+++ b/src/lib/avatars/profilePortrait.ts
@@ -67,6 +67,39 @@ const buildHairSvg = (profile: AgentAvatarProfile, hairColor: string) => {
         `<rect x="22" y="20" width="36" height="10" rx="4" fill="${hairColor}"/>`,
         `<circle cx="40" cy="15" r="6" fill="${hairColor}"/>`,
       ].join("");
+    case "long":
+      return [
+        `<rect x="21" y="19" width="38" height="12" rx="5" fill="${hairColor}"/>`,
+        `<rect x="20" y="25" width="8" height="30" rx="4" fill="${hairColor}"/>`,
+        `<rect x="52" y="25" width="8" height="30" rx="4" fill="${hairColor}"/>`,
+        `<rect x="24" y="24" width="32" height="8" rx="4" fill="${blendHex(hairColor, "#ffffff", 0.06)}"/>`,
+      ].join("");
+    case "bob":
+      return [
+        `<path d="M21 30 C21 16, 59 16, 59 30 L57 43 L51 43 L50 28 L30 28 L29 43 L23 43 Z" fill="${hairColor}"/>`,
+        `<path d="M25 26 C31 18, 47 17, 55 25 L48 29 L31 29 Z" fill="${blendHex(hairColor, "#ffffff", 0.07)}"/>`,
+      ].join("");
+    case "twin-tails":
+      return [
+        `<rect x="22" y="19" width="36" height="11" rx="4" fill="${hairColor}"/>`,
+        `<circle cx="18" cy="32" r="7" fill="${hairColor}"/>`,
+        `<rect x="14" y="34" width="8" height="18" rx="4" fill="${hairColor}"/>`,
+        `<circle cx="62" cy="32" r="7" fill="${hairColor}"/>`,
+        `<rect x="58" y="34" width="8" height="18" rx="4" fill="${hairColor}"/>`,
+      ].join("");
+    case "ponytail":
+      return [
+        `<rect x="22" y="19" width="36" height="11" rx="4" fill="${hairColor}"/>`,
+        `<circle cx="59" cy="27" r="6" fill="${hairColor}"/>`,
+        `<path d="M59 29 C70 31, 68 46, 61 52 C64 43, 57 39, 59 29 Z" fill="${hairColor}"/>`,
+      ].join("");
+    case "long-wave":
+      return [
+        `<rect x="21" y="19" width="38" height="12" rx="5" fill="${hairColor}"/>`,
+        `<path d="M22 25 C16 31, 26 35, 20 41 C15 46, 25 50, 20 56 L29 56 L30 27 Z" fill="${hairColor}"/>`,
+        `<path d="M58 25 C64 31, 54 35, 60 41 C65 46, 55 50, 60 56 L51 56 L50 27 Z" fill="${hairColor}"/>`,
+        `<path d="M25 25 C34 18, 48 18, 55 25 L49 29 L31 29 Z" fill="${blendHex(hairColor, "#ffffff", 0.08)}"/>`,
+      ].join("");
     default:
       return "";
   }

--- a/tests/unit/agentAvatarCreatorModal.test.tsx
+++ b/tests/unit/agentAvatarCreatorModal.test.tsx
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from "vitest";
-import { fireEvent, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { AgentAvatarCreatorModal } from "@/features/agents/components/AgentAvatarCreatorModal";
 import { createDefaultAgentAvatarProfile } from "@/lib/avatars/profile";
 
@@ -9,6 +9,7 @@ vi.mock("@/features/agents/components/AgentAvatarPreview3D", () => ({
 
 describe("AgentAvatarCreatorModal", () => {
   beforeEach(() => {
+    cleanup();
     vi.restoreAllMocks();
   });
 
@@ -37,6 +38,40 @@ describe("AgentAvatarCreatorModal", () => {
         accessories: expect.objectContaining({
           backpack: !initialProfile.accessories.backpack,
         }),
+      })
+    );
+  });
+
+  it("applies one of six female presets and keeps it editable", async () => {
+    const initialProfile = createDefaultAgentAvatarProfile("seed-a");
+    const onSave = vi.fn(async () => {});
+
+    render(
+      <AgentAvatarCreatorModal
+        open
+        agentId="agent-1"
+        agentName="Agent One"
+        initialProfile={initialProfile}
+        onClose={() => {}}
+        onSave={onSave}
+      />
+    );
+
+    expect(screen.getAllByRole("button", { name: /^Apply .+ preset$/ })).toHaveLength(6);
+    fireEvent.click(screen.getByRole("button", { name: "Apply Hot preset" }));
+    fireEvent.click(screen.getByRole("button", { name: "Long wave" }));
+    fireEvent.click(screen.getByRole("button", { name: "Save avatar" }));
+
+    expect(onSave).toHaveBeenCalledWith(
+      expect.objectContaining({
+        seed: initialProfile.seed,
+        body: initialProfile.body,
+        hair: expect.objectContaining({ style: "long-wave" }),
+        clothing: expect.objectContaining({
+          topStyle: "tee",
+          bottomStyle: "hot-pants",
+        }),
+        accessories: initialProfile.accessories,
       })
     );
   });

--- a/tests/unit/avatarProfile.test.ts
+++ b/tests/unit/avatarProfile.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  AGENT_AVATAR_FEMALE_PRESETS,
+  applyAgentAvatarFemalePreset,
+  createDefaultAgentAvatarProfile,
+  normalizeAgentAvatarProfile,
+} from "@/lib/avatars/profile";
+
+describe("female avatar presets", () => {
+  it("defines the six requested outfits and five requested hairstyles", () => {
+    expect(AGENT_AVATAR_FEMALE_PRESETS).toHaveLength(6);
+
+    const outfits = AGENT_AVATAR_FEMALE_PRESETS.map((preset) =>
+      preset.topStyle === "long-dress" || preset.topStyle === "short-dress"
+        ? preset.topStyle
+        : preset.bottomStyle,
+    );
+    expect(new Set(outfits)).toEqual(
+      new Set([
+        "long-dress",
+        "short-dress",
+        "long-skirt",
+        "mini-skirt",
+        "hot-pants",
+        "pants",
+      ]),
+    );
+    expect(new Set(AGENT_AVATAR_FEMALE_PRESETS.map((preset) => preset.hairStyle))).toEqual(
+      new Set(["long", "bob", "twin-tails", "ponytail", "long-wave"]),
+    );
+  });
+
+  it("applies hair and clothing without replacing identity or accessories", () => {
+    const current = createDefaultAgentAvatarProfile("agent-1");
+    const applied = applyAgentAvatarFemalePreset(current, "hot");
+
+    expect(applied).not.toBe(current);
+    expect(applied.seed).toBe(current.seed);
+    expect(applied.body).toEqual(current.body);
+    expect(applied.accessories).toEqual(current.accessories);
+    expect(applied.hair.style).toBe("ponytail");
+    expect(applied.clothing.topStyle).toBe("tee");
+    expect(applied.clothing.bottomStyle).toBe("hot-pants");
+    expect(normalizeAgentAvatarProfile(applied, "fallback")).toEqual(applied);
+  });
+
+  it("keeps legacy seed-generated appearances stable", () => {
+    expect(createDefaultAgentAvatarProfile("seed-a")).toEqual({
+      version: 1,
+      seed: "seed-a",
+      body: { skinTone: "#f7d7c2" },
+      hair: { style: "spiky", color: "#7b341e" },
+      clothing: {
+        topStyle: "hoodie",
+        topColor: "#2d3748",
+        bottomStyle: "shorts",
+        bottomColor: "#f59e0b",
+        shoesColor: "#1a1a1a",
+      },
+      accessories: {
+        glasses: false,
+        headset: true,
+        hatStyle: "cap",
+        backpack: true,
+      },
+    });
+  });
+});

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -10,7 +10,7 @@ export default defineConfig({
   test: {
     environment: "jsdom",
     setupFiles: "./tests/setup.ts",
-    include: ["tests/unit/**/*.test.ts"],
+    include: ["tests/unit/**/*.test.{ts,tsx}"],
     exclude: ["tests/e2e/**"],
   },
 });


### PR DESCRIPTION
## Summary
- add six female avatar presets
- add long, bob, twin-tail, ponytail, and long-wave hairstyles
- add long/short dresses, long/mini skirts, hot pants, sweater, and shirt options across previews and office rendering
- preserve identity and accessories when applying presets

## Validation
- targeted avatar tests: 5 passed
- typecheck: passed
- targeted ESLint: passed
- production build: passed
- gitleaks: no leaks

## Existing upstream test issue
- the full unit suite reaches 1,228 passing tests; only `colorSemanticsGuard.test.ts` fails on four pre-existing amber utility classes in unchanged `GatewayConnectScreen.tsx` on current `main`.