### PR TITLE
fix(ui): use semantic colors in gateway mode selector

### DIFF
--- a/src/features/agents/components/GatewayConnectScreen.tsx
+++ b/src/features/agents/components/GatewayConnectScreen.tsx
@@ -291,14 +291,14 @@ export const GatewayConnectScreen = ({
                   data-testid={`connect-render-mode-${option.id}`}
                   className={`rounded-md border px-3 py-2.5 text-left transition-colors ${
                     selected
-                      ? "border-amber-500/70 bg-amber-500/10"
-                      : "border-border bg-muted/30 hover:border-amber-500/35"
+                      ? "border-primary/70 bg-primary/10"
+                      : "border-border bg-muted/30 hover:border-primary/35"
                   }`}
                   onClick={() => onRenderModeChange(option.id)}
                 >
                   <span className="flex items-center gap-2 text-xs font-semibold text-foreground">
                     {option.label}
-                    {selected ? <Check className="h-3.5 w-3.5 text-amber-400" /> : null}
+                    {selected ? <Check className="h-3.5 w-3.5 text-primary" /> : null}
                   </span>
                   <span className="mt-1 block text-xs leading-snug text-muted-foreground">
                     {option.description}


### PR DESCRIPTION
## Summary

- replace raw amber utility classes in the gateway render-mode selector with the existing semantic `primary` token
- preserve the selected, hover, and checkmark visual states while allowing themes to own their colors
- make the checked-in semantic color guard pass again

## Reproduction

On unchanged `main`:

```text
npx vitest run tests/unit/colorSemanticsGuard.test.ts

FAIL  tests/unit/colorSemanticsGuard.test.ts
4 offenders in GatewayConnectScreen.tsx
```

## Verification

- `npx vitest run tests/unit/colorSemanticsGuard.test.ts`
- `npm run lint` (0 errors; 9 pre-existing warnings)
- `npm run typecheck`
- `npm test` (184 files, 1224 tests)
