### PR TITLE
fix(plugin): declare office bridge hook capability

### DIFF
--- a/plugins/hermes3d-office-bridge/plugin.yaml
+++ b/plugins/hermes3d-office-bridge/plugin.yaml
@@ -9,3 +9,5 @@ platforms:
   - windows
 hooks:
   - post_llm_call
+provides_hooks:
+  - post_llm_call


### PR DESCRIPTION
## Summary

- declare `post_llm_call` in `provides_hooks`
- align the bridge manifest with the hook registered by its runtime
- remove the Hermes Plugin Doctor warning when the observation hook is enabled

## Reproduction

On unchanged `main`, with a throwaway test token:

```text
WARN: registration adds hook 'post_llm_call' not listed in provides_hooks
registrations: 0 tool(s), 1 hook(s)
```

## Verification

```bash
HERMES3D_OFFICE_TOKEN='test-only-doctor-token' \
  hermes plugins doctor plugins/hermes3d-office-bridge --ci
```

Plugin Doctor reports successful discovery/import/registration, one hook, and no warning.
